### PR TITLE
Add a Data call to log library

### DIFF
--- a/cmd/antharun/frontend/frontend.go
+++ b/cmd/antharun/frontend/frontend.go
@@ -62,6 +62,8 @@ func (a *middleware) Measure(ts int64, source, msg string, extra ...interface{})
 
 func (a *middleware) Sensor(ts int64, source, msg string, extra ...interface{}) {}
 
+func (a *middleware) Data(ts int64, data interface{}, extra ...interface{}) {}
+
 func New(opt Opt) (*Frontend, error) {
 	mw := &middleware{out: os.Stdout}
 	logger.RegisterMiddleware(mw)

--- a/microArch/logger/default.go
+++ b/microArch/logger/default.go
@@ -1,22 +1,22 @@
 // microArch/logger/default.go: Part of the Antha language
 // Copyright (C) 2015 The Antha authors. All rights reserved.
-// 
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-// 
+//
 // For more information relating to the software or licensing issues please
-// contact license@antha-lang.org or write to the Antha team c/o 
+// contact license@antha-lang.org or write to the Antha team c/o
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
@@ -45,4 +45,8 @@ func (m *DefaultMiddleware) Measure(ts int64, source string, message string, ext
 
 func (m *DefaultMiddleware) Sensor(ts int64, source string, message string, extra ...interface{}) {
 	log.Println(ts, source, message, extra)
+}
+
+func (m *DefaultMiddleware) Data(ts int64, data interface{}, extra ...interface{}) {
+	log.Printf("%d | %+v | %+v\n", ts, data, extra)
 }

--- a/microArch/logger/logger.go
+++ b/microArch/logger/logger.go
@@ -106,6 +106,14 @@ func Sensor(message string, extra ...interface{}) {
 	}
 }
 
+func Data(data interface{}, extra ...interface{}) {
+	_middlewares_mutex.Lock()
+	defer _middlewares_mutex.Unlock()
+	for _, h := range getMiddlewareList() {
+		h.Data(time.Now().Unix(), data, append(extra, getSource()))
+	}
+}
+
 var (
 	middlewares        []LoggerMiddleware
 	_defaultmw         *DefaultMiddleware //only used if none other available
@@ -155,6 +163,9 @@ type LoggerMiddleware interface {
 	Measure(ts int64, source, msg string, extra ...interface{})
 	//Sensor react to specific sensor readouts
 	Sensor(ts int64, source, msg string, extra ...interface{})
+	//Data saves data to database witha  timestamp and a set of extra fields in order to localise
+	// it is an upper level log call that allows to dump unstructured data into our backend
+	Data(ts int64, data interface{}, extra ...interface{})
 }
 
 //getSource returns a string representing the line of code that the preceeding call was generated.

--- a/microArch/logger/logger_test.go
+++ b/microArch/logger/logger_test.go
@@ -33,6 +33,7 @@ var (
 	logCounter     int
 	measureCounter int
 	sensorCounter  int
+	dataCounter    int
 )
 
 type testMiddleware struct{}
@@ -40,6 +41,7 @@ type testMiddleware struct{}
 func (t testMiddleware) Log(l LogLevel, ts int64, s string, m string, e ...interface{}) { logCounter++ }
 func (t testMiddleware) Measure(ts int64, s, m string, e ...interface{})                { measureCounter++ }
 func (t testMiddleware) Sensor(ts int64, s, m string, e ...interface{})                 { sensorCounter++ }
+func (t testMiddleware) Data(ts int64, d interface{}, e ...interface{})                 { dataCounter++ }
 
 func TestRegisterMiddleware(t *testing.T) {
 	midCount := len(middlewares)

--- a/microArch/logger/middleware/file/fileMiddleware.go
+++ b/microArch/logger/middleware/file/fileMiddleware.go
@@ -1,22 +1,22 @@
 // microArch/logger/middleware/file/fileMiddleware.go: Part of the Antha language
 // Copyright (C) 2015 The Antha authors. All rights reserved.
-// 
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-// 
+//
 // For more information relating to the software or licensing issues please
-// contact license@antha-lang.org or write to the Antha team c/o 
+// contact license@antha-lang.org or write to the Antha team c/o
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
@@ -35,6 +35,8 @@ type fileMiddleware struct {
 	minLevel logger.LogLevel
 	sync.Mutex
 }
+
+var _ logger.LoggerMiddleware = &fileMiddleware{}
 
 func NewFileMiddleware(fileName string, minLevel logger.LogLevel) *fileMiddleware {
 	ret := new(fileMiddleware)
@@ -80,4 +82,17 @@ func (m *fileMiddleware) Sensor(ts int64, source string, message string, extra .
 	defer f.Close()
 
 	_, _ = f.WriteString(fmt.Sprint("[Sensor] ", message, " | ", extra))
+}
+
+func (m *fileMiddleware) Data(ts int64, data interface{}, extra ...interface{}) {
+	m.Lock()
+	defer m.Unlock()
+
+	f, err := os.OpenFile(m.fileName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_, _ = f.WriteString(fmt.Sprintf("[Data] $d | %+v | %+v\n", data, extra))
 }

--- a/microArch/logger/middleware/handler/handler.go
+++ b/microArch/logger/middleware/handler/handler.go
@@ -1,22 +1,22 @@
 // microArch/logger/middleware/handler/handler.go: Part of the Antha language
 // Copyright (C) 2015 The Antha authors. All rights reserved.
-// 
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-// 
+//
 // For more information relating to the software or licensing issues please
-// contact license@antha-lang.org or write to the Antha team c/o 
+// contact license@antha-lang.org or write to the Antha team c/o
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
@@ -30,18 +30,21 @@ import (
 type LogHandlerFunc func(logger.LogLevel, int64, string, string, ...interface{})
 type MeasureHandlerFunc func(int64, string, string, ...interface{})
 type SensorHandlerFunc func(int64, string, string, ...interface{})
+type DataHandlerFunc func(int64, interface{}, ...interface{})
 
 type Handler struct {
 	l LogHandlerFunc
 	t MeasureHandlerFunc
 	s SensorHandlerFunc
+	d DataHandlerFunc
 }
 
-func NewHandler(l LogHandlerFunc, t MeasureHandlerFunc, s SensorHandlerFunc) *Handler {
+func NewHandler(l LogHandlerFunc, t MeasureHandlerFunc, s SensorHandlerFunc, d DataHandlerFunc) *Handler {
 	ret := new(Handler)
 	ret.l = l
 	ret.t = t
 	ret.s = s
+	ret.d = d
 	return ret
 }
 
@@ -63,5 +66,12 @@ func (h Handler) Measure(ts int64, origin string, message string, extra ...inter
 func (h Handler) Sensor(ts int64, origin string, message string, extra ...interface{}) {
 	if h.s != nil {
 		h.s(ts, origin, message, extra)
+	}
+}
+
+//Data log arbitrary structures of data and extra information
+func (h Handler) Data(ts int64, data interface{}, extra ...interface{}) {
+	if h.s != nil {
+		h.d(ts, data, extra)
 	}
 }

--- a/microArch/logger/middleware/handler/handler_test.go
+++ b/microArch/logger/middleware/handler/handler_test.go
@@ -1,22 +1,22 @@
 // microArch/logger/middleware/handler/handler_test.go: Part of the Antha language
 // Copyright (C) 2015 The Antha authors. All rights reserved.
-// 
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-// 
+//
 // For more information relating to the software or licensing issues please
-// contact license@antha-lang.org or write to the Antha team c/o 
+// contact license@antha-lang.org or write to the Antha team c/o
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
@@ -38,7 +38,7 @@ func TestLogHandler(t *testing.T) {
 		}
 	}
 
-	handler := NewHandler(logHandlerFunc, nil, nil)
+	handler := NewHandler(logHandlerFunc, nil, nil, nil)
 
 	handler.Log(logger.DEBUG, time.Now().Unix(), "test", "test")
 	if counter != 1 {
@@ -58,7 +58,7 @@ func TestLogHandlerMiddleware(t *testing.T) {
 		}
 	}
 
-	handler := NewHandler(logHandlerFunc, nil, nil)
+	handler := NewHandler(logHandlerFunc, nil, nil, nil)
 	logger.RegisterMiddleware(handler)
 
 	logger.Debug("test")


### PR DESCRIPTION
Add a Data call to the log library so that we can log arbitrary structs.