### PR TITLE
Addtimeestimate

### DIFF
--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -134,11 +134,15 @@ type Time struct {
 // make a time unit
 func NewTime(v float64, unit string) Time {
 	if unit != "s" {
-		panic("Can't make temperatures which aren't in seconds")
+		panic("Can't make times which aren't in seconds")
 	}
 
 	t := Time{NewMeasurement(v, "", unit)}
 	return t
+}
+
+func (t Time) Seconds() float64 {
+	return t.SIValue()
 }
 
 // mass

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -24,6 +24,10 @@ func (a *incubateInst) SetDependsOn(xs []target.Inst) {
 	a.Depends = xs
 }
 
+func (a *incubateInst) GetTimeEstimate() float64 {
+	return 0.0
+}
+
 type incubator struct{}
 
 func (a *incubator) CanCompile(req ast.Request) bool {

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -60,6 +60,7 @@ type LHRequest struct {
 	Input_vols_supplied      map[string]wunit.Volume
 	Input_vols_required      map[string]wunit.Volume
 	Input_vols_wanting       map[string]wunit.Volume
+	TimeEstimate             float64
 }
 
 func (req *LHRequest) ConfigureYourself() error {

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -127,7 +127,6 @@ func (this *Liquidhandler) Execute(request *LHRequest) error {
 	}
 
 	logger.Debug(fmt.Sprintf("Total time estimate: %s", d.String()))
-
 	request.TimeEstimate = d.Seconds()
 
 	return nil

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -128,6 +128,8 @@ func (this *Liquidhandler) Execute(request *LHRequest) error {
 
 	logger.Debug(fmt.Sprintf("Total time estimate: %s", d.String()))
 
+	request.TimeEstimate = d.Seconds()
+
 	return nil
 }
 

--- a/target/human/inst.go
+++ b/target/human/inst.go
@@ -59,6 +59,7 @@ func (a *Human) makeFromIncubate(c *ast.Incubate) *target.Manual {
 		Dev:     a,
 		Label:   "Incubate",
 		Details: fmt.Sprintf("Incubate %q at %s for %s", from, c.Temp.ToString(), c.Time.ToString()),
+		Time:    c.Time.Seconds(),
 	}
 }
 

--- a/target/inst.go
+++ b/target/inst.go
@@ -14,6 +14,7 @@ type Inst interface {
 	Device() Device
 	DependsOn() []Inst
 	SetDependsOn([]Inst)
+	GetTimeEstimate() float64
 }
 
 type Files struct {
@@ -50,6 +51,7 @@ type Incubate struct {
 	Dev     Device
 	Depends []Inst
 	Files   Files
+	Time    float64
 }
 
 func (a *Incubate) Data() Files {
@@ -66,6 +68,10 @@ func (a *Incubate) DependsOn() []Inst {
 
 func (a *Incubate) SetDependsOn(x []Inst) {
 	a.Depends = x
+}
+
+func (a *Incubate) GetTimeEstimate() float64 {
+	return a.Time
 }
 
 type Mix struct {
@@ -92,11 +98,22 @@ func (a *Mix) SetDependsOn(x []Inst) {
 	a.Depends = x
 }
 
+func (a *Mix) GetTimeEstimate() float64 {
+	est := 0.0
+
+	if a.Request != nil {
+		est = a.Request.TimeEstimate
+	}
+
+	return est
+}
+
 type Manual struct {
 	Dev     Device
 	Label   string
 	Details string
 	Depends []Inst
+	Time    float64
 }
 
 func (a *Manual) DependsOn() []Inst {
@@ -109,6 +126,10 @@ func (a *Manual) Device() Device {
 
 func (a *Manual) SetDependsOn(x []Inst) {
 	a.Depends = x
+}
+
+func (a *Manual) GetTimeEstimate() float64 {
+	return a.Time
 }
 
 // Virtual instruction to hang dependencies on
@@ -126,4 +147,8 @@ func (a *Wait) DependsOn() []Inst {
 
 func (a *Wait) SetDependsOn(x []Inst) {
 	a.Depends = x
+}
+
+func (a *Wait) GetTimeEstimate() float64 {
+	return 0.0
 }


### PR DESCRIPTION
target/insts now implement a call for returning a time estimate 
for mixes this is populated via the timer mechanism for liquid handling instructions
for incubates this comes directly from the time parameter 

also contains a trivial bugfix to an error message

prerequisite for same change on microarch
