### PR TITLE
Addxyoffsets

### DIFF
--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -109,6 +109,10 @@ func (v Volume) Dup() Volume {
 	return ret
 }
 
+func ZeroVolume() Volume {
+	return NewVolume(0.0, "ul")
+}
+
 // temperature
 type Temperature struct {
 	*ConcreteMeasurement

--- a/microArch/driver/liquidhandling/compositerobotinstruction.go
+++ b/microArch/driver/liquidhandling/compositerobotinstruction.go
@@ -1950,10 +1950,76 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 
 	pol := policy.GetPolicyFor(ins)
 
-	// so a simple list of questions
-	// do we pre-mix?
+	// offsets
+	ofx := SafeGetF64(pol, "ASPXOFFSET")
+	ofy := SafeGetF64(pol, "ASPYOFFSET")
+	ofz := SafeGetF64(pol, "ASPZOFFSET")
 
-	cycles, premix := pol["PRE_MIX"]
+	mixofx := SafeGetF64(pol, "PRE_MIX_X")
+	mixofy := SafeGetF64(pol, "PRE_MIX_Y")
+	mixofz := SafeGetF64(pol, "PRE_MIX_Z")
+
+	final_asp_ref := SafeGetInt(pol, "ASPREFERENCE")
+
+	// do we need to enter slowly?
+	entryspeed, gentlynow := pol["ASPENTRYSPEED"]
+	if gentlynow {
+		// go to the well top
+		mov := NewMoveInstruction()
+
+		mov.Head = ins.Head
+		mov.Pos = ins.PltFrom
+		mov.Plt = ins.FPlateType
+		mov.Well = ins.WellFrom
+		mov.WVolume = ins.FVolume
+		for i := 0; i < ins.Multi; i++ {
+			mov.Reference = append(mov.Reference, 1)
+			mov.OffsetX = append(mov.OffsetX, ofx)
+			mov.OffsetY = append(mov.OffsetY, ofy)
+			mov.OffsetZ = append(mov.OffsetZ, 5.0)
+		}
+		ret = append(ret, mov)
+
+		// set the speed
+		spd := NewSetDriveSpeedInstruction()
+		spd.Drive = "Z"
+		spd.Speed = entryspeed.(float64)
+		ret = append(ret, spd)
+
+		/*
+			// now move into the liquid
+			mov = NewMoveInstruction()
+			mov.Head = ins.Head
+			mov.Pos = ins.PltFrom
+			mov.Plt = ins.FPlateType
+			mov.Well = ins.WellFrom
+			mov.WVolume = ins.FVolume
+			ref := SafeGetInt(pol, "ASPREFERENCE")
+			ofx := SafeGetF64(pol, "ASPXOFFSET")
+			ofy := SafeGetF64(pol, "ASPYOFFSET")
+			ofz := SafeGetF64(pol, "ASPZOFFSET")
+
+			// TODO -- different offsets per channel
+
+			for i := 0; i < ins.Multi; i++ {
+				mov.Reference = append(mov.Reference, ref)
+				mov.OffsetX = append(mov.OffsetX, ofx)
+				mov.OffsetY = append(mov.OffsetY, ofy)
+				mov.OffsetZ = append(mov.OffsetZ, ofz)
+			}
+
+			ret = append(ret, mov)
+			// reset the drive speed
+			spd = NewSetDriveSpeedInstruction()
+			spd.Drive = "Z"
+			spd.Speed = pol["DEFAULTZSPEED"].(float64)
+			ret = append(ret, spd)
+		*/
+	}
+
+	// do we pre-mix?
+	_, premix := pol["PRE_MIX"]
+	cycles := SafeGetInt(pol, "PRE_MIX")
 
 	if premix && cycles > 0 {
 		// add the premix step
@@ -1968,58 +2034,47 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		mix.Blowout = []bool{false}
 
 		// this is not safe
-		mixvol, ok := pol["PRE_MIX_VOL"]
+		_, ok := pol["PRE_MIX_VOL"]
 		mix.Volume = ins.Volume
+		mixvol := SafeGetF64(pol, "PRE_MIX_VOL")
 
 		if ok {
 			v := make([]wunit.Volume, ins.Multi)
 			for i := 0; i < ins.Multi; i++ {
-				vl := wunit.NewVolume(mixvol.(float64), "ul")
+				vl := wunit.NewVolume(mixvol, "ul")
 				v[i] = vl
 			}
 			mix.Volume = v
 		}
 		// offsets
 
-		xoff, ok := pol["PRE_MIX_X"]
-
-		if !ok {
-			xoff = 0.0
-		}
 		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetX = append(mix.OffsetX, xoff.(float64))
+			mix.OffsetX = append(mix.OffsetX, mixofx)
 		}
 
-		yoff, ok := pol["PRE_MIX_Y"]
-		if !ok {
-			yoff = 0.0
+		for k := 0; k < ins.Multi; k++ {
+			mix.OffsetY = append(mix.OffsetY, mixofy)
 		}
 		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetY = append(mix.OffsetY, yoff.(float64))
-		}
-		zoff, ok := pol["PRE_MIX_Z"]
-		if !ok {
-			zoff = 0.0
-		}
-		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetZ = append(mix.OffsetZ, zoff.(float64))
+			mix.OffsetZ = append(mix.OffsetZ, mixofz)
 		}
 
 		c := make([]int, ins.Multi)
 
 		for i := 0; i < ins.Multi; i++ {
-			c[i] = cycles.(int)
+			c[i] = cycles
 		}
 
 		// set speed
 
-		mixrate, changepipspeed := pol["PRE_MIX_RATE"]
+		_, changepipspeed := pol["PRE_MIX_RATE"]
 
-		if changespeed {
+		if changepipspeed {
+			mixrate := SafeGetF64(pol, "PRE_MIX_RATE")
 			setspd := NewSetPipetteSpeedInstruction()
 			setspd.Head = ins.Head
 			setspd.Channel = -1 // all channels
-			setspd.Speed = mixrate.(float64)
+			setspd.Speed = mixrate
 			ret = append(ret, setspd)
 		}
 
@@ -2027,64 +2082,28 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		ret = append(ret, mix)
 
 		if changepipspeed {
+			defspeed := SafeGetF64(pol, "DEFAULTPIPETTESPEED")
 			sps := NewSetPipetteSpeedInstruction()
 			sps.Head = ins.Head
 			sps.Channel = -1 // all channels
-			sps.Speed = pol["DEFAULTPIPETTESPEED"].(float64)
+			sps.Speed = defspeed
 			ret = append(ret, sps)
 		}
 	}
 
-	// do we need to enter slowly?
-	// depending on where we end up after the mix this might generate redundant
-	// moves... TODO fix this
+	discrepancy := false
 
-	entryspeed, gentlynow := pol["ASPENTRYSPEED"]
+	if premix {
+		// check whether there is a discrepancy between the mix reference
+		// etc. and the asp reference... if not we don't need to move
 
-	if gentlynow {
-		// go to the well top
-		mov := NewMoveInstruction()
+		discrepancy = discrepancy || (mixofx != ofx)
+		discrepancy = discrepancy || (mixofy != ofy)
+		discrepancy = discrepancy || (mixofz != ofz)
+	}
 
-		mov.Head = ins.Head
-		mov.Pos = ins.PltFrom
-		mov.Plt = ins.FPlateType
-		mov.Well = ins.WellFrom
-		mov.WVolume = ins.FVolume
-		for i := 0; i < ins.Multi; i++ {
-			mov.Reference = append(mov.Reference, 1)
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
-			mov.OffsetZ = append(mov.OffsetZ, 5.0)
-		}
-		ret = append(ret, mov)
-
-		// set the speed
-		spd := NewSetDriveSpeedInstruction()
-		spd.Drive = "Z"
-		spd.Speed = entryspeed.(float64)
-		ret = append(ret, spd)
-
-		// now move into the liquid
-		mov = NewMoveInstruction()
-		mov.Head = ins.Head
-		mov.Pos = ins.PltFrom
-		mov.Plt = ins.FPlateType
-		mov.Well = ins.WellFrom
-		mov.WVolume = ins.FVolume
-		for i := 0; i < ins.Multi; i++ {
-			mov.Reference = append(mov.Reference, 0)
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
-			mov.OffsetZ = append(mov.OffsetZ, pol["ASPZOFFSET"].(float64))
-		}
-
-		ret = append(ret, mov)
-		// reset the drive speed
-		spd = NewSetDriveSpeedInstruction()
-		spd.Drive = "Z"
-		spd.Speed = pol["DEFAULTZSPEED"].(float64)
-		ret = append(ret, spd)
-	} else {
+	if !premix || discrepancy {
+		// only move if we need to
 		mov := NewMoveInstruction()
 		mov.Head = ins.Head
 
@@ -2092,24 +2111,25 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		mov.Plt = ins.FPlateType
 		mov.Well = ins.WellFrom
 		mov.WVolume = ins.FVolume
+
 		for i := 0; i < ins.Multi; i++ {
-			mov.Reference = append(mov.Reference, 0)
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
-			mov.OffsetZ = append(mov.OffsetZ, pol["ASPZOFFSET"].(float64))
+			mov.Reference = append(mov.Reference, final_asp_ref)
+			mov.OffsetX = append(mov.OffsetX, ofx)
+			mov.OffsetY = append(mov.OffsetY, ofy)
+			mov.OffsetZ = append(mov.OffsetZ, ofz)
 		}
 		ret = append(ret, mov)
 	}
 
 	// Set the pipette speed if needed
 
-	pspeed, setpspeed := pol["ASPSPEED"]
+	_, setpspeed := pol["ASPSPEED"]
 
 	if setpspeed {
 		sps := NewSetPipetteSpeedInstruction()
 		sps.Head = ins.Head
-		sps.Channel = -1 // all channels
-		sps.Speed = pspeed.(float64)
+		sps.Channel = -1                        // all channels
+		sps.Speed = SafeGetF64(pol, "ASPSPEED") //pspeed.(float64)
 		ret = append(ret, sps)
 	}
 
@@ -2123,7 +2143,7 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 	if iwantmore {
 		extra_vol := ev.(wunit.Volume)
 		for i, _ := range aspins.Volume {
-			aspins.Volume[i].Add(&extra_vol)
+			aspins.Volume[i].Add(extra_vol)
 		}
 	}
 
@@ -2156,6 +2176,30 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		waitins := NewWaitInstruction()
 		waitins.Time = wait_time.(float64)
 		ret = append(ret, waitins)
+	}
+
+	if gentlynow { // reset the drive speed
+		// go to the well top
+		mov := NewMoveInstruction()
+
+		mov.Head = ins.Head
+		mov.Pos = ins.PltFrom
+		mov.Plt = ins.FPlateType
+		mov.Well = ins.WellFrom
+		mov.WVolume = ins.FVolume
+		for i := 0; i < ins.Multi; i++ {
+			mov.Reference = append(mov.Reference, 1)
+			mov.OffsetX = append(mov.OffsetX, ofx)
+			mov.OffsetY = append(mov.OffsetY, ofy)
+			mov.OffsetZ = append(mov.OffsetZ, 5.0)
+		}
+		ret = append(ret, mov)
+
+		// now get ready to move fast again
+		spd := NewSetDriveSpeedInstruction()
+		spd.Drive = "Z"
+		spd.Speed = pol["DEFAULTZSPEED"].(float64)
+		ret = append(ret, spd)
 	}
 
 	return ret
@@ -2245,7 +2289,20 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 	pol := policy.GetPolicyFor(ins)
 	// first, are we breaking up the move?
 
-	entryspeed, gentlydoesit := pol["DSPENTRYSPEED"]
+	ofx := SafeGetF64(pol, "DSPXOFFSET")
+	ofy := SafeGetF64(pol, "DSPYOFFSET")
+	ofz := SafeGetF64(pol, "DSPZOFFSET")
+
+	ref := SafeGetInt(pol, "DSPREFERENCE")
+
+	entryspeed := SafeGetF64(pol, "DSPENTRYSPEED")
+	defaultspeed := SafeGetF64(pol, "DEFAULTZSPEED")
+
+	var gentlydoesit bool
+
+	if entryspeed != defaultspeed {
+		gentlydoesit = true
+	}
 
 	if gentlydoesit {
 		// go to the well top
@@ -2258,8 +2315,8 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		mov.WVolume = ins.TVolume
 		for i := 0; i < ins.Multi; i++ {
 			mov.Reference = append(mov.Reference, 1)
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
+			mov.OffsetX = append(mov.OffsetX, ofx)
+			mov.OffsetY = append(mov.OffsetY, ofy)
 			mov.OffsetZ = append(mov.OffsetZ, 5.0)
 		}
 		ret = append(ret, mov)
@@ -2267,54 +2324,63 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		// set the speed
 		spd := NewSetDriveSpeedInstruction()
 		spd.Drive = "Z"
-		spd.Speed = entryspeed.(float64)
+		spd.Speed = entryspeed
 		ret = append(ret, spd)
 
-		mov = NewMoveInstruction()
-		mov.Head = ins.Head
-		mov.Pos = ins.PltTo
-		mov.Plt = ins.TPlateType
-		mov.Well = ins.WellTo
-		mov.WVolume = ins.TVolume
-		for i := 0; i < ins.Multi; i++ {
-			mov.Reference = append(mov.Reference, pol["DSPREFERENCE"].(int))
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
-			mov.OffsetZ = append(mov.OffsetZ, pol["DSPZOFFSET"].(float64))
-		}
-		ret = append(ret, mov)
-		// reset the drive speed
-		spd = NewSetDriveSpeedInstruction()
-		spd.Drive = "Z"
-		spd.Speed = pol["DEFAULTZSPEED"].(float64)
-		ret = append(ret, spd)
+		/*
+			mov = NewMoveInstruction()
+			mov.Head = ins.Head
+			mov.Pos = ins.PltTo
+			mov.Plt = ins.TPlateType
+			mov.Well = ins.WellTo
+			mov.WVolume = ins.TVolume
+			for i := 0; i < ins.Multi; i++ {
+				mov.Reference = append(mov.Reference, pol["DSPREFERENCE"].(int))
+				mov.OffsetX = append(mov.OffsetX, 0.0)
+				mov.OffsetY = append(mov.OffsetY, 0.0)
+				mov.OffsetZ = append(mov.OffsetZ, pol["DSPZOFFSET"].(float64))
+			}
+			ret = append(ret, mov)
+			// reset the drive speed
+			spd = NewSetDriveSpeedInstruction()
+			spd.Drive = "Z"
+			spd.Speed = pol["DEFAULTZSPEED"].(float64)
+			ret = append(ret, spd)
+		*/
 
-	} else {
-		mov := NewMoveInstruction()
-		mov.Head = ins.Head
-		mov.Pos = ins.PltTo
-		mov.Plt = ins.TPlateType
-		mov.Well = ins.WellTo
-		mov.WVolume = ins.TVolume
-		for i := 0; i < ins.Multi; i++ {
-			mov.Reference = append(mov.Reference, pol["DSPREFERENCE"].(int))
-			mov.OffsetX = append(mov.OffsetX, 0.0)
-			mov.OffsetY = append(mov.OffsetY, 0.0)
-			mov.OffsetZ = append(mov.OffsetZ, pol["DSPZOFFSET"].(float64))
-		}
-
-		ret = append(ret, mov)
 	}
+
+	mov := NewMoveInstruction()
+	mov.Head = ins.Head
+	mov.Pos = ins.PltTo
+	mov.Plt = ins.TPlateType
+	mov.Well = ins.WellTo
+	mov.WVolume = ins.TVolume
+	for i := 0; i < ins.Multi; i++ {
+		mov.Reference = append(mov.Reference, ref)
+		mov.OffsetX = append(mov.OffsetX, ofx)
+		mov.OffsetY = append(mov.OffsetY, ofy)
+		mov.OffsetZ = append(mov.OffsetZ, ofz)
+	}
+
+	ret = append(ret, mov)
 
 	// next, are we setting the pipette speed
 
-	pspeed, setpspeed := pol["DSPSPEED"]
+	pspeed := SafeGetF64(pol, "DEFAULTPIPETTESPEED")
+	dpspeed := SafeGetF64(pol, "DSPSPEED")
+
+	var setpspeed bool
+
+	if pspeed != dpspeed {
+		setpspeed = true
+	}
 
 	if setpspeed {
 		sps := NewSetPipetteSpeedInstruction()
 		sps.Head = ins.Head
 		sps.Channel = -1 // all channels
-		sps.Speed = pspeed.(float64)
+		sps.Speed = pspeed
 		ret = append(ret, sps)
 	}
 
@@ -2322,10 +2388,23 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 
 	weneedtoreset := true
 
-	if pol["JUSTBLOWOUT"].(bool) {
+	justblowout := SafeGetBool(pol, "JUSTBLOWOUT")
+
+	// bit of a horrible hack... we need to fix this soon
+
+	if justblowout {
+		blowoutvolume := SafeGetF64(pol, "BLOWOUTVOLUME")
+		blowoutvolunit := SafeGetString(pol, "BLOWOUTVOLUMEUNIT")
+
+		// be safe, not sorry...
+
+		if blowoutvolunit == "" {
+			blowoutvolunit = "ul"
+		}
+
 		boins := NewBlowoutInstruction()
 		boins.Head = ins.Head
-		vl := wunit.NewVolume(pol["BLOWOUTVOLUME"].(float64), pol["BLOWOUTVOLUMEUNIT"].(string))
+		vl := wunit.NewVolume(blowoutvolume, blowoutvolunit)
 		boins.Volume = append(boins.Volume, vl)
 		boins.Multi = ins.Multi
 		boins.Plt = ins.TPlateType
@@ -2342,11 +2421,10 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		dspins.Head = ins.Head
 		dspins.Volume = ins.Volume
 
-		ev, iwantmore := pol["EXTRA_DISP_VOLUME"]
-		if iwantmore {
-			extra_vol := ev.(wunit.Volume)
+		extra_vol := SafeGetVolume(pol, "EXTRA_DISP_VOLUME")
+		if extra_vol.GreaterThan(wunit.ZeroVolume()) {
 			for i, _ := range dspins.Volume {
-				dspins.Volume[i].Add(&extra_vol)
+				dspins.Volume[i].Add(extra_vol)
 			}
 		}
 		dspins.Multi = ins.Multi
@@ -2366,22 +2444,23 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		sps := NewSetPipetteSpeedInstruction()
 		sps.Head = ins.Head
 		sps.Channel = -1 // all channels
-		sps.Speed = pol["DEFAULTPIPETTESPEED"].(float64)
+		sps.Speed = dpspeed
 		ret = append(ret, sps)
 	}
 
 	// do we wait?
 
-	wait_time, wait := pol["DSP_WAIT"]
+	wait_time := SafeGetF64(pol, "DSP_WAIT")
 
-	if wait {
+	if wait_time > 0.0 {
 		waitins := NewWaitInstruction()
-		waitins.Time = wait_time.(float64)
+		waitins.Time = wait_time
 		ret = append(ret, waitins)
 	}
 
 	// do we mix?
-	cycles, postmix := pol["POST_MIX"]
+	_, postmix := pol["POST_MIX"]
+	cycles := SafeGetInt(pol, "POST_MIX")
 
 	if postmix && cycles > 0 {
 		// add the postmix step
@@ -2393,45 +2472,38 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		mix.Multi = ins.Multi
 		mix.What = ins.What
 		// TODO get rid of this HARD CODE
-		//	mix.Blowout = []bool{false}
-		// prevent issues with inconsistent array lengths
+		// we might want to change this
 		b := make([]bool, ins.Multi)
 		mix.Blowout = b
 
 		// offsets
 
-		xoff, ok := pol["POST_MIX_X"]
+		pmxoff := SafeGetF64(pol, "POST_MIX_X")
 
-		if !ok {
-			xoff = 0.0
-		}
 		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetX = append(mix.OffsetX, xoff.(float64))
+			mix.OffsetX = append(mix.OffsetX, pmxoff)
 		}
 
-		yoff, ok := pol["POST_MIX_Y"]
-		if !ok {
-			yoff = 0.0
-		}
+		pmyoff := SafeGetF64(pol, "POST_MIX_Y")
 		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetY = append(mix.OffsetY, yoff.(float64))
+			mix.OffsetY = append(mix.OffsetY, pmyoff)
 		}
-		zoff, ok := pol["POST_MIX_Z"]
-		if !ok {
-			zoff = 0.0
-		}
+
+		pmzoff := SafeGetF64(pol, "POST_MIX_Z")
+
 		for k := 0; k < ins.Multi; k++ {
-			mix.OffsetZ = append(mix.OffsetZ, zoff.(float64))
+			mix.OffsetZ = append(mix.OffsetZ, pmzoff)
 		}
 
 		// this is not safe, need to verify volume is OK
-		mixvol, ok := pol["POST_MIX_VOL"]
+		_, ok := pol["POST_MIX_VOL"]
 		mix.Volume = ins.Volume
+		mixvol := SafeGetF64(pol, "POST_MIX_VOL")
 
 		if ok {
 			v := make([]wunit.Volume, ins.Multi)
 			for i := 0; i < ins.Multi; i++ {
-				vl := wunit.NewVolume(mixvol.(float64), "ul")
+				vl := wunit.NewVolume(mixvol, "ul")
 				v[i] = vl
 			}
 			mix.Volume = v
@@ -2440,18 +2512,23 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		c := make([]int, ins.Multi)
 
 		for i := 0; i < ins.Multi; i++ {
-			c[i] = cycles.(int)
+			c[i] = cycles
 		}
 
 		// set speed
 
-		mixrate, changespeed := pol["POST_MIX_RATE"]
+		//mixrate, changespeed := pol["POST_MIX_RATE"]
+		var changespeed bool
+		mixrate := SafeGetF64(pol, "POST_MIX_RATE")
+		if mixrate != dpspeed {
+			changespeed = true
+		}
 
 		if changespeed {
 			setspd := NewSetPipetteSpeedInstruction()
 			setspd.Head = ins.Head
 			setspd.Channel = -1 // all channels
-			setspd.Speed = mixrate.(float64)
+			setspd.Speed = mixrate
 			ret = append(ret, setspd)
 		}
 
@@ -2462,17 +2539,24 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 			sps := NewSetPipetteSpeedInstruction()
 			sps.Head = ins.Head
 			sps.Channel = -1 // all channels
-			sps.Speed = pol["DEFAULTPIPETTESPEED"].(float64)
+			sps.Speed = dpspeed
 			ret = append(ret, sps)
+		}
+
+		// if we wait we need to do this here as well
+		if wait_time > 0.0 {
+			waitins := NewWaitInstruction()
+			waitins.Time = wait_time
+			ret = append(ret, waitins)
 		}
 	}
 
 	// do we need to touch off?
 
-	touch_off := pol["TOUCHOFF"].(bool)
+	touch_off := SafeGetBool(pol, "TOUCHOFF")
 
 	if touch_off {
-		touch_offset := pol["TOUCHOFFSET"].(float64)
+		touch_offset := SafeGetF64(pol, "TOUCHOFFSET")
 		mov := NewMoveInstruction()
 		mov.Head = ins.Head
 		mov.Pos = ins.PltTo

--- a/microArch/driver/liquidhandling/compositerobotinstruction.go
+++ b/microArch/driver/liquidhandling/compositerobotinstruction.go
@@ -1064,8 +1064,6 @@ func (ins *SingleChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, p
 	blowinstruction.Multi = 1
 	blowinstruction.Prms = ins.Prms
 	ret = append(ret, blowinstruction)
-	logger.Debug(InsToString(suckinstruction))
-	logger.Debug(InsToString(blowinstruction))
 
 	/*
 		// commented out pending putting it as part of blow
@@ -1957,7 +1955,7 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 
 	cycles, premix := pol["PRE_MIX"]
 
-	if premix {
+	if premix && cycles > 0 {
 		// add the premix step
 		mix := NewMoveMixInstruction()
 		mix.Head = ins.Head
@@ -2015,7 +2013,7 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 
 		// set speed
 
-		mixrate, changespeed := pol["PRE_MIX_RATE"]
+		mixrate, changepipspeed := pol["PRE_MIX_RATE"]
 
 		if changespeed {
 			setspd := NewSetPipetteSpeedInstruction()
@@ -2028,7 +2026,7 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		mix.Cycles = c
 		ret = append(ret, mix)
 
-		if changespeed {
+		if changepipspeed {
 			sps := NewSetPipetteSpeedInstruction()
 			sps.Head = ins.Head
 			sps.Channel = -1 // all channels
@@ -2385,7 +2383,7 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 	// do we mix?
 	cycles, postmix := pol["POST_MIX"]
 
-	if postmix {
+	if postmix && cycles > 0 {
 		// add the postmix step
 		mix := NewMoveMixInstruction()
 		mix.Head = ins.Head

--- a/microArch/driver/liquidhandling/extra.go
+++ b/microArch/driver/liquidhandling/extra.go
@@ -1,0 +1,70 @@
+package liquidhandling
+
+import "github.com/antha-lang/antha/antha/anthalib/wunit"
+
+func SafeGetF64(m map[string]interface{}, key string) float64 {
+	ret := 0.0
+
+	v, ok := m[key]
+
+	// TODO -- implement type safety
+	if ok {
+		ret = v.(float64)
+	}
+
+	return ret
+}
+
+func SafeGetBool(m map[string]interface{}, key string) bool {
+	ret := false
+
+	v, ok := m[key]
+
+	// TODO -- implement type safety
+	if ok {
+		ret = v.(bool)
+	}
+
+	return ret
+
+}
+
+func SafeGetString(m map[string]interface{}, key string) string {
+	ret := ""
+
+	v, ok := m[key]
+
+	// TODO -- implement type safety
+	if ok {
+		ret = v.(string)
+	}
+
+	return ret
+
+}
+
+func SafeGetInt(m map[string]interface{}, key string) int {
+	ret := 0
+
+	v, ok := m[key]
+
+	// TODO -- implement type safety
+	if ok {
+		ret = v.(int)
+	}
+
+	return ret
+}
+
+func SafeGetVolume(m map[string]interface{}, key string) wunit.Volume {
+	ret := wunit.NewVolume(0.0, "ul")
+
+	v, ok := m[key]
+
+	//TODO -- implement type safety
+	if ok {
+		ret = v.(wunit.Volume)
+	}
+
+	return ret
+}


### PR DESCRIPTION
This branch
- Adds the ability to control X and Y offsets for aspirate, dispense and pre/post mixing

ASP[X/Y/Z]OFFSET
DSP[X/Y/Z]OFFSET
PRE_MIX_[X/Y/Z]
POST_MIX_[X/Y/Z]

- Fixes an issue when combining some consequents: pre-mixing and gentle moves, for instance

- Makes consequents dependent on values of parameters rather than presence of predicates, reducing possibility for errors

- Removes redundant moves when offsets, references etc. match up between mixes
