### PR TITLE
Addplanningerrors

### DIFF
--- a/antha/anthalib/wtype/lherror.go
+++ b/antha/anthalib/wtype/lherror.go
@@ -3,6 +3,9 @@ package wtype
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 // consts for liquid handling planner errors
@@ -35,4 +38,18 @@ func LHError(code int, detail string) error {
 	s := fmt.Sprintf("%d (%s) : %s : %s", code, ErrorName(code), ErrorDesc(code), detail)
 
 	return errors.New(s)
+}
+
+func LHErrorCodeFromErr(err error) int {
+	tx := strings.Split(err.Error(), " ")
+
+	i := wutil.ParseInt(tx[0])
+
+	return i
+}
+
+func LHErrorIsInternal(err error) bool {
+	c := LHErrorCodeFromErr(err)
+
+	return c == LH_ERR_DIRE
 }

--- a/antha/anthalib/wtype/lherror.go
+++ b/antha/anthalib/wtype/lherror.go
@@ -12,20 +12,26 @@ const (
 	LH_ERR_NO_DECK_SPACE
 	LH_ERR_NO_TIPS
 	LH_ERR_NOT_IMPLEMENTED
+	LH_ERR_CONC
+	LH_ERR_DRIV
+	LH_ERR_POLICY
+	LH_ERR_VOL
+	LH_ERR_DIRE
 	LH_ERR_OTHER
 )
 
 func ErrorName(code int) string {
-	errornames := [...]string{"LH_OK", "LH_ERR_NO_DECK_SPACE", "LH_ERR_NO_TIPS", "LH_ERR_NOT_IMPLEMENTED", "LH_ERR_OTHER"}
+	errornames := [...]string{"LH_OK", "LH_ERR_NO_DECK_SPACE", "LH_ERR_NO_TIPS", "LH_ERR_NOT_IMPLEMENTED", "LH_ERR_CONC", "LH_ERR_DRIV", "LH_ERR_POLICY", "LH_ERR_VOL", "LH_ERR_DIRE", "LH_ERR_OTHER"}
 	return errornames[code]
 }
 
 func ErrorDesc(code int) string {
-	errorboilerplate := [...]string{"no problem", "not sufficient deck space to fit all required items; this may be due to constraints", "ran out of tips", "a required command is not implemented", ""}
+	errorboilerplate := [...]string{"no problem", "insufficient deck space to fit all required items; this may be due to constraints", "ran out of tips", "a required command is not implemented", "error calculating required volume for target concentration", "driver error", "liquid handling policy error", "volume error", "an internal error", ""}
 	return errorboilerplate[code]
 }
 
 func LHError(code int, detail string) error {
+	// format here: error code (name) : general description : specific problem
 	s := fmt.Sprintf("%d (%s) : %s : %s", code, ErrorName(code), ErrorDesc(code), detail)
 
 	return errors.New(s)

--- a/antha/anthalib/wtype/lherror.go
+++ b/antha/anthalib/wtype/lherror.go
@@ -26,7 +26,7 @@ func ErrorDesc(code int) string {
 }
 
 func LHError(code int, detail string) error {
-	s := fmt.Sprintf("%d (%s): %s -- %s", code, ErrorName(code), ErrorDesc(code), detail)
+	s := fmt.Sprintf("%d (%s) : %s : %s", code, ErrorName(code), ErrorDesc(code), detail)
 
 	return errors.New(s)
 }

--- a/antha/anthalib/wtype/lherror.go
+++ b/antha/anthalib/wtype/lherror.go
@@ -1,0 +1,32 @@
+package wtype
+
+import (
+	"errors"
+	"fmt"
+)
+
+// consts for liquid handling planner errors
+
+const (
+	LH_OK = iota
+	LH_ERR_NO_DECK_SPACE
+	LH_ERR_NO_TIPS
+	LH_ERR_NOT_IMPLEMENTED
+	LH_ERR_OTHER
+)
+
+func ErrorName(code int) string {
+	errornames := [...]string{"LH_OK", "LH_ERR_NO_DECK_SPACE", "LH_ERR_NO_TIPS", "LH_ERR_NOT_IMPLEMENTED", "LH_ERR_OTHER"}
+	return errornames[code]
+}
+
+func ErrorDesc(code int) string {
+	errorboilerplate := [...]string{"no problem", "not sufficient deck space to fit all required items; this may be due to constraints", "ran out of tips", "a required command is not implemented", ""}
+	return errorboilerplate[code]
+}
+
+func LHError(code int, detail string) error {
+	s := fmt.Sprintf("%d (%s): %s -- %s", code, ErrorName(code), ErrorDesc(code), detail)
+
+	return errors.New(s)
+}

--- a/antha/anthalib/wtype/lherror_test.go
+++ b/antha/anthalib/wtype/lherror_test.go
@@ -1,0 +1,20 @@
+package wtype
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLHError(t *testing.T) {
+	e := LHError(LH_OK, "")
+
+	if e.Error() != "0 (LH_OK): no problem -- " {
+		t.Fatal("LH Error format changed... this may break stuff")
+	}
+
+	e = LHError(LH_ERR_NO_DECK_SPACE, "can't fit tip box in")
+
+	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE): not sufficient deck space to fit all required items; this may be due to constraints -- can't fit tip box in" {
+		t.Fatal("LH Error format changed... this may break stuff")
+	}
+}

--- a/antha/anthalib/wtype/lherror_test.go
+++ b/antha/anthalib/wtype/lherror_test.go
@@ -11,7 +11,7 @@ func TestLHError(t *testing.T) {
 
 	e = LHError(LH_ERR_NO_DECK_SPACE, "can't fit tip box in")
 
-	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE) : not sufficient deck space to fit all required items; this may be due to constraints : can't fit tip box in" {
+	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : can't fit tip box in" {
 		t.Fatal("LH Error format changed... this may break stuff")
 	}
 }

--- a/antha/anthalib/wtype/lherror_test.go
+++ b/antha/anthalib/wtype/lherror_test.go
@@ -1,20 +1,17 @@
 package wtype
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestLHError(t *testing.T) {
 	e := LHError(LH_OK, "")
 
-	if e.Error() != "0 (LH_OK): no problem -- " {
+	if e.Error() != "0 (LH_OK) : no problem : " {
 		t.Fatal("LH Error format changed... this may break stuff")
 	}
 
 	e = LHError(LH_ERR_NO_DECK_SPACE, "can't fit tip box in")
 
-	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE): not sufficient deck space to fit all required items; this may be due to constraints -- can't fit tip box in" {
+	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE) : not sufficient deck space to fit all required items; this may be due to constraints : can't fit tip box in" {
 		t.Fatal("LH Error format changed... this may break stuff")
 	}
 }

--- a/antha/anthalib/wtype/lherror_test.go
+++ b/antha/anthalib/wtype/lherror_test.go
@@ -1,6 +1,9 @@
 package wtype
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestLHError(t *testing.T) {
 	e := LHError(LH_OK, "")
@@ -14,4 +17,28 @@ func TestLHError(t *testing.T) {
 	if e.Error() != "1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : can't fit tip box in" {
 		t.Fatal("LH Error format changed... this may break stuff")
 	}
+}
+
+func TestLHErrorCodeFromErr(t *testing.T) {
+	e := LHError(LH_ERR_DIRE, "yes")
+	c := LHErrorCodeFromErr(e)
+
+	if c != LH_ERR_DIRE {
+		t.Fatal(fmt.Sprintf("Unexpected errorcode mismatch: got %d expected %d", c, LH_ERR_DIRE))
+	}
+}
+
+func TestLHErrorIsInternal(t *testing.T) {
+	e := LHError(LH_OK, "")
+
+	if LHErrorIsInternal(e) {
+		t.Fatal(fmt.Sprint("Error ", e, " is not an internal error but is reported as one"))
+	}
+
+	e = LHError(LH_ERR_DIRE, "YES")
+
+	if !LHErrorIsInternal(e) {
+		t.Fatal(fmt.Sprint("ERROR ", e, " is an internal error but is not reported as one"))
+	}
+
 }

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -20,6 +20,10 @@ func (a *incubateInst) DependsOn() []target.Inst {
 	return a.Depends
 }
 
+func (a *incubateInst) Error() error {
+	return nil
+}
+
 func (a *incubateInst) SetDependsOn(xs []target.Inst) {
 	a.Depends = xs
 }

--- a/microArch/driver/liquidhandling/compositerobotinstruction.go
+++ b/microArch/driver/liquidhandling/compositerobotinstruction.go
@@ -23,7 +23,6 @@
 package liquidhandling
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -193,7 +192,7 @@ func (ins *TransferInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func TransferVolumes(Vol, Min, Max wunit.Volume) []wunit.Volume {
+func TransferVolumes(Vol, Min, Max wunit.Volume) ([]wunit.Volume, error) {
 	ret := make([]wunit.Volume, 0)
 
 	vol := Vol.ConvertTo(Min.Unit())
@@ -201,13 +200,18 @@ func TransferVolumes(Vol, Min, Max wunit.Volume) []wunit.Volume {
 	max := Max.RawValue()
 
 	if vol < min {
-		logger.Fatal(fmt.Sprintf("Error: %f below min vol %f", vol, min))
-		panic(errors.New(fmt.Sprintf("Error: %f below min vol %f", vol, min)))
+		/*
+			logger.Fatal(fmt.Sprintf("Error: %f below min vol %f", vol, min))
+			panic(errors.New(fmt.Sprintf("Error: %f below min vol %f", vol, min)))
+		*/
+
+		err := wtype.LHError(wtype.LH_ERR_VOL, fmt.Sprintf("Liquid Handler cannot service volume requested: %f - minimum volume is %f", vol, min))
+		return ret, err
 	}
 
 	if vol <= max {
 		ret = append(ret, Vol)
-		return ret
+		return ret, nil
 	}
 
 	// vol is > max, need to know by how much
@@ -225,7 +229,7 @@ func TransferVolumes(Vol, Min, Max wunit.Volume) []wunit.Volume {
 		ret = append(ret, wunit.NewVolume(vol/n, Vol.Unit().PrefixedSymbol()))
 	}
 
-	return ret
+	return ret, nil
 }
 
 func (vs VolumeSet) MaxMultiTransferVolume() wunit.Volume {
@@ -485,7 +489,7 @@ func (vs VolumeSet) GetACopy() []wunit.Volume {
 	return r
 }
 
-func (ins *TransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *TransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	pol := policy.GetPolicyFor(ins)
 
 	ret := make([]RobotInstruction, 0)
@@ -499,8 +503,6 @@ func (ins *TransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProper
 		// this is a bit problematic: we need to define head choice here partly on the
 		// basis of its multi, partly based on volume range
 		parallelsets := ins.GetParallelSetsFor(prms.HeadsLoaded[0].Params)
-
-		fmt.Println("PARALLEL SETS FOUND: ", parallelsets)
 
 		mci := NewMultiChannelBlockInstruction()
 		mci.Multi = prms.HeadsLoaded[0].Params.Multi // TODO Remove Hard code here
@@ -616,7 +618,7 @@ func (ins *TransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProper
 		ret = append(ret, sci)
 	}
 
-	return ret
+	return ret, nil
 }
 
 type SingleChannelBlockInstruction struct {
@@ -701,12 +703,18 @@ func (ins *SingleChannelBlockInstruction) GetParameter(name string) interface{} 
 	return nil
 }
 
-func (ins *SingleChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *SingleChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	pol := policy.GetPolicyFor(ins)
 	ret := make([]RobotInstruction, 0)
 	// get tips
 	channel, tiptype := ChooseChannel(ins.Volume[0], prms)
-	ret = append(ret, GetTips(tiptype, prms, channel, 1, false))
+	tipget, err := GetTips(tiptype, prms, channel, 1, false)
+
+	if err != nil {
+		return ret, err
+	}
+
+	ret = append(ret, tipget)
 	n_tip_uses := 0
 
 	var last_thing *wtype.LHComponent
@@ -717,7 +725,11 @@ func (ins *SingleChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms
 
 	for t := 0; t < len(ins.Volume); t++ {
 		newchannel, newtiptype := ChooseChannel(ins.Volume[t], prms)
-		tvs := TransferVolumes(ins.Volume[t], channel.Minvol, channel.Maxvol)
+		tvs, err := TransferVolumes(ins.Volume[t], channel.Minvol, channel.Maxvol)
+
+		if err != nil {
+			return ret, err
+		}
 		for _, vol := range tvs {
 			// determine whether to change tips
 			change_tips := false
@@ -741,8 +753,20 @@ func (ins *SingleChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms
 			if change_tips {
 				// maybe wrap this as a ChangeTips function call
 				// these need parameters
-				ret = append(ret, DropTips(tiptype, prms, channel, 1))
-				ret = append(ret, GetTips(newtiptype, prms, newchannel, 1, false))
+
+				tipdrp, err := DropTips(tiptype, prms, channel, 1)
+				if err != nil {
+					return ret, err
+				}
+				ret = append(ret, tipdrp)
+
+				tipget, err := GetTips(newtiptype, prms, newchannel, 1, false)
+
+				if err != nil {
+					return ret, err
+				}
+
+				ret = append(ret, tipget)
 				tiptype = newtiptype
 				channel = newchannel
 				n_tip_uses = 0
@@ -784,9 +808,14 @@ func (ins *SingleChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms
 		}
 
 	}
-	ret = append(ret, DropTips(tiptype, prms, channel, 1))
+	tipdrp, err := DropTips(tiptype, prms, channel, 1)
 
-	return ret
+	if err != nil {
+		return ret, err
+	}
+	ret = append(ret, tipdrp)
+
+	return ret, nil
 }
 
 type MultiChannelBlockInstruction struct {
@@ -873,13 +902,17 @@ func (ins *MultiChannelBlockInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *MultiChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *MultiChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	pol := policy.GetPolicyFor(ins)
 	ret := make([]RobotInstruction, 0)
 	// get some tips
 
 	channel, tiptype := ChooseChannel(ins.Volume[0][0], prms)
-	ret = append(ret, GetTips(tiptype, prms, channel, ins.Multi, false))
+	tipget, err := GetTips(tiptype, prms, channel, ins.Multi, false)
+	if err != nil {
+		return ret, err
+	}
+	ret = append(ret, tipget)
 	n_tip_uses := 0
 
 	for t := 0; t < len(ins.Volume); t++ {
@@ -901,7 +934,11 @@ func (ins *MultiChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms 
 		// split the transfer up
 		// NB we assume all volumes are equal here;
 		// oof we need to do some work here -- this needs to be in sync with singlechannel block
-		tvs := TransferVolumes(ins.Volume[t][0], newchannel.Minvol, newchannel.Maxvol)
+		tvs, err := TransferVolumes(ins.Volume[t][0], newchannel.Minvol, newchannel.Maxvol)
+
+		if err != nil {
+			return ret, err
+		}
 
 		for _, vol := range tvs {
 			// determine whether to change tips
@@ -927,8 +964,19 @@ func (ins *MultiChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms 
 			if change_tips {
 				// maybe wrap this as a ChangeTips function call
 				// these need parameters
-				ret = append(ret, DropTips(tiptype, prms, channel, ins.Multi))
-				ret = append(ret, GetTips(newtiptype, prms, newchannel, ins.Multi, false))
+				tipdrp, err := DropTips(tiptype, prms, channel, ins.Multi)
+
+				if err != nil {
+					return ret, err
+				}
+				ret = append(ret, tipdrp)
+
+				tipget, err := GetTips(newtiptype, prms, newchannel, ins.Multi, false)
+				if err != nil {
+					return ret, err
+				}
+
+				ret = append(ret, tipget)
 				tiptype = newtiptype
 				channel = newchannel
 				n_tip_uses = 0
@@ -970,9 +1018,15 @@ func (ins *MultiChannelBlockInstruction) Generate(policy *LHPolicyRuleSet, prms 
 	}
 
 	// remove tips
-	ret = append(ret, DropTips(tiptype, prms, channel, ins.Multi))
+	tipdrp, err := DropTips(tiptype, prms, channel, ins.Multi)
 
-	return ret
+	if err != nil {
+		return ret, err
+	}
+
+	ret = append(ret, tipdrp)
+
+	return ret, nil
 }
 
 type SingleChannelTransferInstruction struct {
@@ -1049,7 +1103,7 @@ func (ins *SingleChannelTransferInstruction) GetParameter(name string) interface
 	return nil
 }
 
-func (ins *SingleChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *SingleChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 0)
 	// make the instructions
 
@@ -1076,7 +1130,7 @@ func (ins *SingleChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, p
 		ret = append(ret, resetinstruction)
 	*/
 
-	return ret
+	return ret, nil
 }
 
 type MultiChannelTransferInstruction struct {
@@ -1163,7 +1217,7 @@ func (ins *MultiChannelTransferInstruction) GetParameter(name string) interface{
 	return nil
 }
 
-func (ins *MultiChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *MultiChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 0)
 
 	// make the instructions
@@ -1186,7 +1240,7 @@ func (ins *MultiChannelTransferInstruction) Generate(policy *LHPolicyRuleSet, pr
 	ret = append(ret, blowinstruction)
 	ret = append(ret, resetinstruction)
 
-	return ret
+	return ret, nil
 }
 
 type StateChangeInstruction struct {
@@ -1218,8 +1272,8 @@ func (ins *StateChangeInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *StateChangeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *StateChangeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 type ChangeAdaptorInstruction struct {
@@ -1263,7 +1317,7 @@ func (ins *ChangeAdaptorInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *ChangeAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *ChangeAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 4)
 	/*
 		ret[0]=NewMoveInstruction(ins.DropPosition,...)
@@ -1272,7 +1326,7 @@ func (ins *ChangeAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHP
 		ret[3]=NewLoadAdaptorInstruction(ins.GetPosition,...)
 	*/
 
-	return ret
+	return ret, nil
 }
 
 type LoadTipsMoveInstruction struct {
@@ -1314,7 +1368,7 @@ func (ins *LoadTipsMoveInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *LoadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *LoadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 2)
 
 	// move
@@ -1342,7 +1396,7 @@ func (ins *LoadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHPr
 	lod.Well = ins.Well
 	ret[1] = lod
 
-	return ret
+	return ret, nil
 }
 
 type UnloadTipsMoveInstruction struct {
@@ -1384,7 +1438,7 @@ func (ins *UnloadTipsMoveInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *UnloadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *UnloadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 2)
 
 	// move
@@ -1412,7 +1466,7 @@ func (ins *UnloadTipsMoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LH
 	uld.Well = ins.WellTo
 	ret[1] = uld
 
-	return ret
+	return ret, nil
 }
 
 type AspirateInstruction struct {
@@ -1461,8 +1515,8 @@ func (ins *AspirateInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *AspirateInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *AspirateInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *AspirateInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1518,8 +1572,8 @@ func (ins *DispenseInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *DispenseInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *DispenseInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *DispenseInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1572,8 +1626,8 @@ func (ins *BlowoutInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *BlowoutInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *BlowoutInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *BlowoutInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1615,8 +1669,8 @@ func (ins *PTZInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *PTZInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *PTZInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *PTZInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1679,8 +1733,8 @@ func (ins *MoveInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *MoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *MoveInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *MoveInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1754,8 +1808,8 @@ func (ins *MoveRawInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *MoveRawInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *MoveRawInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *MoveRawInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1812,8 +1866,8 @@ func (ins *LoadTipsInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *LoadTipsInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *LoadTipsInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *LoadTipsInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1867,8 +1921,8 @@ func (ins *UnloadTipsInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *UnloadTipsInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *UnloadTipsInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *UnloadTipsInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -1945,7 +1999,7 @@ func (ins *SuckInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 0, 1)
 
 	// this is where the policies come into effect
@@ -2160,7 +2214,7 @@ func (ins *SuckInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		ret = append(ret, waitins)
 	}
 
-	return ret
+	return ret, nil
 }
 
 type BlowInstruction struct {
@@ -2240,7 +2294,7 @@ func (scti *BlowInstruction) Params() MultiTransferParams {
 	return tp
 }
 
-func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 0)
 	// apply policies here
 
@@ -2509,7 +2563,7 @@ func (ins *BlowInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties
 		ret = append(ret, resetinstruction)
 	}
 
-	return ret
+	return ret, nil
 }
 
 type SetPipetteSpeedInstruction struct {
@@ -2542,8 +2596,8 @@ func (ins *SetPipetteSpeedInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *SetPipetteSpeedInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *SetPipetteSpeedInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *SetPipetteSpeedInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2577,8 +2631,8 @@ func (ins *SetDriveSpeedInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *SetDriveSpeedInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *SetDriveSpeedInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *SetDriveSpeedInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2602,8 +2656,8 @@ func (ins *InitializeInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *InitializeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *InitializeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *InitializeInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2627,8 +2681,8 @@ func (ins *FinalizeInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *FinalizeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *FinalizeInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *FinalizeInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2659,8 +2713,8 @@ func (ins *WaitInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *WaitInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *WaitInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *WaitInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2701,8 +2755,8 @@ func (ins *LightsOnInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *LightsOnInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *LightsOnInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *LightsOnInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2744,8 +2798,8 @@ func (ins *LightsOffInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *LightsOffInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *LightsOffInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *LightsOffInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2787,8 +2841,8 @@ func (ins *OpenInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *OpenInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *OpenInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *OpenInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2830,8 +2884,8 @@ func (ins *CloseInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *CloseInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *CloseInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *CloseInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2873,8 +2927,8 @@ func (ins *LoadAdaptorInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *LoadAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *LoadAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *LoadAdaptorInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -2916,8 +2970,8 @@ func (ins *UnloadAdaptorInstruction) GetParameter(name string) interface{} {
 	return nil
 }
 
-func (ins *UnloadAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *UnloadAdaptorInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *UnloadAdaptorInstruction) OutputTo(driver LiquidhandlingDriver) {
@@ -3009,7 +3063,7 @@ func (ins *ResetInstruction) AddMultiTransferParams(mtp MultiTransferParams) {
 	ins.Prms = mtp.Channel
 }
 
-func (ins *ResetInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *ResetInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	pol := policy.GetPolicyFor(ins)
 	ret := make([]RobotInstruction, 0)
 
@@ -3061,7 +3115,7 @@ func (ins *ResetInstruction) Generate(policy *LHPolicyRuleSet, prms *LHPropertie
 		ret = append(ret, mov2)
 		ret = append(ret, ptz)
 	}
-	return ret
+	return ret, nil
 }
 
 type MoveMixInstruction struct {
@@ -3141,7 +3195,7 @@ func (ins *MoveMixInstruction) InstructionType() int {
 	return MMX
 }
 
-func (ins *MoveMixInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
+func (ins *MoveMixInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 2)
 
 	// move
@@ -3172,7 +3226,7 @@ func (ins *MoveMixInstruction) Generate(policy *LHPolicyRuleSet, prms *LHPropert
 	mix.Blowout = ins.Blowout
 	ret[1] = mix
 
-	return ret
+	return ret, nil
 }
 
 type MixInstruction struct {
@@ -3202,8 +3256,8 @@ func (mi *MixInstruction) InstructionType() int {
 	return mi.Type
 }
 
-func (ins *MixInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction {
-	return nil
+func (ins *MixInstruction) Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error) {
+	return nil, nil
 }
 
 func (ins *MixInstruction) GetParameter(name string) interface{} {
@@ -3237,13 +3291,17 @@ func (mi *MixInstruction) OutputTo(driver LiquidhandlingDriver) {
 
 // TODO -- implement MESSAGE
 
-func GetTips(tiptype string, params *LHProperties, channel *wtype.LHChannelParameter, multi int, mirror bool) RobotInstruction {
+func GetTips(tiptype string, params *LHProperties, channel *wtype.LHChannelParameter, multi int, mirror bool) (RobotInstruction, error) {
 
-	tipwells, tipboxpositions, tipboxtypes := params.GetCleanTips(tiptype, channel, mirror, multi)
+	tipwells, tipboxpositions, tipboxtypes, terr := params.GetCleanTips(tiptype, channel, mirror, multi)
 
-	if tipwells == nil {
-		logger.Fatal("No tips left")
-		panic("NO TIPS LEFT BOYO")
+	if tipwells == nil || terr != nil {
+		/*
+			logger.Fatal("No tips left")
+			panic("NO TIPS LEFT BOYO")
+		*/
+		err := wtype.LHError(wtype.LH_ERR_NO_TIPS, fmt.Sprint("PICKUP: type: ", tiptype, " n: ", multi, " mirror: ", mirror))
+		return NewLoadTipsMoveInstruction(), err
 	}
 
 	ins := NewLoadTipsMoveInstruction()
@@ -3253,17 +3311,18 @@ func GetTips(tiptype string, params *LHProperties, channel *wtype.LHChannelParam
 	ins.FPlateType = tipboxtypes
 	ins.Multi = multi
 
-	logger.Debug(InsToString(ins))
-
-	return ins
+	return ins, nil
 }
 
-func DropTips(tiptype string, params *LHProperties, channel *wtype.LHChannelParameter, multi int) RobotInstruction {
+func DropTips(tiptype string, params *LHProperties, channel *wtype.LHChannelParameter, multi int) (RobotInstruction, error) {
 	tipwells, tipwastepositions, tipwastetypes := params.DropDirtyTips(channel, multi)
 
 	if tipwells == nil {
-		logger.Fatal("Could not dispose tip. No usable tipwell found")
-		panic("NO ROOM AT THE INN FOR THESE LITTLE TIPS")
+		//logger.Fatal("Could not dispose tip. No usable tipwell found")
+		//panic("NO ROOM AT THE INN FOR THESE LITTLE TIPS")
+		ins := NewUnloadTipsMoveInstruction()
+		err := wtype.LHError(wtype.LH_ERR_NO_TIPS, fmt.Sprint("DROP: type: ", tiptype, " n: ", multi))
+		return ins, err
 	}
 
 	ins := NewUnloadTipsMoveInstruction()
@@ -3273,5 +3332,5 @@ func DropTips(tiptype string, params *LHProperties, channel *wtype.LHChannelPara
 	ins.TPlateType = tipwastetypes
 	ins.Multi = multi
 	logger.Debug(InsToString(ins))
-	return ins
+	return ins, nil
 }

--- a/microArch/driver/liquidhandling/lherror_test.go
+++ b/microArch/driver/liquidhandling/lherror_test.go
@@ -1,0 +1,24 @@
+package liquidhandling
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPolicyError(t *testing.T) {
+	rule := NewLHPolicyRule("test_rule")
+	err := rule.AddNumericConditionOn("VOLUME", 32.5, 32.3)
+	e1 := "6 (LH_ERR_POLICY) : liquid handling policy error : Numeric condition requested with lower limit (32.500000) greater than upper limit (32.300000), which is not allowed"
+	if err == nil {
+		t.Fatal(fmt.Sprintf("Expected error %s\nGot nil", e1))
+	} else if err.Error() != e1 {
+		t.Fatal(fmt.Sprintf("Expected error --%s--\nGot error --%s--\n", e1, err.Error()))
+	}
+	e2 := "6 (LH_ERR_POLICY) : liquid handling policy error : Categoric condition  has an empty category, which is not allowed"
+	err = rule.AddCategoryConditionOn("VOLUME", "")
+	if err == nil {
+		t.Fatal(fmt.Sprintf("Expected error %s\nGot nil", e2))
+	} else if err.Error() != e2 {
+		t.Fatal(fmt.Sprintf("Expected error %s\nGot error %s\n", e2, err.Error()))
+	}
+}

--- a/microArch/driver/liquidhandling/lhpolicy.go
+++ b/microArch/driver/liquidhandling/lhpolicy.go
@@ -28,8 +28,8 @@ import (
 	"io/ioutil"
 	"sort"
 
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
-	"github.com/antha-lang/antha/microArch/logger"
 )
 
 const (
@@ -85,18 +85,29 @@ func NewLHPolicyRule(name string) LHPolicyRule {
 	return lhpr
 }
 
-func (lhpr *LHPolicyRule) AddNumericConditionOn(variable string, low, up float64) {
+func (lhpr *LHPolicyRule) AddNumericConditionOn(variable string, low, up float64) error {
 	lhvc := NewLHVariableCondition(variable)
-	lhvc.SetNumeric(low, up)
+	err := lhvc.SetNumeric(low, up)
+
+	if err != nil {
+		return err
+	}
 	lhpr.Conditions = append(lhpr.Conditions, lhvc)
 	lhpr.Priority += 1
+	return nil
 }
 
-func (lhpr *LHPolicyRule) AddCategoryConditionOn(variable, category string) {
+func (lhpr *LHPolicyRule) AddCategoryConditionOn(variable, category string) error {
 	lhvc := NewLHVariableCondition(variable)
-	lhvc.SetCategoric(category)
+	err := lhvc.SetCategoric(category)
+
+	if err != nil {
+		return err
+	}
+
 	lhpr.Conditions = append(lhpr.Conditions, lhvc)
 	lhpr.Priority += 1
+	return err
 }
 
 func (lhpr LHPolicyRule) Check(ins RobotInstruction) bool {
@@ -215,20 +226,28 @@ func NewLHVariableCondition(testvariable string) LHVariableCondition {
 	return lhvc
 }
 
-func (lhvc *LHVariableCondition) SetNumeric(low, up float64) {
+func (lhvc *LHVariableCondition) SetNumeric(low, up float64) error {
 	if low > up {
-		logger.Fatal("Nonsensical numeric condition requested")
-		panic("Nonsensical numeric condition requested")
+		/*
+			logger.Fatal("Nonsensical numeric condition requested")
+			panic("Nonsensical numeric condition requested")
+		*/
+		return wtype.LHError(wtype.LH_ERR_POLICY, fmt.Sprintf("Numeric condition requested with lower limit (%f) greater than upper limit (%f), which is not allowed", low, up))
 	}
 	lhvc.Condition = LHNumericCondition{up, low}
+	return nil
 }
 
-func (lhvc *LHVariableCondition) SetCategoric(category string) {
+func (lhvc *LHVariableCondition) SetCategoric(category string) error {
 	if category == "" {
-		logger.Fatal("No empty categoric conditions can be made")
-		panic("No empty categoric conditions can be made")
+		/*
+			logger.Fatal("No empty categoric conditions can be made")
+			panic("No empty categoric conditions can be made")
+		*/
+		return wtype.LHError(wtype.LH_ERR_POLICY, fmt.Sprintf("Categoric condition %s has an empty category, which is not allowed", category))
 	}
 	lhvc.Condition = LHCategoryCondition{category}
+	return nil
 }
 
 func (lhvc LHVariableCondition) IsEqualTo(other LHVariableCondition) bool {

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -434,36 +434,33 @@ func (lhp *LHProperties) AddTipWaste(tipwaste *wtype.LHTipwaste) error {
 			continue
 		}
 
-		lhp.AddTipWasteTo(pref, tipwaste)
-		return nil
+		err := lhp.AddTipWasteTo(pref, tipwaste)
+		return err
 	}
 
 	return wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, "Trying to add tip waste")
 }
 
-func (lhp *LHProperties) AddTipWasteTo(pos string, tipwaste *wtype.LHTipwaste) bool {
+func (lhp *LHProperties) AddTipWasteTo(pos string, tipwaste *wtype.LHTipwaste) error {
 	if lhp.PosLookup[pos] != "" {
-		logger.Debug("CAN'T ADD TIPWASTE TO FULL POSITION")
-		//panic("CAN'T ADD TIPWASTE TO FULL POSITION")
-		return false
+		return wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, fmt.Sprintf("Trying to add tip waste to full position %s", pos))
 	}
 	lhp.Tipwastes[pos] = tipwaste
 	lhp.PlateLookup[tipwaste.ID] = tipwaste
 	lhp.PosLookup[pos] = tipwaste.ID
 	lhp.PlateIDLookup[tipwaste.ID] = pos
-	return true
+	return nil
 }
 
-func (lhp *LHProperties) AddPlate(pos string, plate *wtype.LHPlate) bool {
+func (lhp *LHProperties) AddPlate(pos string, plate *wtype.LHPlate) error {
 	if lhp.PosLookup[pos] != "" {
-		logger.Debug("CAN'T ADD PLATE TO FULL POSITION")
-		return false
+		return wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, fmt.Sprintf("Trying to add plate to full position %s", pos))
 	}
 	lhp.Plates[pos] = plate
 	lhp.PlateLookup[plate.ID] = plate
 	lhp.PosLookup[pos] = plate.ID
 	lhp.PlateIDLookup[plate.ID] = pos
-	return true
+	return nil
 }
 
 // reverse the above

--- a/microArch/driver/liquidhandling/makelhpolicy.go
+++ b/microArch/driver/liquidhandling/makelhpolicy.go
@@ -481,7 +481,7 @@ func MakeLVExtraPolicy() LHPolicy {
 	return lvep
 }
 
-func GetLHPolicyForTest() *LHPolicyRuleSet {
+func GetLHPolicyForTest() (*LHPolicyRuleSet, error) {
 	// make some policies
 
 	policies := MakePolicies()
@@ -492,7 +492,11 @@ func GetLHPolicyForTest() *LHPolicyRuleSet {
 
 	for name, policy := range policies {
 		rule := NewLHPolicyRule(name)
-		rule.AddCategoryConditionOn("LIQUIDCLASS", name)
+		err := rule.AddCategoryConditionOn("LIQUIDCLASS", name)
+
+		if err != nil {
+			return nil, err
+		}
 		lhpr.AddRule(rule, policy)
 	}
 
@@ -501,8 +505,16 @@ func GetLHPolicyForTest() *LHPolicyRuleSet {
 	// are being properly kept in sync
 
 	rule := NewLHPolicyRule("BlowOutToEmptyWells")
-	rule.AddNumericConditionOn("WELLTOVOLUME", 0.0, 1.0)
-	rule.AddCategoryConditionOn("LIQUIDCLASS", "water")
+	err := rule.AddNumericConditionOn("WELLTOVOLUME", 0.0, 1.0)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = rule.AddCategoryConditionOn("LIQUIDCLASS", "water")
+	if err != nil {
+		return nil, err
+	}
 	pol := MakeJBPolicy()
 	lhpr.AddRule(rule, pol)
 
@@ -510,11 +522,15 @@ func GetLHPolicyForTest() *LHPolicyRuleSet {
 	// for aspirate and dispense
 
 	rule = NewLHPolicyRule("ExtraVolumeForLV")
-	rule.AddNumericConditionOn("VOLUME", 0.0, 20.0)
+	err = rule.AddNumericConditionOn("VOLUME", 0.0, 20.0)
+	if err != nil {
+		return nil, err
+	}
+
 	pol = MakeLVExtraPolicy()
 	lhpr.AddRule(rule, pol)
 
-	return lhpr
+	return lhpr, nil
 }
 
 func LoadLHPoliciesFromFile() (*LHPolicyRuleSet, error) {

--- a/microArch/driver/liquidhandling/robotinstruction.go
+++ b/microArch/driver/liquidhandling/robotinstruction.go
@@ -30,7 +30,7 @@ import (
 type RobotInstruction interface {
 	InstructionType() int
 	GetParameter(name string) interface{}
-	Generate(policy *LHPolicyRuleSet, prms *LHProperties) []RobotInstruction
+	Generate(policy *LHPolicyRuleSet, prms *LHProperties) ([]RobotInstruction, error)
 }
 
 type TerminalRobotInstruction interface {

--- a/microArch/driver/liquidhandling/robotinstructionset.go
+++ b/microArch/driver/liquidhandling/robotinstructionset.go
@@ -43,16 +43,20 @@ func (ri *RobotInstructionSet) Add(ins RobotInstruction) {
 	ri.instructions = append(ri.instructions, ris)
 }
 
-func (ri *RobotInstructionSet) Generate(lhpr *LHPolicyRuleSet, lhpm *LHProperties) []RobotInstruction {
+func (ri *RobotInstructionSet) Generate(lhpr *LHPolicyRuleSet, lhpm *LHProperties) ([]RobotInstruction, error) {
 	ret := make([]RobotInstruction, 0, 1)
 
 	if ri.parent != nil {
-		arr := ri.parent.Generate(lhpr, lhpm)
+		arr, err := ri.parent.Generate(lhpr, lhpm)
+
+		if err != nil {
+			return ret, err
+		}
 
 		// if the parent doesn't generate anything then it is our return - bottom out here
 		if arr == nil || len(arr) == 0 {
 			ret = append(ret, ri.parent)
-			return ret
+			return ret, nil
 		} else {
 			for _, ins := range arr {
 				ri.Add(ins)
@@ -61,7 +65,11 @@ func (ri *RobotInstructionSet) Generate(lhpr *LHPolicyRuleSet, lhpm *LHPropertie
 	}
 
 	for _, ins := range ri.instructions {
-		arr := ins.Generate(lhpr, lhpm)
+		arr, err := ins.Generate(lhpr, lhpm)
+
+		if err != nil {
+			return arr, err
+		}
 		ret = append(ret, arr...)
 	}
 
@@ -76,7 +84,7 @@ func (ri *RobotInstructionSet) Generate(lhpr *LHPolicyRuleSet, lhpm *LHPropertie
 		ret = newret
 	}
 
-	return ret
+	return ret, nil
 }
 
 func (ri *RobotInstructionSet) ToString(level int) string {

--- a/microArch/factory/make_component_library.go
+++ b/microArch/factory/make_component_library.go
@@ -25,9 +25,9 @@ package factory
 import (
 	"fmt"
 
+	"github.com/Synthace/antha/microArch/logger"
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/image"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
-	"github.com/antha-lang/antha/microArch/logger"
 )
 
 func makeComponentLibrary() map[string]*wtype.LHComponent {

--- a/microArch/factory/make_component_library.go
+++ b/microArch/factory/make_component_library.go
@@ -25,9 +25,9 @@ package factory
 import (
 	"fmt"
 
-	"github.com/Synthace/antha/microArch/logger"
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/image"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/microArch/logger"
 )
 
 func makeComponentLibrary() map[string]*wtype.LHComponent {

--- a/microArch/factory/make_tip_library.go
+++ b/microArch/factory/make_tip_library.go
@@ -82,6 +82,10 @@ func makeTipLibrary() map[string]*wtype.LHTipbox {
 	return tips
 }
 
+func GetTipBoxByTip(tip *wtype.LHTip) *wtype.LHTipbox {
+	return GetTipByType(tip.Type)
+}
+
 func GetTipboxByType(typ string) *wtype.LHTipbox {
 	return GetTipByType(typ)
 }

--- a/microArch/scheduler/liquidhandling/funcs.go
+++ b/microArch/scheduler/liquidhandling/funcs.go
@@ -32,6 +32,7 @@ func RaiseError(err string) {
 }
 
 // looks up where a plate is mounted on a liquid handler as expressed in a request
+/* deprecated
 func PlateLookup(rq LHRequest, id string) string {
 	lookupmap := rq.Plate_lookup
 
@@ -41,3 +42,4 @@ func PlateLookup(rq LHRequest, id string) string {
 
 	return lookupmap[id]
 }
+*/

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -73,7 +73,7 @@ func (is InputSorter) Less(i, j int) bool {
 // INPUT: 	"input_platetype", "inputs"
 //OUTPUT: 	"input_plates"      -- these each have components in wells
 //		"input_assignments" -- map with arrays of assignment strings, i.e. {tea: [plate1:A:1, plate1:A:2...] }etc.
-func input_plate_setup(request *LHRequest) *LHRequest {
+func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 	// I think this might need moving too
 	logger.Debug("in input plate setup")
 	input_platetypes := (*request).Input_platetypes
@@ -223,5 +223,5 @@ func input_plate_setup(request *LHRequest) *LHRequest {
 	(*request).Input_plates = input_plates
 	(*request).Input_assignments = input_assignments
 	//return input_plates, input_assignments
-	return request
+	return request, nil
 }

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -33,30 +33,38 @@ import (
 	"strings"
 )
 
-func ImprovedLayoutAgent(request *LHRequest, params *liquidhandling.LHProperties) *LHRequest {
+func ImprovedLayoutAgent(request *LHRequest, params *liquidhandling.LHProperties) (*LHRequest, error) {
 	// do this multiply based on the order in the chain
 
 	ch := request.InstructionChain
 	pc := make([]PlateChoice, 0, 3)
 	mp := make(map[int]string)
+	var err error
 	for {
 		if ch == nil {
 			break
 		}
-		request, pc, mp = LayoutStage(request, params, ch, pc, mp)
+		request, pc, mp, err = LayoutStage(request, params, ch, pc, mp)
+		if err != nil {
+			break
+		}
 		ch = ch.Child
 	}
 
-	return request
+	return request, err
 }
-func LayoutStage(request *LHRequest, params *liquidhandling.LHProperties, chain *IChain, plate_choices []PlateChoice, mapchoices map[int]string) (*LHRequest, []PlateChoice, map[int]string) {
+func LayoutStage(request *LHRequest, params *liquidhandling.LHProperties, chain *IChain, plate_choices []PlateChoice, mapchoices map[int]string) (*LHRequest, []PlateChoice, map[int]string, error) {
 	// we have three kinds of solution
 	// 1- ones going to a specific plate
 	// 2- ones going to a specific plate type
 	// 3- ones going to a plate of our choosing
 
 	// find existing assignments
-	plate_choices, mapchoices = get_and_complete_assignments(request, chain.ValueIDs(), plate_choices, mapchoices)
+	plate_choices, mapchoices, err := get_and_complete_assignments(request, chain.ValueIDs(), plate_choices, mapchoices)
+
+	if err != nil {
+		return request, plate_choices, mapchoices, err
+	}
 	// now we know what remains unassigned, we assign it
 
 	plate_choices = choose_plates(request, plate_choices, chain.ValueIDs())
@@ -144,7 +152,7 @@ func LayoutStage(request *LHRequest, params *liquidhandling.LHProperties, chain 
 		}
 	}
 
-	return request, plate_choices, mapchoices
+	return request, plate_choices, mapchoices, nil
 }
 
 type PlateChoice struct {
@@ -154,7 +162,7 @@ type PlateChoice struct {
 	Wells     []string
 }
 
-func get_and_complete_assignments(request *LHRequest, order []string, s []PlateChoice, m map[int]string) ([]PlateChoice, map[int]string) {
+func get_and_complete_assignments(request *LHRequest, order []string, s []PlateChoice, m map[int]string) ([]PlateChoice, map[int]string, error) {
 	//s := make([]PlateChoice, 0, 3)
 	//m := make(map[int]string)
 
@@ -200,7 +208,9 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 			addr, ok := st.GetLocationOf(v.Components[0].ID)
 
 			if !ok {
-				logger.Fatal("MIX IN PLACE WITH NO LOCATION SET")
+				//logger.Fatal("MIX IN PLACE WITH NO LOCATION SET")
+				err := wtype.LHError(wtype.LH_ERR_DIRE, "MIX IN PLACE WITH NO LOCATION SET")
+				return s, m, err
 			}
 
 			v.Components[0].Loc = addr
@@ -241,7 +251,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 		}
 	}
 
-	return s, m
+	return s, m, nil
 }
 
 func defined(s string, pc []PlateChoice) int {
@@ -398,7 +408,7 @@ func make_plates(request *LHRequest, order []string) map[string]string {
 	return remap
 }
 
-func make_layouts(request *LHRequest, pc []PlateChoice) {
+func make_layouts(request *LHRequest, pc []PlateChoice) error {
 	// we need to fill in the platechoice structure then
 	// transfer the info across to the solutions
 
@@ -432,14 +442,13 @@ func make_layouts(request *LHRequest, pc []PlateChoice) {
 
 			var assignment string
 
-			fmt.Println("OK ONE OF THESE HAS TO BE THERE")
 			if well == "" {
-				fmt.Println("WTAF????")
 				wc := plat.NextEmptyWell(it)
 
 				if wc.IsZero() {
 					// something very bad has happened
-					logger.Fatal("DIRE WARNING: The unthinkable has happened... output plate has too many assignments!")
+					//	logger.Fatal("DIRE WARNING: The unthinkable has happened... output plate has too many assignments!")
+					return wtype.LHError(wtype.LH_ERR_DIRE, "DIRE WARNING: The unthinkable has happened... output plate has too many assignments!")
 				}
 
 				//plat.Cols[wc.X][wc.Y].Currvol += 100.0
@@ -450,7 +459,6 @@ func make_layouts(request *LHRequest, pc []PlateChoice) {
 				assignment = c.ID + ":" + wc.FormatA1()
 				c.Wells[i] = wc.FormatA1()
 			} else {
-				fmt.Println("WELL HERE: ", well)
 				assignment = c.ID + ":" + well
 			}
 
@@ -459,4 +467,5 @@ func make_layouts(request *LHRequest, pc []PlateChoice) {
 	}
 
 	request.Output_assignments = opa
+	return nil
 }

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -1,0 +1,43 @@
+package liquidhandling
+
+import (
+	//"github.com/antha-lang/antha/microArch/driver/liquidhandling"
+	"fmt"
+	"testing"
+)
+
+func GetLiquidHandlerForTest() *Liquidhandler {
+	gilson := makeGilson()
+	return Init(gilson)
+}
+
+func GetLHRequestForTest() *LHRequest {
+	req := NewLHRequest()
+	return req
+}
+
+func TestNoInstructions(t *testing.T) {
+	req := GetLHRequestForTest()
+	lh := GetLiquidHandlerForTest()
+	err := lh.MakeSolutions(req)
+
+	if err.Error() != "9 (LH_ERR_OTHER) :  : Nil plan requested: no Mix Instructions present" {
+		t.Fatal(fmt.Sprint("Unexpected error: ", err.Error()))
+	}
+}
+
+func TestDeckSpace1(t *testing.T) {
+
+}
+
+func TestNoTips(t *testing.T) {
+
+}
+
+func TestNotImplemented(t *testing.T) {
+
+}
+
+func TestDriv(t *testing.T) {
+
+}

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -74,15 +74,3 @@ func TestDeckSpace2(t *testing.T) {
 	}
 
 }
-
-func TestNoTips(t *testing.T) {
-
-}
-
-func TestNotImplemented(t *testing.T) {
-
-}
-
-func TestDriv(t *testing.T) {
-
-}

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -4,6 +4,10 @@ import (
 	//"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 	"fmt"
 	"testing"
+
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/microArch/factory"
 )
 
 func GetLiquidHandlerForTest() *Liquidhandler {
@@ -36,8 +40,18 @@ func TestDeckSpace1(t *testing.T) {
 
 	lh := GetLiquidHandlerForTest()
 
-	for i := 0; i < lh.Properties.Nposns; i++ {
-		tb := factory.GetTipBoxByType()
+	for i := 0; i < len(lh.Properties.Tip_preferences); i++ {
+		tb := factory.GetTipBoxByTip(lh.Properties.Tips[0])
+		err := lh.Properties.AddTipBox(tb)
+		if err != nil {
+			t.Fatal(fmt.Sprintf("Should be able to fill deck with tipboxes, only managed %d", i+1))
+		}
+	}
+
+	tb := factory.GetTipBoxByTip(lh.Properties.Tips[0])
+	err := lh.Properties.AddTipBox(tb)
+	if err.Error() != "1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : Trying to add tip box" {
+		t.Fatal(fmt.Sprint("Expected error : 1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : Trying to add tip box\n", " got: ", err.Error()))
 	}
 }
 

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -55,6 +55,26 @@ func TestDeckSpace1(t *testing.T) {
 	}
 }
 
+func TestDeckSpace2(t *testing.T) {
+	lh := GetLiquidHandlerForTest()
+
+	for i := 0; i < len(lh.Properties.Input_preferences); i++ {
+		plate := factory.GetPlateByType("pcrplate_skirted")
+		err := lh.Properties.AddPlate(lh.Properties.Input_preferences[i], plate)
+		if err != nil {
+			t.Fatal(fmt.Sprintf("position %s is full, should be empty", lh.Properties.Input_preferences[i]))
+		}
+	}
+
+	plate := factory.GetPlateByType("pcrplate_skirted")
+	err := lh.Properties.AddPlate(lh.Properties.Input_preferences[0], plate)
+
+	if err.Error() != "1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : Trying to add plate to full position position_4" {
+		t.Fatal(fmt.Sprint("1 (LH_ERR_NO_DECK_SPACE) : insufficient deck space to fit all required items; this may be due to constraints : Trying to add plate to full position position_4\n", " got: ", err.Error()))
+	}
+
+}
+
 func TestNoTips(t *testing.T) {
 
 }

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -37,7 +37,7 @@ func TestDeckSpace1(t *testing.T) {
 	lh := GetLiquidHandlerForTest()
 
 	for i := 0; i < lh.Properties.Nposns; i++ {
-
+		tb := factory.GetTipBoxByType()
 	}
 }
 

--- a/microArch/scheduler/liquidhandling/lherror_test.go
+++ b/microArch/scheduler/liquidhandling/lherror_test.go
@@ -16,6 +16,12 @@ func GetLHRequestForTest() *LHRequest {
 	return req
 }
 
+func GetComponentForTest(name string, vol wunit.Volume) *wtype.LHComponent {
+	c := factory.GetComponentByType(name)
+	c.SetVolume(vol)
+	return c
+}
+
 func TestNoInstructions(t *testing.T) {
 	req := GetLHRequestForTest()
 	lh := GetLiquidHandlerForTest()
@@ -28,6 +34,11 @@ func TestNoInstructions(t *testing.T) {
 
 func TestDeckSpace1(t *testing.T) {
 
+	lh := GetLiquidHandlerForTest()
+
+	for i := 0; i < lh.Properties.Nposns; i++ {
+
+	}
 }
 
 func TestNoTips(t *testing.T) {

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -294,6 +294,8 @@ func (this *Liquidhandler) Plan(request *LHRequest) error {
 	// fix the deck setup
 
 	request = this.Tip_box_setup(request)
+
+	return nil
 }
 
 // sort out inputs

--- a/microArch/scheduler/liquidhandling/make_liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/make_liquidhandler.go
@@ -1,0 +1,117 @@
+package liquidhandling
+
+import (
+	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
+	. "github.com/antha-lang/antha/microArch/factory"
+)
+
+func SetUpTipsFor(lhp *liquidhandling.LHProperties) *liquidhandling.LHProperties {
+	tips := GetTipList()
+	for _, tt := range tips {
+		tb := GetTipByType(tt)
+		if tb.Mnfr == lhp.Mnfr || lhp.Mnfr == "MotherNature" {
+			lhp.Tips = append(lhp.Tips, tb.Tips[0][0])
+		}
+	}
+	return lhp
+}
+
+func makeLiquidhandlerLibrary() map[string]*liquidhandling.LHProperties {
+	robots := make(map[string]*liquidhandling.LHProperties, 2)
+	robots["GilsonPipetmax"] = makeGilson()
+	return robots
+}
+
+func makeGilson() *liquidhandling.LHProperties {
+	// gilson pipetmax
+
+	layout := make(map[string]wtype.Coordinates)
+	i := 0
+	x0 := 3.886
+	y0 := 3.513
+	z0 := -82.035
+	xi := 149.86
+	yi := 95.25
+	xp := x0
+	yp := y0
+	zp := z0
+	for y := 0; y < 3; y++ {
+		xp = x0
+		for x := 0; x < 3; x++ {
+			posname := fmt.Sprintf("position_%d", i+1)
+			crds := wtype.Coordinates{xp, yp, zp}
+			layout[posname] = crds
+			i += 1
+			xp += xi
+		}
+		yp += yi
+	}
+	lhp := liquidhandling.NewLHProperties(9, "Pipetmax", "Gilson", "discrete", "disposable", layout)
+	// get tips permissible from the factory
+	SetUpTipsFor(lhp)
+
+	//lhp.Tip_preferences = []string{"position_2", "position_3", "position_6", "position_9", "position_8", "position_5", "position_4", "position_7"}
+	//lhp.Tip_preferences = []string{"position_2", "position_3", "position_6", "position_9", "position_8", "position_5", "position_7"}
+
+	lhp.Tip_preferences = []string{"position_9", "position_6", "position_3", "position_5", "position_2"} //jmanart i cut it down to 5, as it was hardcoded in the liquidhandler getInputs call before
+
+	// original preferences
+	lhp.Input_preferences = []string{"position_4", "position_5", "position_6", "position_9", "position_8", "position_3"}
+	lhp.Output_preferences = []string{"position_7", "position_8", "position_9", "position_6", "position_5", "position_3"}
+
+	// use these new preferences for gel loading: this is needed because outplate overlaps inplate otherwise so move inplate to position 5 rather than 4 (pos 4 deleted)
+	//lhp.Input_preferences = []string{"position_5", "position_6", "position_9", "position_8", "position_3"}
+	//lhp.Output_preferences = []string{"position_9", "position_8", "position_7", "position_6", "position_5", "position_3"}
+
+	lhp.Wash_preferences = []string{"position_8"}
+	lhp.Tipwaste_preferences = []string{"position_1"}
+	lhp.Waste_preferences = []string{"position_9"}
+	//	lhp.Tip_preferences = []int{2, 3, 6, 9, 5, 8, 4, 7}
+	//	lhp.Input_preferences = []int{24, 25, 26, 29, 28, 23}
+	//	lhp.Output_preferences = []int{10, 11, 12, 13, 14, 15}
+	minvol := wunit.NewVolume(10, "ul")
+	maxvol := wunit.NewVolume(250, "ul")
+	minspd := wunit.NewFlowRate(0.5, "ml/min")
+	maxspd := wunit.NewFlowRate(2, "ml/min")
+
+	hvconfig := wtype.NewLHChannelParameter("HVconfig", minvol, maxvol, minspd, maxspd, 8, false, wtype.LHVChannel, 0)
+	hvadaptor := wtype.NewLHAdaptor("DummyAdaptor", "Gilson", hvconfig)
+	hvhead := wtype.NewLHHead("HVHead", "Gilson", hvconfig)
+	hvhead.Adaptor = hvadaptor
+	newminvol := wunit.NewVolume(0.5, "ul")
+	newmaxvol := wunit.NewVolume(20, "ul")
+	newminspd := wunit.NewFlowRate(0.1, "ml/min")
+	newmaxspd := wunit.NewFlowRate(0.5, "ml/min")
+
+	lvconfig := wtype.NewLHChannelParameter("LVconfig", newminvol, newmaxvol, newminspd, newmaxspd, 8, false, wtype.LHVChannel, 1)
+	lvadaptor := wtype.NewLHAdaptor("DummyAdaptor", "Gilson", lvconfig)
+	lvhead := wtype.NewLHHead("LVHead", "Gilson", lvconfig)
+	lvhead.Adaptor = lvadaptor
+
+	lhp.Heads = append(lhp.Heads, hvhead)
+	lhp.Heads = append(lhp.Heads, lvhead)
+	lhp.HeadsLoaded = append(lhp.HeadsLoaded, hvhead)
+	lhp.HeadsLoaded = append(lhp.HeadsLoaded, lvhead)
+
+	return lhp
+}
+
+func GetLiquidhandlerByType(typ string) *liquidhandling.LHProperties {
+	liquidhandlers := makeLiquidhandlerLibrary()
+	t := liquidhandlers[typ]
+	return t.Dup()
+}
+
+func LiquidhandlerList() []string {
+	liquidhandlers := makeLiquidhandlerLibrary()
+	kz := make([]string, len(liquidhandlers))
+	x := 0
+	for name, _ := range liquidhandlers {
+		kz[x] = name
+		x += 1
+	}
+	return kz
+}

--- a/microArch/scheduler/liquidhandling/make_liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/make_liquidhandler.go
@@ -1,5 +1,8 @@
 package liquidhandling
 
+// this version of the liquid handler factory is JUST for testing
+// so has no public calls to return liquid handlers
+
 import (
 	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
@@ -97,21 +100,4 @@ func makeGilson() *liquidhandling.LHProperties {
 	lhp.HeadsLoaded = append(lhp.HeadsLoaded, lvhead)
 
 	return lhp
-}
-
-func GetLiquidhandlerByType(typ string) *liquidhandling.LHProperties {
-	liquidhandlers := makeLiquidhandlerLibrary()
-	t := liquidhandlers[typ]
-	return t.Dup()
-}
-
-func LiquidhandlerList() []string {
-	liquidhandlers := makeLiquidhandlerLibrary()
-	kz := make([]string, len(liquidhandlers))
-	x := 0
-	for name, _ := range liquidhandlers {
-		kz[x] = name
-		x += 1
-	}
-	return kz
 }

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -25,6 +25,7 @@ package liquidhandling
 import (
 	"fmt"
 
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 	"github.com/antha-lang/antha/microArch/logger"
 )
@@ -33,7 +34,7 @@ import (
 // positioning in the face of constraints
 
 // default setup agent
-func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) *LHRequest {
+func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) (*LHRequest, error) {
 	// this is quite tricky and requires extensive interaction with the liquid handling
 	// parameters
 
@@ -94,7 +95,9 @@ func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) *L
 	for _, p := range output_plates {
 		position := get_first_available_preference(output_preferences, setup)
 		if position == "" {
-			RaiseError("No positions left for output")
+			//RaiseError("No positions left for output")
+			err := wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, "No positions left for output")
+			return request, err
 		}
 		setup[position] = p
 		plate_lookup[p.ID] = position
@@ -105,7 +108,9 @@ func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) *L
 	for _, p := range input_plates {
 		position := get_first_available_preference(input_preferences, setup)
 		if position == "" {
-			RaiseError("No positions left for input")
+			//RaiseError("No positions left for input")
+			err := wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, "No positions left for input")
+			return request, err
 		}
 		//fmt.Println("PLAATE: ", position)
 		setup[position] = p
@@ -116,7 +121,7 @@ func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) *L
 
 	//request.Setup = setup
 	request.Plate_lookup = plate_lookup
-	return request
+	return request, nil
 }
 
 func get_first_available_preference(prefs []string, setup map[string]interface{}) string {

--- a/microArch/scheduler/liquidhandling/solution_setup.go
+++ b/microArch/scheduler/liquidhandling/solution_setup.go
@@ -23,8 +23,8 @@
 package liquidhandling
 
 import (
-	"errors"
 	"fmt"
+
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
@@ -35,7 +35,7 @@ import (
 // fulfil the requirements for making
 // instructions to specifications
 
-func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[string]*wtype.LHInstruction, map[string]float64) {
+func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[string]*wtype.LHInstruction, map[string]float64, error) {
 	instructions := request.LHInstructions
 
 	// index of components used to make up to a total volume, along with the required total
@@ -77,7 +77,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 					totalvol = tv
 				} else {
 					// error
-					wutil.Error(errors.New(fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.Name)))
+					wtype.LHError(wtype.LH_ERR_CONC, fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.Name))
 				}
 			} else {
 				cmpvol += component.Vol
@@ -207,7 +207,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 					totalvol = tv
 				} else {
 					// error
-					wutil.Error(errors.New(fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.Name)))
+					wtype.LHError(wtype.LH_ERR_CONC, fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.Name))
 				}
 			} else {
 				// need to add in the volume taken up by any volume components
@@ -252,5 +252,5 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 		newInstructions[instruction.ID] = instruction
 	}
 
-	return newInstructions, stockconcs
+	return newInstructions, stockconcs, nil
 }

--- a/microArch/scheduler/liquidhandling/tip_box_setup.go
+++ b/microArch/scheduler/liquidhandling/tip_box_setup.go
@@ -35,7 +35,7 @@ import (
 //  TASK: 	Determine number of tip boxes of each type
 // INPUT: 	instructions
 //OUTPUT: 	arrays of tip boxes
-func (lh *Liquidhandler) Tip_box_setup(request *LHRequest) *LHRequest {
+func (lh *Liquidhandler) Tip_box_setup(request *LHRequest) (*LHRequest, error) {
 	tip_boxes := make([]*wtype.LHTipbox, 0)
 
 	// the instructions have been generated at this point so we just need to go through and count the tips used
@@ -131,5 +131,5 @@ func (lh *Liquidhandler) Tip_box_setup(request *LHRequest) *LHRequest {
 		lh.Properties.AddTipBoxTo(tiplocs2[i], tb)
 	}
 
-	return request
+	return request, nil
 }

--- a/target/inst.go
+++ b/target/inst.go
@@ -27,6 +27,11 @@ type RunInst interface {
 	Data() Files // Blob of data that is runnable
 }
 
+type ErrInst interface {
+	Inst
+	Error() error // error returned during compilation
+}
+
 type Graph struct {
 	Insts []Inst
 }
@@ -48,7 +53,28 @@ func (a *Graph) Out(n graph.Node, i int) graph.Node {
 }
 
 type CmpError struct {
-	Err error
+	Dev     Device
+	Depends []Inst
+	Err     error
+}
+
+func (a *CmpError) Device() Device {
+	return a.Dev
+}
+
+func (a *CmpError) DependsOn() []Inst {
+	return a.Depends
+}
+
+func (a *CmpError) SetDependsOn(x []Inst) {
+	a.Depends = x
+}
+func (a *CmpError) GetTimeEstimate() float64 {
+	return 0.0
+}
+
+func (a *CmpError) Error() error {
+	return a.Err
 }
 
 type Incubate struct {

--- a/target/inst.go
+++ b/target/inst.go
@@ -15,7 +15,6 @@ type Inst interface {
 	DependsOn() []Inst
 	SetDependsOn([]Inst)
 	GetTimeEstimate() float64
-	Error() error
 }
 
 type Files struct {
@@ -46,6 +45,10 @@ func (a *Graph) NumOuts(n graph.Node) int {
 
 func (a *Graph) Out(n graph.Node, i int) graph.Node {
 	return n.(Inst).DependsOn()[i]
+}
+
+type CmpError struct {
+	Err error
 }
 
 type Incubate struct {
@@ -81,7 +84,6 @@ type Mix struct {
 	Request    *lh.LHRequest
 	Properties liquidhandling.LHProperties
 	Files      Files
-	Err        error
 }
 
 func (a *Mix) Data() Files {
@@ -94,11 +96,6 @@ func (a *Mix) Device() Device {
 
 func (a *Mix) DependsOn() []Inst {
 	return a.Depends
-}
-
-// TODO -- this needs to return the real result
-func (a *Mix) Error() error {
-	return a.Err
 }
 
 func (a *Mix) SetDependsOn(x []Inst) {
@@ -131,10 +128,6 @@ func (a *Manual) Device() Device {
 	return a.Dev
 }
 
-func (a *Manual) Error() error {
-	return nil
-}
-
 func (a *Manual) SetDependsOn(x []Inst) {
 	a.Depends = x
 }
@@ -154,10 +147,6 @@ func (a *Wait) Device() Device {
 
 func (a *Wait) DependsOn() []Inst {
 	return a.Depends
-}
-
-func (a *Wait) Error() error {
-	return nil
 }
 
 func (a *Wait) SetDependsOn(x []Inst) {

--- a/target/inst.go
+++ b/target/inst.go
@@ -15,6 +15,7 @@ type Inst interface {
 	DependsOn() []Inst
 	SetDependsOn([]Inst)
 	GetTimeEstimate() float64
+	Error() error
 }
 
 type Files struct {
@@ -80,6 +81,7 @@ type Mix struct {
 	Request    *lh.LHRequest
 	Properties liquidhandling.LHProperties
 	Files      Files
+	Err        error
 }
 
 func (a *Mix) Data() Files {
@@ -92,6 +94,11 @@ func (a *Mix) Device() Device {
 
 func (a *Mix) DependsOn() []Inst {
 	return a.Depends
+}
+
+// TODO -- this needs to return the real result
+func (a *Mix) Error() error {
+	return a.Err
 }
 
 func (a *Mix) SetDependsOn(x []Inst) {
@@ -124,6 +131,10 @@ func (a *Manual) Device() Device {
 	return a.Dev
 }
 
+func (a *Manual) Error() error {
+	return nil
+}
+
 func (a *Manual) SetDependsOn(x []Inst) {
 	a.Depends = x
 }
@@ -143,6 +154,10 @@ func (a *Wait) Device() Device {
 
 func (a *Wait) DependsOn() []Inst {
 	return a.Depends
+}
+
+func (a *Wait) Error() error {
+	return nil
 }
 
 func (a *Wait) SetDependsOn(x []Inst) {

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -69,7 +69,13 @@ func (a *Mixer) makeLhreq() (*lhreq, error) {
 	}
 
 	req := planner.NewLHRequest()
-	req.Policies = driver.GetLHPolicyForTest()
+	pols, err := driver.GetLHPolicyForTest()
+
+	if err != nil {
+		return nil, err
+	}
+	req.Policies = pols
+
 	plan := planner.Init(&a.properties)
 
 	if p := a.opt.MaxPlates; p != nil {
@@ -137,7 +143,7 @@ func (a *Mixer) makeLhreq() (*lhreq, error) {
 		}
 	}
 
-	err := req.ConfigureYourself()
+	err = req.ConfigureYourself()
 	if err != nil {
 		return nil, err
 	}

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -241,12 +241,14 @@ func (a *Mixer) makeMix(mixes []*wtype.LHInstruction) (target.Inst, error) {
 	err = r.Liquidhandler.MakeSolutions(r.LHRequest)
 
 	if err != nil {
-		return &target.Mix{
-			Dev:        a,
-			Request:    r.LHRequest,
-			Properties: a.properties,
-			Err:        err,
-		}, nil
+		// depending on what went wrong we might error out or return
+		// an error instruction
+
+		if wtype.LHErrorIsInternal(err) {
+			return nil, err
+		} else {
+			return CmpErr{Err: err}, nil
+		}
 	}
 
 	tarball, err := a.saveFile("input")

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -241,7 +241,12 @@ func (a *Mixer) makeMix(mixes []*wtype.LHInstruction) (target.Inst, error) {
 	err = r.Liquidhandler.MakeSolutions(r.LHRequest)
 
 	if err != nil {
-		return nil, err
+		return &target.Mix{
+			Dev:        a,
+			Request:    r.LHRequest,
+			Properties: a.properties,
+			Err:        err,
+		}, nil
 	}
 
 	tarball, err := a.saveFile("input")

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -247,7 +247,7 @@ func (a *Mixer) makeMix(mixes []*wtype.LHInstruction) (target.Inst, error) {
 		if wtype.LHErrorIsInternal(err) {
 			return nil, err
 		} else {
-			return CmpErr{Err: err}, nil
+			return &target.CmpError{Err: err, Dev: a}, nil
 		}
 	}
 

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -232,7 +232,11 @@ func (a *Mixer) makeMix(mixes []*wtype.LHInstruction) (target.Inst, error) {
 		r.LHRequest.Add_instruction(mix)
 	}
 
-	r.Liquidhandler.MakeSolutions(r.LHRequest)
+	err := r.Liquidhandler.MakeSolutions(r.LHRequest)
+
+	if err != nil {
+		return nil, err
+	}
 
 	tarball, err := a.saveFile("input")
 	if err != nil {

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -232,7 +232,7 @@ func (a *Mixer) makeMix(mixes []*wtype.LHInstruction) (target.Inst, error) {
 		r.LHRequest.Add_instruction(mix)
 	}
 
-	err := r.Liquidhandler.MakeSolutions(r.LHRequest)
+	err = r.Liquidhandler.MakeSolutions(r.LHRequest)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Mostly additions to liquid handling planner code to ensure that errors are passed back to caller instead of creating calls to logger.Fatal

target/Inst now has Error() which returns any error it has received
the only bullet bitten is in the generator for MixInsts -- in order to pass them back to the front end, mix tasks which generate errors now return MixInsts which do not return nil when Error() is called... attempts to look at generated files without checking this is safe will therefore fail

