### PR TITLE
Preandpostmixliquidtypes

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/buffers/buffercomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/buffers/buffercomponents.go
@@ -1,4 +1,24 @@
-// buffercomponents.go
+// buffercomponents.go Part of the Antha language
+// Copyright (C) 2015 The Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
 
 // Package for dealing with manipulation of buffers
 package buffers

--- a/antha/AnthaStandardLibrary/Packages/buffers/enzymebuffers.go
+++ b/antha/AnthaStandardLibrary/Packages/buffers/enzymebuffers.go
@@ -1,9 +1,29 @@
-// enzymebuffers.go
+// enzymebuffers.go Part of the Antha language
+// Copyright (C) 2015 The Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
+
+// Package for dealing with manipulation of buffers
 package buffers
 
-import (
 //"fmt"
-)
 
 type pH struct {
 	pH        float64

--- a/antha/AnthaStandardLibrary/Packages/buffers/ph.go
+++ b/antha/AnthaStandardLibrary/Packages/buffers/ph.go
@@ -1,4 +1,24 @@
-// ph.go
+// ph.go Part of the Antha language
+// Copyright (C) 2015 The Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
 
 // Package for dealing with manipulation of buffers
 package buffers

--- a/antha/AnthaStandardLibrary/Packages/eng/fluiddynamics.go
+++ b/antha/AnthaStandardLibrary/Packages/eng/fluiddynamics.go
@@ -20,7 +20,7 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
-// Package containing formulae for the estimation of mixing properties
+// Package for performing engineering calculations; at present this consists of evaporation rate estimation, thawtime estimation and fluid dynamics
 package eng
 
 import (

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Assemblydesign.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Assemblydesign.go
@@ -20,7 +20,7 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
-// Package for working with enzymes; in particular restriction enzymes are particularly well characterised at present
+// Package for working with enzymes; in particular restriction enzymes
 package enzymes
 
 import (

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Digestion.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Digestion.go
@@ -20,16 +20,18 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
+// Package for working with enzymes; in particular restriction enzymes
 package enzymes
 
 import (
+	"sort"
+	"strconv"
+	"strings"
+
 	. "github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/search"
 	. "github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/sequences"
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/text"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 //should expand to be more general, i.e. 3prime overhangs

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
@@ -20,6 +20,7 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
+// Package for working with enzymes; in particular restriction enzymes
 package enzymes
 
 import (

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Polymerases.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Polymerases.go
@@ -20,6 +20,7 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
+// Package for working with enzymes; in particular restriction enzymes
 package enzymes
 
 import (

--- a/antha/AnthaStandardLibrary/Packages/igem/igem.go
+++ b/antha/AnthaStandardLibrary/Packages/igem/igem.go
@@ -19,6 +19,27 @@
 // contact license@antha-lang.org or write to the Antha team c/o
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
+//Part of the Antha language
+// Copyright (C) 2015 The Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
 
 // Package for interacting with the iGem registry
 package igem

--- a/antha/anthalib/wtype/LiquidType.go
+++ b/antha/anthalib/wtype/LiquidType.go
@@ -22,6 +22,8 @@ const (
 	LTDoNotMix
 	LTloadwater
 	LTNeedToMix
+	LTPreMix
+	LTPostMix
 	LTVISCOUS
 	LTPAINT
 	LTDISPENSEABOVE
@@ -67,6 +69,10 @@ func LiquidTypeFromString(s string) LiquidType {
 		return LTloadwater
 	case "NeedToMix":
 		return LTNeedToMix
+	case "PreMix":
+		return LTPreMix
+	case "PostMix":
+		return LTPostMix
 	case "viscous":
 		return LTVISCOUS
 	case "Paint":
@@ -122,6 +128,10 @@ func LiquidTypeName(lt LiquidType) string {
 		return "loadwater"
 	case LTNeedToMix:
 		return "NeedToMix"
+	case LTPreMix:
+		return "PreMix"
+	case LTPostMix:
+		return "PostMix"
 	case LTPAINT:
 		return "Paint"
 	case LTDISPENSEABOVE:

--- a/antha/anthalib/wtype/LiquidType.go
+++ b/antha/anthalib/wtype/LiquidType.go
@@ -1,6 +1,7 @@
 package wtype
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype/liquidtype"
@@ -35,65 +36,65 @@ const (
 	LTCOLONY
 )
 
-func LiquidTypeFromString(s string) LiquidType {
+func LiquidTypeFromString(s string) (LiquidType, error) {
 
 	match, number := liquidtype.LiquidTypeFromPolicyDOE(s)
 
 	if match {
-		return LiquidType(number)
+		return LiquidType(number), nil
 	}
 
 	switch s {
 	case "water":
 	case "":
-		return LTWater
+		return LTWater, nil
 	case "glycerol":
-		return LTGlycerol
+		return LTGlycerol, nil
 	case "ethanol":
-		return LTEthanol
+		return LTEthanol, nil
 	case "detergent":
-		return LTDetergent
+		return LTDetergent, nil
 	case "culture":
-		return LTCulture
+		return LTCulture, nil
 	case "culturereuse":
-		return LTCulutureReuse
+		return LTCulutureReuse, nil
 	case "protein":
-		return LTProtein
+		return LTProtein, nil
 	case "dna":
-		return LTDNA
+		return LTDNA, nil
 	case "load":
-		return LTload
+		return LTload, nil
 	case "DoNotMix":
-		return LTDoNotMix
+		return LTDoNotMix, nil
 	case "loadwater":
-		return LTloadwater
+		return LTloadwater, nil
 	case "NeedToMix":
-		return LTNeedToMix
+		return LTNeedToMix, nil
 	case "PreMix":
-		return LTPreMix
+		return LTPreMix, nil
 	case "PostMix":
-		return LTPostMix
+		return LTPostMix, nil
 	case "viscous":
-		return LTVISCOUS
+		return LTVISCOUS, nil
 	case "Paint":
-		return LTPAINT
+		return LTPAINT, nil
 	case "DispenseAboveLiquid":
-		return LTDISPENSEABOVE
+		return LTDISPENSEABOVE, nil
 	case "PEG":
-		return LTPEG
+		return LTPEG, nil
 	case "Protoplasts":
-		return LTProtoplasts
+		return LTProtoplasts, nil
 	case "dna_mix":
-		return LTDNAMIX
+		return LTDNAMIX, nil
 	case "plateout":
-		return LTPLATEOUT
+		return LTPLATEOUT, nil
 	case "colony":
-		return LTCOLONY
+		return LTCOLONY, nil
 	default:
-		return LTWater
+		return LTWater, nil
 	}
 
-	return LTWater
+	return LTWater, fmt.Errorf("no liquid policy found so using default water policy")
 }
 
 func LiquidTypeName(lt LiquidType) string {

--- a/antha/anthalib/wtype/wtype_test.go
+++ b/antha/anthalib/wtype/wtype_test.go
@@ -208,7 +208,7 @@ type testpair struct {
 	ltint    int
 }
 
-var lts []testpair = []testpair{testpair{ltstring: "170516CCFDesign_noTouchoff_noBlowout2", ltint: 102}, testpair{ltstring: "190516OnePolicy0", ltint: 3000}, testpair{ltstring: "dna_mix", ltint: LTDNAMIX}}
+var lts []testpair = []testpair{testpair{ltstring: "170516CCFDesign_noTouchoff_noBlowout2", ltint: 102}, testpair{ltstring: "190516OnePolicy0", ltint: 3000}, testpair{ltstring: "dna_mix", ltint: LTDNAMIX}, testpair{ltstring: "PreMix", ltint: LTPreMix}, testpair{ltstring: "InvalidEntry", ltint: LTWater}}
 
 func TestLiquidTypeFromString(t *testing.T) {
 

--- a/antha/anthalib/wtype/wtype_test.go
+++ b/antha/anthalib/wtype/wtype_test.go
@@ -206,19 +206,24 @@ func TestLHComponentSampleStuff(t *testing.T) {
 type testpair struct {
 	ltstring string
 	ltint    int
+	err      error
 }
 
-var lts []testpair = []testpair{testpair{ltstring: "170516CCFDesign_noTouchoff_noBlowout2", ltint: 102}, testpair{ltstring: "190516OnePolicy0", ltint: 3000}, testpair{ltstring: "dna_mix", ltint: LTDNAMIX}, testpair{ltstring: "PreMix", ltint: LTPreMix}, testpair{ltstring: "InvalidEntry", ltint: LTWater}}
+var lts []testpair = []testpair{testpair{ltstring: "170516CCFDesign_noTouchoff_noBlowout2", ltint: 102}, testpair{ltstring: "190516OnePolicy0", ltint: 3000}, testpair{ltstring: "dna_mix", ltint: LTDNAMIX}, testpair{ltstring: "PreMix", ltint: LTPreMix} /*testpair{ltstring: "InvalidEntry", ltint: LTWater, err: fmt.Errorf("!")}*/}
 
 func TestLiquidTypeFromString(t *testing.T) {
 
 	for _, lt := range lts {
 
-		ltnum := LiquidTypeFromString(lt.ltstring)
+		ltnum, err := LiquidTypeFromString(lt.ltstring)
 		if int(ltnum) != lt.ltint {
 			t.Error("running LiquidTypeFromString on ", lt.ltstring, "expected", lt.ltint, "got", ltnum)
 		}
-
+		if err != nil {
+			if err != lt.err {
+				t.Error("running LiquidTypeFromString on ", lt.ltstring, "expected err:", lt.err.Error(), "got", err.Error())
+			}
+		}
 	}
 }
 

--- a/antha/component/an/Liquid_handling/DNA_gel/DNA_gel.an
+++ b/antha/component/an/Liquid_handling/DNA_gel/DNA_gel.an
@@ -128,7 +128,7 @@ Steps {
 	DNAgelloadmix.CName = Samplenames[0]//[i] //originalname + strconv.Itoa(i)
 	
 	// replacing following line with temporary hard code whilst developing protocol:
-	DNAgelloadmix.Type = wtype.LiquidTypeFromString(Mixingpolicy)	
+	DNAgelloadmix.Type,_ = wtype.LiquidTypeFromString(Mixingpolicy)	
 	//DNAgelloadmix.Type = "loadwater"
 	
 	loadedsample := MixInto(

--- a/antha/component/an/Liquid_handling/PipetteImage/PipetteImage.an
+++ b/antha/component/an/Liquid_handling/PipetteImage/PipetteImage.an
@@ -122,7 +122,7 @@ Steps {
 		component := componentmap[colourtostringmap[colour]]
 
 		// make sure liquid class is appropriate for cell culture in case this is not set elsewhere
-		component.Type = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
+		component.Type,_ = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
 		
 		fmt.Println(image.Colourcomponentmap[colour])
 		
@@ -151,7 +151,7 @@ Steps {
 			counter = counter + 1
 			fmt.Println("wells not ",Notthiscolour,counter)
 	
-		component.Type = wtype.LiquidTypeFromString(UseLiquidClass)
+		component.Type,_ = wtype.LiquidTypeFromString(UseLiquidClass)
 		pixelSample := mixer.Sample(component, VolumePerWell)
 	
 		solution := MixTo(OutPlate.Type, locationkey, 1, pixelSample)

--- a/antha/component/an/Liquid_handling/PipetteImage/PipetteImage_Gray.an
+++ b/antha/component/an/Liquid_handling/PipetteImage/PipetteImage_Gray.an
@@ -126,7 +126,7 @@ Steps {
 		fmt.Println("skipping well:", skipped,locationkey)
 		}else{
 			whitevol := VolumeForFullcolour
-			Diluent.Type = wtype.LiquidTypeFromString(NonMixingClass)
+			Diluent.Type,_ = wtype.LiquidTypeFromString(NonMixingClass)
 			
 			waterSample := mixer.Sample(Diluent,whitevol)
 			solution = MixTo(OutPlate.Type, locationkey,1, waterSample)
@@ -173,9 +173,9 @@ Steps {
 		if DontMix {
 		Black.Type = wtype.LTDISPENSEABOVE
 		}else if gray.Y >= fullblackuint8 {
-		Black.Type = wtype.LiquidTypeFromString(NonMixingClass)
+		Black.Type,_ = wtype.LiquidTypeFromString(NonMixingClass)
 		}else{
-			Black.Type = wtype.LiquidTypeFromString(MixingLiquidClass)
+			Black.Type,_ = wtype.LiquidTypeFromString(MixingLiquidClass)
 		}
 		
 		//fmt.Println("blackvol2",blackvol.ToString())

--- a/antha/component/an/Liquid_handling/PipetteImage/PipetteLivingimage.an
+++ b/antha/component/an/Liquid_handling/PipetteImage/PipetteLivingimage.an
@@ -71,6 +71,7 @@ Steps {
 	
 	// make sub pallete if necessary
 	var chosencolourpalette color.Palette
+	var err error
 	
 	if Subset {
 		chosencolourpalette = image.MakeSubPallette(Palettename, Subsetnames)
@@ -127,7 +128,11 @@ Steps {
 		component := componentmap[colourtostringmap[colour]]
 
 		// make sure liquid class is appropriate for cell culture in case this is not set elsewhere
-		component.Type = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
+		component.Type, err = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
+		
+		if err != nil {
+			panic(err.Error())
+		}
 		
 		fmt.Println(image.Colourcomponentmap[colour])
 		
@@ -171,7 +176,12 @@ Steps {
 		inducerSample := mixer.Sample(Inducer, InducerVolume)
 		components = append(components,inducerSample)*/
 		
-		component.Type = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
+		component.Type,err = wtype.LiquidTypeFromString(UseLiquidClass)//wtype.LTCulture
+		
+		if err != nil {
+			panic(err.Error())
+		}
+		
 		pixelSample := mixer.Sample(component, VolumePerWell)
 		//components = append(components,pixelSample)
 		solution := MixTo(OutPlate.Type, locationkey, 1, pixelSample)

--- a/antha/component/an/Liquid_handling/TypeIIsAssembly/TypeIISConstructAssemblyMMX/TypeIISConstructAssemblyMMX.an
+++ b/antha/component/an/Liquid_handling/TypeIIsAssembly/TypeIISConstructAssemblyMMX/TypeIISConstructAssemblyMMX.an
@@ -56,7 +56,7 @@ Steps {
 	for k, part := range Parts {
 		fmt.Println("creating dna part num ", k, " comp ", part.CName, " renamed to ", PartNames[k], " vol ", PartVols[k])
 		
-		part.Type = wtype.LiquidTypeFromString(LHPolicyName)
+		part.Type,_ = wtype.LiquidTypeFromString(LHPolicyName)
 		
 		partSample := mixer.Sample(part, PartVols[k])
 		partSample.CName = PartNames[k]

--- a/antha/component/an/Liquid_handling/TypeIIsAssembly/TypeIISConstructAssemblyMMX_forscreen/TypeIISConstructAssemblyMMX.an
+++ b/antha/component/an/Liquid_handling/TypeIIsAssembly/TypeIISConstructAssemblyMMX_forscreen/TypeIISConstructAssemblyMMX.an
@@ -37,7 +37,9 @@ Outputs (
 )
 
 // Data which is returned from this protocol, and data types
-Data ()
+Data (
+	Errors []error
+)
 
 Requirements {}
 
@@ -47,6 +49,10 @@ Setup {}
 // The core process for this protocol, with the steps to be performed
 // for every input
 Steps {
+	
+	Errors = make([]error,0)
+	var err error
+	
 	samples := make([]*wtype.LHComponent, 0)
 	
 	waterSample:=mixer.SampleForTotalVolume(Water,ReactionVolume)
@@ -58,7 +64,11 @@ Steps {
 	for k, part := range Parts {
 		fmt.Println("creating dna part num ", k, " comp ", part.CName, " renamed to ", PartNames[k], " vol ", PartVols[k])
 		
-		part.Type = wtype.LiquidTypeFromString(LHPolicyName)
+		part.Type, err = wtype.LiquidTypeFromString(LHPolicyName)
+		
+		if err != nil {
+			Errors = append(Errors,err)
+		}
 		
 		partSample := mixer.Sample(part, PartVols[k])
 		partSample.CName = PartNames[k]

--- a/antha/component/an/Utility/AccuracyTest.an
+++ b/antha/component/an/Utility/AccuracyTest.an
@@ -9,9 +9,7 @@ import (
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/doe"
 	"fmt"
 	"strconv"
-
 )
-
 
 // Input parameters for this protocol (data)
 Parameters (
@@ -77,6 +75,8 @@ Steps {
 	counter := 0
 	var platenum = 1
 	var runs = make([]doe.Run,1)
+	var err error
+	Errors = make([]error,0)
 	// work out plate layout based on picture or just in order
 	
 	if Printasimage {
@@ -133,7 +133,10 @@ Steps {
 		
 		// change lhpolicy if desired
 		if UseLHPolicyDoeforDiluent {
-				Diluent.Type = wtype.LiquidTypeFromString(LHPolicy)
+				Diluent.Type, err = wtype.LiquidTypeFromString(LHPolicy)
+				if err != nil {
+				Errors = append(Errors,err)
+				}
 			}
 		
 		
@@ -151,7 +154,10 @@ Steps {
 		
 		// change liquid class
 		if UseLiquidPolicyForTestSolutions && LHPolicy != ""{
-		TestSols[k].Type = wtype.LiquidTypeFromString(LHPolicy)
+		TestSols[k].Type, err = wtype.LiquidTypeFromString(LHPolicy)
+		if err != nil {
+			Errors = append(Errors,err)
+		}
 		}
 		
 		if TestSolVolumes[l].RawValue() > 0.0 {

--- a/antha/component/an/Utility/AccuracyTest_2.an
+++ b/antha/component/an/Utility/AccuracyTest_2.an
@@ -106,7 +106,8 @@ Steps {
 	
 	// use first policy as reference to ensure consistent range through map values
 	referencepolicy,found := liquidhandling.GetPolicyByName(LHPolicy)
-	if  !found {
+	if found == false {
+		panic("policy "+LHPolicy+" not found")
 		Errors = append(Errors,fmt.Errorf("policy ",LHPolicy," not found"))
 	}
 	
@@ -244,6 +245,7 @@ Steps {
 	// print out LHPolicy info
 	policy, found := liquidhandling.GetPolicyByName(doerun)
 	if  !found {
+		panic("policy "+doerun+" not found")
 		Errors = append(Errors,fmt.Errorf("policy ",doerun," not found"))
 	}
 	

--- a/antha/component/an/Utility/AccuracyTest_2.an
+++ b/antha/component/an/Utility/AccuracyTest_2.an
@@ -78,6 +78,8 @@ Steps {
 	var platenum = 1
 	var runs = make([]doe.Run,1)
 	var newruns = make([]doe.Run,0)
+	var err error
+	Errors = make([]error,0)
 	// work out plate layout based on picture or just in order
 	
 	if Printasimage {
@@ -103,7 +105,10 @@ Steps {
 	reactions := make([]*wtype.LHComponent,0)
 	
 	// use first policy as reference to ensure consistent range through map values
-	referencepolicy, _ := liquidhandling.GetPolicyByName(LHPolicy)
+	referencepolicy,found := liquidhandling.GetPolicyByName(LHPolicy)
+	if  !found {
+		Errors = append(Errors,fmt.Errorf("policy ",LHPolicy," not found"))
+	}
 	
 	referencekeys := make([]string,0)
 	for key,_:= range referencepolicy {
@@ -135,7 +140,10 @@ Steps {
 		
 		// change lhpolicy if desired
 		if UseLHPolicyDoeforDiluent {
-				Diluent.Type = wtype.LiquidTypeFromString(LHPolicy)
+				Diluent.Type, err = wtype.LiquidTypeFromString(LHPolicy)
+				if err != nil {
+					Errors = append(Errors,err)
+				}
 			}
 		
 		
@@ -153,7 +161,10 @@ Steps {
 		
 		// change liquid class
 		if UseLiquidPolicyForTestSolutions && LHPolicy != ""{
-		TestSols[k].Type = wtype.LiquidTypeFromString(LHPolicy)
+		TestSols[k].Type,err = wtype.LiquidTypeFromString(LHPolicy)
+			if err != nil {
+					Errors = append(Errors,err)
+				}
 		}
 		
 		if TestSolVolumes[l].RawValue() > 0.0 {
@@ -174,6 +185,7 @@ Steps {
 		
 		// get annotation info
 		doerun :=  wtype.LiquidTypeName(TestSols[k].Type)
+		
 		
 		volume := TestSolVolumes[l].ToString() //strconv.Itoa(wutil.RoundInt(number))+"ul"
 		
@@ -230,7 +242,10 @@ Steps {
 	run = doe.AddAdditionalHeaderandValue(run,"Additional","LHPolicy", doerun)
 	
 	// print out LHPolicy info
-	policy, _ := liquidhandling.GetPolicyByName(doerun)
+	policy, found := liquidhandling.GetPolicyByName(doerun)
+	if  !found {
+		Errors = append(Errors,fmt.Errorf("policy ",doerun," not found"))
+	}
 	
 	for _,key := range referencekeys {
 		run = doe.AddAdditionalHeaderandValue(run,"Additional","LHPolicy"+"_"+key, policy[key])

--- a/antha/component/lib/AccuracyTest_.go
+++ b/antha/component/lib/AccuracyTest_.go
@@ -48,6 +48,8 @@ func _AccuracyTestSteps(_ctx context.Context, _input *AccuracyTestInput, _output
 	counter := 0
 	var platenum = 1
 	var runs = make([]doe.Run, 1)
+	var err error
+	_output.Errors = make([]error, 0)
 	// work out plate layout based on picture or just in order
 
 	if _input.Printasimage {
@@ -104,7 +106,10 @@ func _AccuracyTestSteps(_ctx context.Context, _input *AccuracyTestInput, _output
 
 					// change lhpolicy if desired
 					if _input.UseLHPolicyDoeforDiluent {
-						_input.Diluent.Type = wtype.LiquidTypeFromString(_input.LHPolicy)
+						_input.Diluent.Type, err = wtype.LiquidTypeFromString(_input.LHPolicy)
+						if err != nil {
+							_output.Errors = append(_output.Errors, err)
+						}
 					}
 
 					bufferSample := mixer.SampleForTotalVolume(_input.Diluent, _input.TotalVolume)
@@ -119,7 +124,10 @@ func _AccuracyTestSteps(_ctx context.Context, _input *AccuracyTestInput, _output
 
 					// change liquid class
 					if _input.UseLiquidPolicyForTestSolutions && _input.LHPolicy != "" {
-						_input.TestSols[k].Type = wtype.LiquidTypeFromString(_input.LHPolicy)
+						_input.TestSols[k].Type, err = wtype.LiquidTypeFromString(_input.LHPolicy)
+						if err != nil {
+							_output.Errors = append(_output.Errors, err)
+						}
 					}
 
 					if _input.TestSolVolumes[l].RawValue() > 0.0 {

--- a/antha/component/lib/AccuracyTest_2_.go
+++ b/antha/component/lib/AccuracyTest_2_.go
@@ -79,7 +79,8 @@ func _AccuracyTest_2Steps(_ctx context.Context, _input *AccuracyTest_2Input, _ou
 
 	// use first policy as reference to ensure consistent range through map values
 	referencepolicy, found := liquidhandling.GetPolicyByName(_input.LHPolicy)
-	if !found {
+	if found == false {
+		panic("policy " + _input.LHPolicy + " not found")
 		_output.Errors = append(_output.Errors, fmt.Errorf("policy ", _input.LHPolicy, " not found"))
 	}
 
@@ -211,6 +212,7 @@ func _AccuracyTest_2Steps(_ctx context.Context, _input *AccuracyTest_2Input, _ou
 					// print out LHPolicy info
 					policy, found := liquidhandling.GetPolicyByName(doerun)
 					if !found {
+						panic("policy " + doerun + " not found")
 						_output.Errors = append(_output.Errors, fmt.Errorf("policy ", doerun, " not found"))
 					}
 

--- a/antha/component/lib/DNA_gel_.go
+++ b/antha/component/lib/DNA_gel_.go
@@ -119,7 +119,7 @@ func _DNA_gelSteps(_ctx context.Context, _input *DNA_gelInput, _output *DNA_gelO
 		DNAgelloadmix.CName = _input.Samplenames[0] //[i] //originalname + strconv.Itoa(i)
 
 		// replacing following line with temporary hard code whilst developing protocol:
-		DNAgelloadmix.Type = wtype.LiquidTypeFromString(_input.Mixingpolicy)
+		DNAgelloadmix.Type, _ = wtype.LiquidTypeFromString(_input.Mixingpolicy)
 		//DNAgelloadmix.Type = "loadwater"
 
 		loadedsample := execute.MixInto(_ctx, _input.DNAgel,

--- a/antha/component/lib/PipetteImage_.go
+++ b/antha/component/lib/PipetteImage_.go
@@ -96,7 +96,7 @@ func _PipetteImageSteps(_ctx context.Context, _input *PipetteImageInput, _output
 		component := componentmap[colourtostringmap[colour]]
 
 		// make sure liquid class is appropriate for cell culture in case this is not set elsewhere
-		component.Type = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
+		component.Type, _ = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
 
 		fmt.Println(image.Colourcomponentmap[colour])
 
@@ -125,7 +125,7 @@ func _PipetteImageSteps(_ctx context.Context, _input *PipetteImageInput, _output
 				counter = counter + 1
 				fmt.Println("wells not ", _input.Notthiscolour, counter)
 
-				component.Type = wtype.LiquidTypeFromString(_input.UseLiquidClass)
+				component.Type, _ = wtype.LiquidTypeFromString(_input.UseLiquidClass)
 				pixelSample := mixer.Sample(component, _input.VolumePerWell)
 
 				solution := execute.MixTo(_ctx, _input.OutPlate.Type, locationkey, 1, pixelSample)

--- a/antha/component/lib/PipetteImage_Gray_.go
+++ b/antha/component/lib/PipetteImage_Gray_.go
@@ -97,7 +97,7 @@ func _PipetteImage_GraySteps(_ctx context.Context, _input *PipetteImage_GrayInpu
 				fmt.Println("skipping well:", skipped, locationkey)
 			} else {
 				whitevol := _input.VolumeForFullcolour
-				_input.Diluent.Type = wtype.LiquidTypeFromString(_input.NonMixingClass)
+				_input.Diluent.Type, _ = wtype.LiquidTypeFromString(_input.NonMixingClass)
 
 				waterSample := mixer.Sample(_input.Diluent, whitevol)
 				solution = execute.MixTo(_ctx, _input.OutPlate.Type, locationkey, 1, waterSample)
@@ -144,9 +144,9 @@ func _PipetteImage_GraySteps(_ctx context.Context, _input *PipetteImage_GrayInpu
 			if _input.DontMix {
 				_input.Black.Type = wtype.LTDISPENSEABOVE
 			} else if gray.Y >= fullblackuint8 {
-				_input.Black.Type = wtype.LiquidTypeFromString(_input.NonMixingClass)
+				_input.Black.Type, _ = wtype.LiquidTypeFromString(_input.NonMixingClass)
 			} else {
-				_input.Black.Type = wtype.LiquidTypeFromString(_input.MixingLiquidClass)
+				_input.Black.Type, _ = wtype.LiquidTypeFromString(_input.MixingLiquidClass)
 			}
 
 			//fmt.Println("blackvol2",blackvol.ToString())

--- a/antha/component/lib/PipetteImage_living_.go
+++ b/antha/component/lib/PipetteImage_living_.go
@@ -53,6 +53,7 @@ func _PipetteImage_livingSteps(_ctx context.Context, _input *PipetteImage_living
 
 	// make sub pallete if necessary
 	var chosencolourpalette color.Palette
+	var err error
 
 	if _input.Subset {
 		chosencolourpalette = image.MakeSubPallette(_input.Palettename, _input.Subsetnames)
@@ -108,7 +109,11 @@ func _PipetteImage_livingSteps(_ctx context.Context, _input *PipetteImage_living
 		component := componentmap[colourtostringmap[colour]]
 
 		// make sure liquid class is appropriate for cell culture in case this is not set elsewhere
-		component.Type = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
+		component.Type, err = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
+
+		if err != nil {
+			panic(err.Error())
+		}
 
 		fmt.Println(image.Colourcomponentmap[colour])
 
@@ -152,7 +157,12 @@ func _PipetteImage_livingSteps(_ctx context.Context, _input *PipetteImage_living
 				inducerSample := mixer.Sample(Inducer, InducerVolume)
 				components = append(components,inducerSample)*/
 
-				component.Type = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
+				component.Type, err = wtype.LiquidTypeFromString(_input.UseLiquidClass) //wtype.LTCulture
+
+				if err != nil {
+					panic(err.Error())
+				}
+
 				pixelSample := mixer.Sample(component, _input.VolumePerWell)
 				//components = append(components,pixelSample)
 				solution := execute.MixTo(_ctx, _input.OutPlate.Type, locationkey, 1, pixelSample)

--- a/antha/component/lib/TypeIISConstructAssemblyMMX_.go
+++ b/antha/component/lib/TypeIISConstructAssemblyMMX_.go
@@ -38,7 +38,7 @@ func _TypeIISConstructAssemblyMMXSteps(_ctx context.Context, _input *TypeIISCons
 	for k, part := range _input.Parts {
 		fmt.Println("creating dna part num ", k, " comp ", part.CName, " renamed to ", _input.PartNames[k], " vol ", _input.PartVols[k])
 
-		part.Type = wtype.LiquidTypeFromString(_input.LHPolicyName)
+		part.Type, _ = wtype.LiquidTypeFromString(_input.LHPolicyName)
 
 		partSample := mixer.Sample(part, _input.PartVols[k])
 		partSample.CName = _input.PartNames[k]

--- a/antha/component/lib/TypeIISConstructAssemblyMMX_forscreen_.go
+++ b/antha/component/lib/TypeIISConstructAssemblyMMX_forscreen_.go
@@ -27,6 +27,10 @@ func _TypeIISConstructAssemblyMMX_forscreenSetup(_ctx context.Context, _input *T
 // The core process for this protocol, with the steps to be performed
 // for every input
 func _TypeIISConstructAssemblyMMX_forscreenSteps(_ctx context.Context, _input *TypeIISConstructAssemblyMMX_forscreenInput, _output *TypeIISConstructAssemblyMMX_forscreenOutput) {
+
+	_output.Errors = make([]error, 0)
+	var err error
+
 	samples := make([]*wtype.LHComponent, 0)
 
 	waterSample := mixer.SampleForTotalVolume(_input.Water, _input.ReactionVolume)
@@ -38,7 +42,11 @@ func _TypeIISConstructAssemblyMMX_forscreenSteps(_ctx context.Context, _input *T
 	for k, part := range _input.Parts {
 		fmt.Println("creating dna part num ", k, " comp ", part.CName, " renamed to ", _input.PartNames[k], " vol ", _input.PartVols[k])
 
-		part.Type = wtype.LiquidTypeFromString(_input.LHPolicyName)
+		part.Type, err = wtype.LiquidTypeFromString(_input.LHPolicyName)
+
+		if err != nil {
+			_output.Errors = append(_output.Errors, err)
+		}
 
 		partSample := mixer.Sample(part, _input.PartVols[k])
 		partSample.CName = _input.PartNames[k]
@@ -133,11 +141,13 @@ type TypeIISConstructAssemblyMMX_forscreenInput struct {
 }
 
 type TypeIISConstructAssemblyMMX_forscreenOutput struct {
+	Errors   []error
 	Reaction *wtype.LHComponent
 }
 
 type TypeIISConstructAssemblyMMX_forscreenSOutput struct {
 	Data struct {
+		Errors []error
 	}
 	Outputs struct {
 		Reaction *wtype.LHComponent
@@ -167,6 +177,7 @@ func init() {
 				{Name: "ReactionTime", Desc: "", Kind: "Parameters"},
 				{Name: "ReactionVolume", Desc: "", Kind: "Parameters"},
 				{Name: "Water", Desc: "", Kind: "Inputs"},
+				{Name: "Errors", Desc: "", Kind: "Data"},
 				{Name: "Reaction", Desc: "", Kind: "Outputs"},
 			},
 		},

--- a/antha/component/lib/test.go
+++ b/antha/component/lib/test.go
@@ -1,1 +1,0 @@
-package lib

--- a/antha/examples/workflows/AccuracyTest/parameters.yml
+++ b/antha/examples/workflows/AccuracyTest/parameters.yml
@@ -5,16 +5,20 @@
             "TestSols": [
 			"tartrazine"
 			],
-            "NumberofReplicates": 3,
+            "NumberofReplicates": 5,
             "OutPlate": "greiner384_riser",
             "TestSolVolumes": [
 			"25ul",
+			"30ul",
+			"35ul",
+			"40ul",
+			"45ul",
 			"50ul"
 			],
 			"UseLiquidPolicyForTestSolutions": true,
-			"LHPolicy":"NeedToMix",
+			"LHPolicy":"PostMix",
 			"DXORJMP":"JMP",
-			"OutputFilename":"Accuracytest2output_test.xlsx",
+			"OutputFilename":"AccuracytestPostMixHVoutput_test.xlsx",
 			"Printasimage": true,
 			"Imagefilename": "star.png",
             "TotalVolume": "100ul",

--- a/microArch/driver/liquidhandling/makelhpolicy.go
+++ b/microArch/driver/liquidhandling/makelhpolicy.go
@@ -641,12 +641,12 @@ func MakeNeedToMixPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 15)
 	dnapolicy["POST_MIX"] = 3
 	dnapolicy["POST_MIX_VOLUME"] = 10
-	dnapolicy["POST_MIX_RATE"] = 3.9
+	dnapolicy["POST_MIX_RATE"] = 3.74
 	dnapolicy["PRE_MIX"] = 3
 	dnapolicy["PRE_MIX_VOLUME"] = 10
-	dnapolicy["PRE_MIX_RATE"] = 3.9
-	dnapolicy["ASPSPEED"] = 3.9
-	dnapolicy["DSPSPEED"] = 3.9
+	dnapolicy["PRE_MIX_RATE"] = 3.74
+	dnapolicy["ASPSPEED"] = 3.74
+	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = false
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -661,12 +661,12 @@ func PreMixPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 12)
 	//dnapolicy["POST_MIX"] = 3
 	//dnapolicy["POST_MIX_VOLUME"] = 10
-	//dnapolicy["POST_MIX_RATE"] = 3.9
+	//dnapolicy["POST_MIX_RATE"] = 3.74
 	dnapolicy["PRE_MIX"] = 3
 	dnapolicy["PRE_MIX_VOLUME"] = 10
-	dnapolicy["PRE_MIX_RATE"] = 3.9
-	dnapolicy["ASPSPEED"] = 3.9
-	dnapolicy["DSPSPEED"] = 3.9
+	dnapolicy["PRE_MIX_RATE"] = 3.74
+	dnapolicy["ASPSPEED"] = 3.74
+	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = false
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -682,12 +682,12 @@ func PostMixPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 12)
 	dnapolicy["POST_MIX"] = 3
 	dnapolicy["POST_MIX_VOLUME"] = 10
-	dnapolicy["POST_MIX_RATE"] = 3.9
+	dnapolicy["POST_MIX_RATE"] = 3.74
 	//dnapolicy["PRE_MIX"] = 3
 	//dnapolicy["PRE_MIX_VOLUME"] = 10
-	//dnapolicy["PRE_MIX_RATE"] = 3.9
-	dnapolicy["ASPSPEED"] = 3.9
-	dnapolicy["DSPSPEED"] = 3.9
+	//dnapolicy["PRE_MIX_RATE"] = 3.74
+	dnapolicy["ASPSPEED"] = 3.74
+	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = false
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -769,6 +769,15 @@ func MakeHVOffsetPolicy() LHPolicy {
 	return lvop
 }
 
+func MakeHVFlowRatePolicy() LHPolicy {
+	policy := make(LHPolicy, 4)
+	policy["POST_MIX_RATE"] = 37
+	policy["PRE_MIX_RATE"] = 37
+	policy["ASPSPEED"] = 37
+	policy["DSPSPEED"] = 37
+	return policy
+}
+
 func GetLHPolicyForTest() (*LHPolicyRuleSet, error) {
 
 	// make some policies
@@ -821,9 +830,16 @@ func GetLHPolicyForTest() (*LHPolicyRuleSet, error) {
 
 	// hack to fix plate type problems
 	rule := NewLHPolicyRule("HVOffsetFix")
-	rule.AddNumericConditionOn("VOLUME", 9.9, 300.0) // what about higher? // set specifically for openPlant configuration
+	rule.AddNumericConditionOn("VOLUME", 20.1, 300.0) // what about higher? // set specifically for openPlant configuration
 	//rule.AddCategoryConditionOn("FROMPLATETYPE", "pcrplate_skirted_riser")
 	pol := MakeHVOffsetPolicy()
+	lhpr.AddRule(rule, pol)
+
+	// hack to fix plate type problems
+	rule = NewLHPolicyRule("HVFlowRate")
+	rule.AddNumericConditionOn("VOLUME", 20.1, 300.0) // what about higher? // set specifically for openPlant configuration
+	//rule.AddCategoryConditionOn("FROMPLATETYPE", "pcrplate_skirted_riser")
+	pol = MakeHVFlowRatePolicy()
 	lhpr.AddRule(rule, pol)
 
 	/*rule = NewLHPolicyRule("LVOffsetFix2")

--- a/microArch/driver/liquidhandling/makelhpolicy.go
+++ b/microArch/driver/liquidhandling/makelhpolicy.go
@@ -91,6 +91,8 @@ func MakePolicies() map[string]LHPolicy {
 	pols["dna"] = MakeDNAPolicy()
 	pols["DoNotMix"] = MakeDefaultPolicy()
 	pols["NeedToMix"] = MakeNeedToMixPolicy()
+	pols["PreMix"] = PreMixPolicy()
+	pols["PostMix"] = PostMixPolicy()
 	pols["viscous"] = MakeViscousPolicy()
 	pols["Paint"] = MakePaintPolicy()
 
@@ -637,12 +639,53 @@ func MakeLoadlowPolicy() LHPolicy {
 
 func MakeNeedToMixPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 15)
-	dnapolicy["POST_MIX"] = 2
+	dnapolicy["POST_MIX"] = 3
 	dnapolicy["POST_MIX_VOLUME"] = 10
 	dnapolicy["POST_MIX_RATE"] = 3.9
-	//dnapolicy["PRE_MIX"] = 4
+	dnapolicy["PRE_MIX"] = 3
 	dnapolicy["PRE_MIX_VOLUME"] = 10
-	dnapolicy["PRE_MIX_RATE"] = 3.0
+	dnapolicy["PRE_MIX_RATE"] = 3.9
+	dnapolicy["ASPSPEED"] = 3.9
+	dnapolicy["DSPSPEED"] = 3.9
+	dnapolicy["CAN_MULTI"] = false
+	dnapolicy["CAN_MSA"] = false
+	dnapolicy["CAN_SDD"] = false
+	dnapolicy["DSPREFERENCE"] = 0
+	dnapolicy["DSPZOFFSET"] = 0.5
+	dnapolicy["TIP_REUSE_LIMIT"] = 0
+	dnapolicy["NO_AIR_DISPENSE"] = true
+	return dnapolicy
+}
+
+func PreMixPolicy() LHPolicy {
+	dnapolicy := make(LHPolicy, 12)
+	//dnapolicy["POST_MIX"] = 3
+	//dnapolicy["POST_MIX_VOLUME"] = 10
+	//dnapolicy["POST_MIX_RATE"] = 3.9
+	dnapolicy["PRE_MIX"] = 3
+	dnapolicy["PRE_MIX_VOLUME"] = 10
+	dnapolicy["PRE_MIX_RATE"] = 3.9
+	dnapolicy["ASPSPEED"] = 3.9
+	dnapolicy["DSPSPEED"] = 3.9
+	dnapolicy["CAN_MULTI"] = false
+	dnapolicy["CAN_MSA"] = false
+	dnapolicy["CAN_SDD"] = false
+	dnapolicy["DSPREFERENCE"] = 0
+	dnapolicy["DSPZOFFSET"] = 0.5
+	dnapolicy["TIP_REUSE_LIMIT"] = 0
+	dnapolicy["NO_AIR_DISPENSE"] = true
+	return dnapolicy
+
+}
+
+func PostMixPolicy() LHPolicy {
+	dnapolicy := make(LHPolicy, 12)
+	dnapolicy["POST_MIX"] = 3
+	dnapolicy["POST_MIX_VOLUME"] = 10
+	dnapolicy["POST_MIX_RATE"] = 3.9
+	//dnapolicy["PRE_MIX"] = 3
+	//dnapolicy["PRE_MIX_VOLUME"] = 10
+	//dnapolicy["PRE_MIX_RATE"] = 3.9
 	dnapolicy["ASPSPEED"] = 3.9
 	dnapolicy["DSPSPEED"] = 3.9
 	dnapolicy["CAN_MULTI"] = false

--- a/microArch/factory/make_tip_waste_library.go
+++ b/microArch/factory/make_tip_waste_library.go
@@ -29,6 +29,7 @@ func makeTipwastes() map[string]*wtype.LHTipwaste {
 
 	ret["Gilsontipwaste"] = makeGilsonTipWaste()
 	ret["CyBiotipwaste"] = makeCyBioTipwaste()
+	ret["Manualtipwaste"] = makeManualTipwaste()
 	return ret
 }
 
@@ -44,6 +45,14 @@ func makeCyBioTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("CyBiotipwaste", "", "A1", "ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
 	lht := wtype.NewLHTipwaste(700, "CyBiotipwaste", "cybio", 90.5, w, 85.5, 45.0, 0.0)
+	return lht
+}
+
+// TODO figure out tip capacity
+func makeManualTipwaste() *wtype.LHTipwaste {
+	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
+	w := wtype.NewLHWell("manualtipwaste", "", "A1", "ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
+	lht := wtype.NewLHTipwaste(1000000, "TipWasteBag", "ACMEBagsInc", 90.5, w, 85.5, 45.0, 0.0)
 	return lht
 }
 

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -161,14 +161,20 @@ func BasicSetupAgent(request *LHRequest, params *liquidhandling.LHProperties) (*
 		var waste *wtype.LHTipwaste
 		// this should be added to the automagic config setup... however it will require adding to the
 		// representation of the liquid handler
-		//TODO handle general case differently
 		if params.Model == "Pipetmax" {
 			waste = factory.GetTipwasteByType("Gilsontipwaste")
-		} else if params.Model == "GeneTheatre" {
+		} else if params.Model == "GeneTheatre" || params.Model == "Felix" {
 			waste = factory.GetTipwasteByType("CyBiotipwaste")
+		} else if params.Model == "Human" {
+			waste = factory.GetTipwasteByType("Manualtipwaste")
 		}
 
-		params.AddTipWaste(waste)
+		if waste != nil {
+			params.AddTipWaste(waste)
+		} else {
+			err := wtype.LHError(wtype.LH_ERR_OTHER, fmt.Sprint("No tip waste defined for model ", params.Model))
+			return nil, err
+		}
 	}
 	//request.Setup = setup
 	request.Plate_lookup = plate_lookup

--- a/target/mixer/extra.go
+++ b/target/mixer/extra.go
@@ -108,7 +108,7 @@ func parseInputPlateData(inData io.Reader) (*wtype.LHPlate, error) {
 
 		// component type
 
-		ctype := wtype.LiquidTypeFromString(rec[2])
+		ctype, _ := wtype.LiquidTypeFromString(rec[2])
 
 		if ctype == wtype.LTWater && !strings.Contains(rec[2], "water") {
 			// just warn, this is tolerable but possibly not desired


### PR DESCRIPTION
This Pull request: 

(i) adds two standard liquid classes: PreMix and PostMix.
(ii) adds an error output when converting string liquidclass to LiquidType using wtype.LiquidClassFromString("someliquidclass") to allow user to prevent incorrect liquidtypes silently passing through as default type
(iii) adds a rule for increasing flowrate when using high volumes (should be head!)
(iv) adds copyright headers to some packages 