### PR TITLE
Autoallocate mixes in place

### DIFF
--- a/antha/anthalib/wtype/lhcomponent.go
+++ b/antha/anthalib/wtype/lhcomponent.go
@@ -51,8 +51,16 @@ type LHComponent struct {
 	Visc               float64
 	StockConcentration float64
 	Extra              map[string]interface{}
-	Loc                string
+	Loc                string // refactor to PlateLocation
 	Destination        string
+}
+
+func (lhc *LHComponent) PlateLocation() PlateLocation {
+	return PlateLocationFromString(lhc.Loc)
+}
+
+func (lhc *LHComponent) CNID() string {
+	return fmt.Sprintf("CNID:%s:%s", lhc.CName, lhc.ID)
 }
 
 func (lhc *LHComponent) Generation() int {

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -665,6 +665,8 @@ func (p *LHPlate) IsUserAllocated() bool {
 	return false
 }
 
+// semantics are: put stuff from p2 into p unless
+// the well in p is declared as user allocated
 func (p *LHPlate) MergeWith(p2 *LHPlate) {
 	// do nothing if these are not same type
 

--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -210,6 +210,10 @@ func (w *LHWell) Remove(v wunit.Volume) *LHComponent {
 	return ret
 }
 
+func (w *LHWell) PlateLocation() PlateLocation {
+	return w.WContents.PlateLocation()
+}
+
 func (w *LHWell) WorkingVolume() wunit.Volume {
 	v := wunit.NewVolume(w.Currvol(), w.Vunit)
 	v2 := wunit.NewVolume(w.Rvol, w.Vunit)

--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -492,6 +492,12 @@ func (well *LHWell) IsTemporary() bool {
 			return false
 		}
 
+		// user allocated wells are never temporary
+
+		if well.IsUserAllocated() {
+			return false
+		}
+
 		t, ok := well.Extra["temporary"]
 
 		if !ok || !t.(bool) {
@@ -499,7 +505,7 @@ func (well *LHWell) IsTemporary() bool {
 		}
 		return true
 	} else {
-		logger.Debug("Warning: Attempt to access nil well in DeclareTemporary()")
+		logger.Debug("Warning: Attempt to access nil well in IsTemporary()")
 	}
 	return false
 }

--- a/antha/anthalib/wtype/platelocation.go
+++ b/antha/anthalib/wtype/platelocation.go
@@ -7,12 +7,20 @@ type PlateLocation struct {
 	Coords WellCoords
 }
 
+func ZeroPlateLocation() PlateLocation {
+	return PlateLocation{"", ZeroWellCoords()}
+}
+
+func (pc PlateLocation) IsZero() bool {
+	return pc.Equals(ZeroPlateLocation())
+}
+
 func (pc PlateLocation) ToString() string {
 	return pc.ID + ":" + pc.Coords.FormatA1()
 }
 
 func PlateLocationFromString(s string) PlateLocation {
-	pl := PlateLocation{}
+	pl := ZeroPlateLocation()
 	tx := strings.Split(s, ":")
 
 	if len(tx) != 2 {

--- a/antha/anthalib/wtype/platelocation.go
+++ b/antha/anthalib/wtype/platelocation.go
@@ -2,16 +2,29 @@ package wtype
 
 import "strings"
 
-type platelocation struct {
+type PlateLocation struct {
 	ID     string
 	Coords WellCoords
 }
 
-func (pc platelocation) ToString() string {
+func (pc PlateLocation) ToString() string {
 	return pc.ID + ":" + pc.Coords.FormatA1()
 }
 
-func PlateLocationFromString(s string) platelocation {
+func PlateLocationFromString(s string) PlateLocation {
+	pl := PlateLocation{}
 	tx := strings.Split(s, ":")
-	return platelocation{tx[0], MakeWellCoords(tx[1])}
+
+	if len(tx) != 2 {
+		return pl
+	}
+
+	return PlateLocation{tx[0], MakeWellCoords(tx[1])}
+}
+
+func (pc PlateLocation) Equals(opc PlateLocation) bool {
+	if !(pc.ID == opc.ID && pc.Coords.FormatA1() == opc.Coords.FormatA1()) {
+		return false
+	}
+	return true
 }

--- a/antha/anthalib/wtype/wtype_test.go
+++ b/antha/anthalib/wtype/wtype_test.go
@@ -378,3 +378,43 @@ func TestLHCPCanMove(t *testing.T) {
 		t.Fatal("Channel claims to be able to move excessive volume in one shot... it cannot")
 	}
 }
+
+func TestPlateLocation(t *testing.T) {
+	plstring := "PLATEX:A1"
+	pl1 := PlateLocationFromString(plstring)
+
+	if !(pl1.ToString() == plstring) {
+		t.Fatal("PlateLocation.ToString() must recreate input string if canonically formatted")
+	}
+
+	if !pl1.Equals(pl1) {
+		t.Fatal("Identity rule for equality violated")
+	}
+
+	pl2 := PlateLocationFromString(pl1.ToString())
+
+	if !pl2.Equals(pl1) {
+		t.Fatal("PlateLocation output format incorrect")
+	}
+
+	pl2 = PlateLocationFromString(plstring)
+
+	if !pl2.Equals(pl1) {
+		t.Fatal("PlateLocation creation from string inconsistent")
+	}
+
+	plstring2 := "PLATEY:A1"
+	pl3 := PlateLocationFromString(plstring2)
+
+	if pl3.Equals(pl2) {
+		t.Fatal("PlateLocations on different plates reported equal")
+	}
+
+	plstring3 := "PLATEX:A2"
+
+	pl3 = PlateLocationFromString(plstring3)
+
+	if pl3.Equals(pl2) {
+		t.Fatal("PlateLocations in different wells reported equal")
+	}
+}

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -864,6 +864,7 @@ func (p *LHProperties) RestoreUserPlates(up UserPlates) {
 		p.RemovePlateAtPosition(plate.Position)
 		// merge these
 		plate.Plate.MergeWith(oldPlate)
+
 		p.AddPlate(plate.Position, plate.Plate)
 	}
 }

--- a/microArch/scheduler/liquidhandling/autoallocate_test.go
+++ b/microArch/scheduler/liquidhandling/autoallocate_test.go
@@ -1,0 +1,114 @@
+package liquidhandling
+
+import (
+	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/mixer"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
+	"github.com/antha-lang/antha/microArch/factory"
+	"testing"
+)
+
+func TestInputSampleAutoAllocate(t *testing.T) {
+	rbt := makeGilson()
+	rq := NewLHRequest()
+
+	cmp1 := factory.GetComponentByType("water")
+	cmp2 := factory.GetComponentByType("dna_part")
+
+	s1 := mixer.Sample(cmp1, wunit.NewVolume(50.0, "ul"))
+	s2 := mixer.Sample(cmp2, wunit.NewVolume(25.0, "ul"))
+
+	mo := mixer.MixOptions{
+		Components: []*wtype.LHComponent{s1, s2},
+		PlateType:  "pcrplate_skirted_riser20",
+		Address:    "A1",
+		PlateNum:   1,
+	}
+
+	ins := mixer.GenericMix(mo)
+
+	rq.LHInstructions[ins.ID] = ins
+
+	pl := factory.GetPlateByType("pcrplate_skirted_riser20")
+
+	rq.Input_platetypes = append(rq.Input_platetypes, pl)
+
+	rq.ConfigureYourself()
+
+	lh := Init(rbt)
+
+	lh.Plan(rq)
+
+	expected := make(map[string]float64)
+
+	expected["dna_part"] = 30.5
+	expected["water"] = 55.5
+
+	testSetup(rbt, expected, t)
+}
+
+func testSetup(rbt *liquidhandling.LHProperties, expected map[string]float64, t *testing.T) {
+	for _, p := range rbt.Plates {
+		for _, w := range p.Wellcoords {
+			if !w.Empty() {
+				v, ok := expected[w.WContents.CName]
+
+				if !ok {
+					t.Fatal(fmt.Sprint("ERROR: unexpected component in plating area: ", w.WContents.CName))
+				}
+
+				if v != w.WContents.Vol {
+					t.Fatal(fmt.Sprint("ERROR: Volume of component ", w.WContents.CName, " was ", w.WContents.Vol, " should be ", v))
+				}
+
+				delete(expected, w.WContents.CName)
+			}
+		}
+	}
+
+	if len(expected) != 0 {
+		t.Fatal(fmt.Sprint("ERROR: Expected components remaining: ", expected))
+	}
+
+}
+func TestInPlaceAutoAllocate(t *testing.T) {
+	rbt := makeGilson()
+	rq := NewLHRequest()
+
+	cmp1 := factory.GetComponentByType("water")
+	cmp2 := factory.GetComponentByType("dna_part")
+
+	cmp1.Vol = 100.0
+	cmp2.Vol = 50.0
+
+	mo := mixer.MixOptions{
+		Components: []*wtype.LHComponent{cmp1, cmp2},
+		PlateType:  "pcrplate_skirted_riser20",
+		Address:    "A1",
+		PlateNum:   1,
+	}
+
+	ins := mixer.GenericMix(mo)
+
+	rq.LHInstructions[ins.ID] = ins
+
+	pl := factory.GetPlateByType("pcrplate_skirted_riser20")
+
+	rq.Input_platetypes = append(rq.Input_platetypes, pl)
+
+	rq.ConfigureYourself()
+
+	lh := Init(rbt)
+
+	lh.Plan(rq)
+
+	expected := make(map[string]float64)
+
+	expected["dna_part"] = 55.5
+	expected["water"] = 100.0
+
+	testSetup(rbt, expected, t)
+
+}

--- a/microArch/scheduler/liquidhandling/autoallocate_test.go
+++ b/microArch/scheduler/liquidhandling/autoallocate_test.go
@@ -1,13 +1,13 @@
 package liquidhandling
 
 import (
-	"fmt"
+	"testing"
+
 	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 	"github.com/antha-lang/antha/microArch/factory"
-	"testing"
 )
 
 func TestInputSampleAutoAllocate(t *testing.T) {
@@ -56,11 +56,11 @@ func testSetup(rbt *liquidhandling.LHProperties, expected map[string]float64, t 
 				v, ok := expected[w.WContents.CName]
 
 				if !ok {
-					t.Fatal(fmt.Sprint("ERROR: unexpected component in plating area: ", w.WContents.CName))
+					t.Errorf("ERROR: unexpected component in plating area: ", w.WContents.CName)
 				}
 
 				if v != w.WContents.Vol {
-					t.Fatal(fmt.Sprint("ERROR: Volume of component ", w.WContents.CName, " was ", w.WContents.Vol, " should be ", v))
+					t.Errorf("ERROR: Volume of component ", w.WContents.CName, " was ", w.WContents.Vol, " should be ", v)
 				}
 
 				delete(expected, w.WContents.CName)
@@ -69,7 +69,7 @@ func testSetup(rbt *liquidhandling.LHProperties, expected map[string]float64, t 
 	}
 
 	if len(expected) != 0 {
-		t.Fatal(fmt.Sprint("ERROR: Expected components remaining: ", expected))
+		t.Errorf("ERROR: Expected components remaining: ", expected)
 	}
 
 }

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -74,7 +74,6 @@ func (is InputSorter) Less(i, j int) bool {
 //		"input_assignments" -- map with arrays of assignment strings, i.e. {tea: [plate1:A:1, plate1:A:2...] }etc.
 func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 	// I think this might need moving too
-	//	logger.Debug("in input plate setup")
 	input_platetypes := (*request).Input_platetypes
 	if input_platetypes == nil || len(input_platetypes) == 0 {
 		// XXX this is dangerous... until input_plate_linear is replaced we will hit big problems here
@@ -100,7 +99,6 @@ func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 	var curr_plate *wtype.LHPlate
 
 	inputs := (*request).Input_solutions
-	//	input_order := (*request).Input_order
 
 	input_order := make([]string, len((*request).Input_order))
 	for i, v := range (*request).Input_order {
@@ -109,7 +107,7 @@ func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 
 	// this needs to be passed in via the request... must specify how much of inputs cannot
 	// be satisfied by what's already passed in
-	//	input_volumes := make(map[string]wunit.Volume, len(inputs))
+
 	input_volumes := request.Input_vols_wanting
 
 	// sort to make deterministic
@@ -124,8 +122,6 @@ func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 	weights_constraints := request.Input_setup_weights
 
 	// get the assignment
-
-	//well_count_assignments := choose_plate_assignments(input_volumes, input_platetypes, weights_constraints)
 
 	var well_count_assignments map[string]map[*wtype.LHPlate]int
 
@@ -146,10 +142,7 @@ func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 			continue
 		}
 
-		// inputs[cname][0] -- this is the first little spritz required
-		// should probably refactor this to aggregate first
 		component := inputs[cname][0]
-		//logger.Debug(fmt.Sprintln("Plate_setup - component", cname, ":"))
 
 		well_assignments, ok := well_count_assignments[cname]
 
@@ -163,7 +156,7 @@ func input_plate_setup(request *LHRequest) (*LHRequest, error) {
 		ass := make([]string, 0, 3)
 
 		// best hack so far: add an extra well of everything
-		// except we should do this at the end
+		// in case we run out
 		for platetype, nwells := range well_assignments {
 			for i := 0; i < nwells+1; i++ {
 				curr_plate = plates_in_play[platetype.Type]

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -313,6 +313,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 		} else if v.IsMixInPlace() {
 			// the first component sets the destination
 			// and now it should indeed be set
+
 			addr, ok := st.GetLocationOf(v.Components[0].ID)
 
 			if !ok {

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -82,12 +82,16 @@ func (req *LHRequest) ConfigureYourself() error {
 	// i.e. anything used in a mix-in-place; these don't add to the general
 	// store of anonymous components to be sampled from
 
-	uniques := make(map[wtype.PlateLocation]string, len(req.LHInstructions))
+	uniques := make(map[wtype.PlateLocation]*wtype.LHComponent, len(req.LHInstructions))
 
 	for _, ins := range req.LHInstructions {
+		// If provenance info is brought in here this becomes unsafe
 		if ins.IsMixInPlace() && !ins.HasAnyParent() {
-			// first component is special
-			uniques[ins.Components[0].PlateLocation().ToString()] = ins.Components[0].CNID()
+			if !ins.Components[0].PlateLocation().IsZero() {
+				uniques[ins.Components[0].PlateLocation()] = ins.Components[0]
+			} else {
+				// this will be autoallocated
+			}
 		}
 	}
 
@@ -99,15 +103,25 @@ func (req *LHRequest) ConfigureYourself() error {
 
 			// special case for components treated literally
 
-			cnid, ok := uniques[w.PlateLocation()]
+			cmp, ok := uniques[w.PlateLocation()]
 
-			c := w.Contents().Dup()
-			vvvvvv := c.Volume()
-			vvvvvv.Subtract(w.ResidualVolume())
-			c.SetVolume(vvvvvv)
-			ar := inputs[c.CName]
-			ar = append(ar, c)
-			inputs[c.CName] = ar
+			if ok {
+				// unique components (where instances matter) are
+				// identified using CNID()
+				ar := inputs[cmp.CNID()]
+				ar = append(ar, cmp)
+				inputs[cmp.CNID()] = ar
+			} else {
+				// bulk components (where instances don't matter) are
+				// identified using just CName
+				c := w.Contents().Dup()
+				vvvvvv := c.Volume()
+				vvvvvv.Subtract(w.ResidualVolume())
+				c.SetVolume(vvvvvv)
+				ar := inputs[c.CName]
+				ar = append(ar, c)
+				inputs[c.CName] = ar
+			}
 		}
 	}
 

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -510,11 +510,19 @@ func (this *Liquidhandler) GetInputs(request *LHRequest) (*LHRequest, error) {
 	for _, instruction := range instructions {
 		components := instruction.Components
 
-		for _, component := range components {
+		for ix, component := range components {
 			// ignore anything which is made in another mix
 
 			if component.HasAnyParent() {
 				continue
+			}
+
+			// what if this is a mix in place?
+			if ix == 0 && !component.IsSample() {
+				// these components come in as instances -- hence 1 per well
+				inputs[component.CNID()] = make([]*wtype.LHComponent, 0, 3)
+				allinputs = append(allinputs, component.CNID())
+				vmap[component.CNID()] = component.Volume()
 			}
 
 			cmps, ok := inputs[component.CName]


### PR DESCRIPTION
This PR extends autoallocation to anonymous components coming in outside plates.

This may create confusion in some cases but hopefully will be clearer on aggregate.

Limitation: if the component is too big to fit into a single autoallocated well the system will refuse, throw an error, and go sulk in the corner

this may be confusing in some cases since it will work or not depending on what other autoallocated components are in the mix. Hence YMMV.

Please test and see how it goes. 