### PR TITLE
New plate/idt plate

### DIFF
--- a/microArch/factory/make_plate_library.go
+++ b/microArch/factory/make_plate_library.go
@@ -230,8 +230,14 @@ func makePlateLibrary() map[string]*wtype.LHPlate {
 
 	// deep square well 96
 	swshp := wtype.NewShape("box", "mm", 8.2, 8.2, 41.3)
-	deepsquarewell := wtype.NewLHWell("DSW96", "", "", "ul", 1000, 200, swshp, wtype.LHWBV, 8.2, 8.2, 41.3, 4.7, "mm")
+	deepsquarewell := wtype.NewLHWell("DSW96", "", "", "ul", 1000, 200, swshp, wtype.LHWBFLAT, 8.2, 8.2, 41.3, 4.7, "mm")
 	plate := wtype.NewLHPlate("DSW96", "Unknown", 8, 12, 44.1, "mm", deepsquarewell, 9, 9, 0.0, 0.0, valueformaxheadtonotintoDSWplatewithp20tips)
+	plates[plate.Type] = plate
+
+	// IDT/ABgene 1.2 ml storage plate AB0564
+	idtshp := wtype.NewShape("cylinder", "mm", 7, 7, 39.35)
+	idtroundwell96 := wtype.NewLHWell("IDT96", "", "", "ul", 1200, 200, idtshp, wtype.LHWBU, 7, 7, 39.35, 3, "mm")
+	plate = wtype.NewLHPlate("IDT96", "Unknown", 8, 12, 42.5, "mm", idtroundwell96, 9, 9, 0, 0, 3)
 	plates[plate.Type] = plate
 
 	// 24 well deep square well plate on riser

--- a/microArch/factory/make_plate_library.go
+++ b/microArch/factory/make_plate_library.go
@@ -230,7 +230,7 @@ func makePlateLibrary() map[string]*wtype.LHPlate {
 
 	// deep square well 96
 	swshp := wtype.NewShape("box", "mm", 8.2, 8.2, 41.3)
-	deepsquarewell := wtype.NewLHWell("DSW96", "", "", "ul", 1000, 200, swshp, wtype.LHWBFLAT, 8.2, 8.2, 41.3, 4.7, "mm")
+	deepsquarewell := wtype.NewLHWell("DSW96", "", "", "ul", 1000, 200, swshp, wtype.LHWBV, 8.2, 8.2, 41.3, 4.7, "mm")
 	plate := wtype.NewLHPlate("DSW96", "Unknown", 8, 12, 44.1, "mm", deepsquarewell, 9, 9, 0.0, 0.0, valueformaxheadtonotintoDSWplatewithp20tips)
 	plates[plate.Type] = plate
 


### PR DESCRIPTION
Ran plate tests on the new IDT plate:

Residual volume was set at 200ul, which allows efficient aspirating/dispensing after testing. Tips unable to go to bottom of well due to tip head collision, hence high residual volume set. Likely with multichannel use, when implemented, tip head can go much lower

-High volume aspirating and dispensing tested OK

-Low volume aspirating and dispensing tested OK




