### PR TITLE
fix doe-return-error-if-incorrect-fileformat

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/doe/doe.go
+++ b/antha/AnthaStandardLibrary/Packages/doe/doe.go
@@ -1680,7 +1680,7 @@ func XLSXFileFromRuns(runs []Run, outputfilename string, dxorjmp string) (xlsxfi
 	} else if dxorjmp == "JMP" {
 		xlsxfile = JMPXLSXFilefromRuns(runs, outputfilename)
 	} else {
-		panic("Unknown design file format when exporting design to XLSX file. Please specify File type as JMP or DX (Design Expert)")
+		panic(fmt.Sprintf("Unknown design file format %s when exporting design to XLSX file. Please specify File type as JMP or DX (Design Expert)", dxorjmp))
 	}
 	return
 }

--- a/antha/AnthaStandardLibrary/Packages/doe/doe.go
+++ b/antha/AnthaStandardLibrary/Packages/doe/doe.go
@@ -1677,8 +1677,7 @@ func JMPXLSXFilefromRuns(runs []Run, outputfilename string) (xlsxfile *xlsx.File
 func XLSXFileFromRuns(runs []Run, outputfilename string, dxorjmp string) (xlsxfile *xlsx.File) {
 	if dxorjmp == "DX" {
 		xlsxfile = DXXLSXFilefromRuns(runs, outputfilename)
-	}
-	if dxorjmp == "JMP" {
+	} else if dxorjmp == "JMP" {
 		xlsxfile = JMPXLSXFilefromRuns(runs, outputfilename)
 	} else {
 		panic("Unknown design file format when exporting design to XLSX file. Please specify File type as JMP or DX (Design Expert)")


### PR DESCRIPTION
Previous fix resulted in panic if the file was specified as DX