### PR TITLE
Moved execution planning version to default options in mixer

### DIFF
--- a/cmd/antharun/cmd/run.go
+++ b/cmd/antharun/cmd/run.go
@@ -83,7 +83,7 @@ func makeMixerOpt() (mixer.Opt, error) {
 
 	opt.OutputSort = viper.GetBool("outputSort")
 
-	executionPlannerVersion := "ep2"
+	executionPlannerVersion := ""
 	if viper.GetBool("WithMulti") {
 		executionPlannerVersion = "ep3"
 	}

--- a/target/mixer/opt.go
+++ b/target/mixer/opt.go
@@ -17,6 +17,7 @@ var (
 		OutputPlateType:      []string{"pcrplate_skirted_riser20"},
 		InputPlates:          []*wtype.LHPlate{},
 		OutputPlates:         []*wtype.LHPlate{},
+		PlanningVersion:      "ep2",
 	}
 )
 
@@ -55,6 +56,7 @@ func (a Opt) Merge(x *Opt) Opt {
 	if x == nil {
 		return a
 	}
+
 	obj, err := meta.ShallowMerge(a, *x)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Previously was getting squashed by version coming from makeMixerOpt
