### PR TITLE
Feature/warning

### DIFF
--- a/antha/anthalib/wtype/warning.go
+++ b/antha/anthalib/wtype/warning.go
@@ -28,3 +28,8 @@ type Warning string
 func (w Warning) Error() string {
 	return string(w)
 }
+
+// generate a new Warning
+func NewWarning(s string) Warning {
+	return Warning(s)
+}

--- a/antha/anthalib/wtype/warning.go
+++ b/antha/anthalib/wtype/warning.go
@@ -1,0 +1,30 @@
+// wtype/warning.go: Part of the Antha language
+// Copyright (C) 2014 the Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
+
+package wtype
+
+// Representation of a non fatal error in Antha which implements the golang error interface.
+type Warning string
+
+func (w Warning) Error() string {
+	return string(w)
+}

--- a/antha/compile/antha.go
+++ b/antha/compile/antha.go
@@ -134,6 +134,7 @@ func (p *compiler) anthaInit() {
 		"Velocity":             "wunit.Velocity",
 		"Voltage":              "wunit.Voltage",
 		"Volume":               "wunit.Volume",
+		"Warning":              "wtype.Warning",
 		"Well":                 "wtype.LHWell",
 	}
 	p.imports = map[string]string{


### PR DESCRIPTION
New Warning type intended to report non-fatal errors in Antha protocols. 

This is intended to allow the UI to recognise the warning as an output and emphasise the display of the warning so it is prominent to the user.