### PR TITLE
Ensure waste is included in our output plate state

### DIFF
--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -1004,10 +1004,11 @@ func (lhp *LHProperties) RemoveComponent(plateID string, well string, volume wun
 	return true
 }
 
-// RemoveIntermediaryComponents removes any and all components that represent any stage of the liquid handling
-// execution that do not represent a input or output phase. In direct translation to component states that
+// RemoveUnusedAutoallocatedComponents removes any autoallocated component wells
+// that didn't end up getting used
+// In direct translation to component states that
 // means any components that are temporary _and_ autoallocated.
-func (lhp *LHProperties) RemoveIntermediaryComponents() {
+func (lhp *LHProperties) RemoveUnusedAutoallocatedComponents() {
 	ids := make([]string, 0, 1)
 	for _, p := range lhp.Plates {
 		if p.IsTemporary() && p.IsAutoallocated() {

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -1004,19 +1004,19 @@ func (lhp *LHProperties) RemoveComponent(plateID string, well string, volume wun
 	return true
 }
 
-func (lhp *LHProperties) RemoveTemporaryComponents() {
+// RemoveIntermediaryComponents removes any and all components that represent any stage of the liquid handling
+// execution that do not represent a input or output phase. In direct translation to component states that
+// means any components that are temporary _and_ autoallocated.
+func (lhp *LHProperties) RemoveIntermediaryComponents() {
 	ids := make([]string, 0, 1)
 	for _, p := range lhp.Plates {
-		// if the whole plate is temporary we can just delete the whole thing
-		if p.IsTemporary() {
+		if p.IsTemporary() && p.IsAutoallocated() {
 			ids = append(ids, p.ID)
 			continue
 		}
 
-		// now remove any components in wells still marked temporary
-
 		for _, w := range p.Wellcoords {
-			if w.IsTemporary() {
+			if w.IsTemporary() && w.IsAutoallocated() {
 				w.Clear()
 			}
 		}

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -66,7 +66,7 @@ func (it *IChain) Print() {
 				for i := 0; i < len(it.Values[j].Components); i++ {
 					fmt.Print(" ", it.Values[j].Components[i].CName, " (", it.Values[j].Components[i].ID, ") ")
 				}
-				fmt.Print(":", it.Values[j].Result.ID)
+				fmt.Print(":", it.Values[j].Result.ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
 				fmt.Printf("-- ")
 			} else if it.Values[j].Type == wtype.LHIPRM {
 				fmt.Print("PROMPT ", it.Values[j].Message, "-- ")

--- a/microArch/scheduler/liquidhandling/input_output_state_test.go
+++ b/microArch/scheduler/liquidhandling/input_output_state_test.go
@@ -1,0 +1,184 @@
+package liquidhandling
+
+import (
+	"context"
+	"github.com/antha-lang/antha/antha/anthalib/mixer"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/testinventory"
+	"reflect"
+	"testing"
+)
+
+type initFinalCmp struct {
+	CNameI string
+	CNameF string
+	VolI   float64
+	VolF   float64
+}
+
+func (ifc initFinalCmp) IsZero() bool {
+	v := initFinalCmp{}
+	return reflect.DeepEqual(v, ifc)
+}
+
+func TestStateBeforeAfter(t *testing.T) {
+	ctx := testinventory.NewContext(context.Background())
+	rq := makeRequest()
+	lh := makeLiquidhandler(ctx)
+	cmp1, err := inventory.NewComponent(ctx, inventory.WaterType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmp2, err := inventory.NewComponent(ctx, "dna_part")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1 := mixer.Sample(cmp1, wunit.NewVolume(50.0, "ul"))
+	s2 := mixer.Sample(cmp2, wunit.NewVolume(25.0, "ul"))
+
+	mo := mixer.MixOptions{
+		Components: []*wtype.LHComponent{s1, s2},
+		PlateType:  "pcrplate_skirted_riser20",
+		Address:    "A1",
+		PlateNum:   1,
+	}
+
+	ins := mixer.GenericMix(mo)
+
+	rq.LHInstructions[ins.ID] = ins
+
+	pl, err := inventory.NewPlate(ctx, "pcrplate_skirted_riser20")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rq.Input_platetypes = append(rq.Input_platetypes, pl)
+
+	rq.ConfigureYourself()
+
+	lh.Plan(ctx, rq)
+
+	/*
+		expectedInitial := make(map[string]float64)
+		expectedInitial["dna_part"] = 30.5
+		expectedInitial["water"] = 55.5
+
+		expectedFinal := make(map[string]float64)
+		expectedFinal["water+dna_part"] = 75.0
+		expectedFinal["water"] = 5.0
+		expectedFinal["dna_part"] = 5.0
+	*/
+
+	expected := make(map[string][]initFinalCmp)
+
+	expected["dna_part"] = []initFinalCmp{initFinalCmp{CNameI: "dna_part", CNameF: "dna_part", VolI: 30.5, VolF: 5.0}}
+	expected["water"] = []initFinalCmp{initFinalCmp{CNameI: "water", CNameF: "water", VolI: 55.5, VolF: 5.0}}
+
+	expected["water+dna_part"] = []initFinalCmp{initFinalCmp{CNameI: "", CNameF: "water+dna_part", VolI: 0.0, VolF: 75.0}}
+
+	compareInitFinalStates(t, lh, expected)
+}
+
+// all means just one or the whole lot
+func del(a initFinalCmp, ar []initFinalCmp, all bool) []initFinalCmp {
+	ar2 := make([]initFinalCmp, 0, len(ar)-1)
+	d := false
+	for _, b := range ar {
+		if !reflect.DeepEqual(a, b) || (d && !all) {
+			ar2 = append(ar2, b)
+			d = true
+		}
+	}
+
+	return ar2
+}
+
+/*
+
+type initFinalCmp struct {
+	CNameI string
+	CNameF string
+	VolI   float64
+	VolF   float64
+}
+
+*/
+func findWells(wi, wf *wtype.LHWell, ar []initFinalCmp) initFinalCmp {
+	ifc := initFinalCmp{CNameI: wi.WContents.CName, CNameF: wf.WContents.CName, VolI: wi.WContents.Vol, VolF: wf.WContents.Vol}
+
+	return findIFC(ifc, ar)
+}
+
+func findIFC(ifc initFinalCmp, ar []initFinalCmp) initFinalCmp {
+	r := initFinalCmp{}
+
+	for _, ifc2 := range ar {
+		if reflect.DeepEqual(ifc, ifc2) {
+			r = ifc2
+			break
+		}
+	}
+
+	return r
+}
+
+func compareInitFinalStates(t *testing.T, lh *Liquidhandler, expected map[string][]initFinalCmp) {
+	xor := func(a, b bool) bool {
+		return (a && !b) || (b && !a)
+	}
+	for _, pos := range lh.Properties.InputSearchPreferences() {
+		p, ok := lh.Properties.Plates[pos]
+		p2, ok2 := lh.FinalProperties.Plates[pos]
+
+		if xor(ok, ok2) {
+			t.Errorf("Plates moving in simple liquid handling plan")
+		}
+
+		if ok {
+			// find each component and make sure it has stayed in the same place
+			for _, crd := range p.AllWellPositions(false) {
+				w := p.Wellcoords[crd]
+				w2 := p2.Wellcoords[crd]
+
+				v, ok3 := expected[w2.WContents.CName]
+
+				if ok3 {
+					ifc := findWells(w, w2, v)
+
+					if ifc.IsZero() {
+						t.Errorf("Extraneous components in before / after: %s %f %s %f", w.WContents.CName, w.WContents.Vol, w2.WContents.CName, w2.WContents.Vol)
+					}
+
+					// good, delete this now
+
+					expected[w2.WContents.CName] = del(ifc, v, false)
+				}
+			}
+		}
+	}
+
+	// is anything left in the expected pile?
+
+	for k, v := range expected {
+		if len(v) != 0 {
+			t.Errorf("Unmatched components of type %s : %d total", k, len(v))
+			for _, vv := range v {
+				t.Errorf("%+v", vv)
+			}
+		}
+	}
+}
+
+func makeLiquidhandler(ctx context.Context) *Liquidhandler {
+	rbt := makeGilson(ctx)
+	lh := Init(rbt)
+	return lh
+}
+
+func makeRequest() *LHRequest {
+	rq := NewLHRequest()
+	return rq
+}

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -324,8 +324,8 @@ func (this *Liquidhandler) revise_volumes(rq *LHRequest) error {
 
 	// finally get rid of any temporary stuff
 
-	this.Properties.RemoveIntermediaryComponents()
-	this.FinalProperties.RemoveIntermediaryComponents()
+	this.Properties.RemoveUnusedAutoallocatedComponents()
+	this.FinalProperties.RemoveUnusedAutoallocatedComponents()
 
 	pidm := make(map[string]string, len(this.Properties.Plates))
 	for pos, _ := range this.Properties.Plates {

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -324,8 +324,8 @@ func (this *Liquidhandler) revise_volumes(rq *LHRequest) error {
 
 	// finally get rid of any temporary stuff
 
-	this.Properties.RemoveTemporaryComponents()
-	this.FinalProperties.RemoveTemporaryComponents()
+	this.Properties.RemoveIntermediaryComponents()
+	this.FinalProperties.RemoveIntermediaryComponents()
 
 	pidm := make(map[string]string, len(this.Properties.Plates))
 	for pos, _ := range this.Properties.Plates {


### PR DESCRIPTION
Volume calculations for our 'output plates' should not have 'temporary'
items removed, but rather remove any intermediary wells that would have
been used but aren't relevant to the input or output plates.

If I've followed the code correctly when a component is both temporary and auto-allocated it should represent a non-final well state.