### PR TITLE
allow specification of output filename

### DIFF
--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -301,10 +301,14 @@ func (a *Mixer) makeMix(ctx context.Context, mixes []*wtype.LHInstruction) (targ
 		return nil, err
 	}
 
-	// TODO: Desired filename not exposed in current driver interface, so pick
-	// a name. So far, at least Gilson software cares what the filename is, so
-	// use .sqlite for compatibility
-	name := strings.Replace(fmt.Sprintf("%s.sqlite", time.Now().Format(time.RFC3339)), ":", "_", -1)
+	name := a.opt.DriverOutputFileName
+	if len(name) == 0 {
+		// TODO: Desired filename not exposed in current driver interface, so pick
+		// a name. So far, at least Gilson software cares what the filename is, so
+		// use .sqlite for compatibility
+		name = strings.Replace(fmt.Sprintf("%s.sqlite", time.Now().Format(time.RFC3339)), ":", "_", -1)
+	}
+
 	tarball, err := a.saveFile(name)
 	if err != nil {
 		return nil, err

--- a/target/mixer/opt.go
+++ b/target/mixer/opt.go
@@ -38,6 +38,9 @@ type Opt struct {
 	// Direct specification of Output plates
 	OutputPlates []*wtype.LHPlate
 
+	// Specify file name in the instruction stream of any driver generated file
+	DriverOutputFileName string
+
 	// Driver specific options. Semantics are not stable. Will need to be
 	// revised when multi device execution is supported.
 	DriverSpecificInputPreferences    []string
@@ -45,11 +48,12 @@ type Opt struct {
 	DriverSpecificTipPreferences      []string // Driver specific position names (e.g., position_1 or A2)
 	DriverSpecificTipWastePreferences []string
 	DriverSpecificWashPreferences     []string
-	ModelEvaporation                  bool
-	OutputSort                        bool
-	PrintInstructions                 bool
-	UseDriverTipTracking              bool
-	LegacyVolume                      bool // don't track volumes for intermediates
+
+	ModelEvaporation     bool
+	OutputSort           bool
+	PrintInstructions    bool
+	UseDriverTipTracking bool
+	LegacyVolume         bool // don't track volumes for intermediates
 }
 
 // Merge two configs together and return the result. Values in the argument


### PR DESCRIPTION
Required to allow cleanup of sqlite filenames in trilution.