### PR TITLE
anthaFmt minor improvement

### DIFF
--- a/cmd/anthafmt/format.go
+++ b/cmd/anthafmt/format.go
@@ -52,6 +52,13 @@ type walker struct {
 const chmodSupported = runtime.GOOS != "windows"
 
 func (w *walker) Walk(path string, fi os.FileInfo, err error) error {
+	if err := w.walk(path, fi, err); err != nil {
+		return fmt.Errorf("%s: %s",path, err)
+	}
+	return nil
+}
+
+func (w *walker) walk(path string, fi os.FileInfo, err error) error {
 	if err != nil {
 		return err
 	}

--- a/cmd/anthafmt/format.go
+++ b/cmd/anthafmt/format.go
@@ -53,7 +53,7 @@ const chmodSupported = runtime.GOOS != "windows"
 
 func (w *walker) Walk(path string, fi os.FileInfo, err error) error {
 	if err := w.walk(path, fi, err); err != nil {
-		return fmt.Errorf("%s: %s",path, err)
+		return fmt.Errorf("%s: %s", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Giving more comprehensive error message to anthafmt.

It now returns the path to the file in which errors occurs along with the error message.