### PR TITLE
Support for no-op mixes

### DIFF
--- a/antha/anthalib/wtype/lhcomponent.go
+++ b/antha/anthalib/wtype/lhcomponent.go
@@ -391,6 +391,12 @@ func (lhc *LHComponent) Sample(v wunit.Volume) (*LHComponent, error) {
 	return c, nil
 }
 
+func (lhc *LHComponent) Cp() *LHComponent {
+	c := lhc.Dup()
+	c.ID = GetUUID()
+	return c
+}
+
 func (lhc *LHComponent) Dup() *LHComponent {
 	c := NewLHComponent()
 	c.ID = lhc.ID

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -22,6 +22,44 @@ func NewIChain(parent *IChain) *IChain {
 	return &it
 }
 
+func (it *IChain) PruneOut(Remove map[string]bool) *IChain {
+	if it == nil || len(Remove) == 0 || len(it.Values) == 0 {
+		return it
+	}
+
+	it.Child = it.Child.PruneOut(Remove)
+
+	newValues := make([]*wtype.LHInstruction, 0, len(it.Values))
+
+	for _, v := range it.Values {
+		if Remove[v.ID] {
+			continue
+		}
+		newValues = append(newValues, v)
+		delete(Remove, v.ID)
+	}
+
+	// if we've removed a whole layer, get rid of it
+
+	if len(newValues) == 0 {
+
+		if it.Child != nil {
+			it.Child.Parent = it.Parent
+		}
+
+		if it.Parent != nil {
+			it.Parent.Child = it.Child
+		}
+
+		return it.Child
+
+	} else {
+		it.Values = newValues
+		return it
+	}
+
+}
+
 func (it *IChain) Reverse() {
 	if it.Child != nil {
 		it.Child.Reverse()

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -535,6 +535,10 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 		return err
 	}
 
+	// remove dummy mix-in-place instructions
+
+	request = removeDummyInstructions(request)
+
 	// now make instructions
 	request, err = this.ExecutionPlan(ctx, request)
 
@@ -908,4 +912,50 @@ func (lh *Liquidhandler) fix_post_names(rq *LHRequest) error {
 	}
 
 	return nil
+}
+
+func dummy(ins *wtype.LHInstruction) bool {
+	if ins.IsMixInPlace() && len(ins.Components) == 1 {
+		// instructions of this form generally mean "do nothing"
+		// but have very useful side-effects
+		return true
+	}
+
+	return false
+}
+
+func removeDummyInstructions(rq *LHRequest) *LHRequest {
+	toRemove := make(map[string]bool, len(rq.LHInstructions))
+	for _, ins := range rq.LHInstructions {
+		if dummy(ins) {
+			toRemove[ins.ID] = true
+		}
+	}
+
+	if len(toRemove) == 0 {
+		//no dummies
+		return rq
+	}
+
+	oo := make([]string, 0, len(rq.Output_order)-len(toRemove))
+
+	for _, ins := range rq.Output_order {
+		if toRemove[ins] {
+			continue
+		} else {
+			oo = append(oo, ins)
+		}
+	}
+
+	if len(oo) != len(rq.Output_order)-len(toRemove) {
+		panic(fmt.Sprintf("Dummy instruction prune failed: before %d dummies %d after %d", len(rq.Output_order), len(toRemove), len(oo)))
+	}
+
+	rq.Output_order = oo
+
+	// prune instructionChain
+
+	rq.InstructionChain.PruneOut(toRemove)
+
+	return rq
 }

--- a/microArch/scheduler/liquidhandling/newexecutionplanner.go
+++ b/microArch/scheduler/liquidhandling/newexecutionplanner.go
@@ -50,9 +50,11 @@ func ImprovedExecutionPlanner(ctx context.Context, request *LHRequest, robot *li
 
 	for ix, insID := range request.Output_order {
 		//	request.InstructionSet.Add(ConvertInstruction(request.LHInstructions[insID], robot))
-		ris := liquidhandling.NewRobotInstructionSet(nil)
 
 		ins := request.LHInstructions[insID]
+
+		ris := liquidhandling.NewRobotInstructionSet(nil)
+
 		if ins.Type == wtype.LHIPRM {
 			// prompt
 			prm := liquidhandling.NewMessageInstruction(ins)


### PR DESCRIPTION
Sample should return two components: the sample and the original component, which has now changed. Currently this does not happen.

This feature allows us to use previouslySampledComponent = Mix(previouslySampledComponent) to keep the ID up to date and ensure mixes happen in the correct order

Whether this persists in future is an open question; we might consider postpending this to any sampling that goes on during the transpilation step so that it is transparent to the user. Whether this is preferable to having two returns to Sample is open to discussion.
