### PR TITLE
Fix/reservoir platetypes

### DIFF
--- a/inventory/testinventory/make_plate_library.go
+++ b/inventory/testinventory/make_plate_library.go
@@ -179,6 +179,12 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	plate = wtype.NewLHPlate("DWR1", "Unknown", 1, 1, 44.1, "mm", singlewelltrough, 9, 9, 49.5, 0.0, 0.0)
 	plates = append(plates, plate)
 
+	// 250ml box reservoir (working vol estimated to be 100ml to prevent spillage on moving decks)
+	reservoirbox := wtype.NewShape("box", "mm", 121, 80, 40) // 39?
+	welltypereservoir := wtype.NewLHWell("Reservoir", "", "", "ul", 100000, 10000, reservoirbox, wtype.LHWBFLAT, 121, 80, 40, 3, "mm")
+	plate = wtype.NewLHPlate("reservoir", "unknown", 1, 1, 40, "mm", welltypereservoir, 1, 1, 0.0, 0.0, 0.0)
+	plates = append(plates, plate)
+
 	// well area function
 	// -- determined empirically since inverse cubic was giving us some numerical issues
 	areaf := wutil.Quartic{A: -3.3317851312e-09, B: 0.00000225834467, C: -0.0006305492472, D: 0.1328156706978, E: 0}
@@ -383,11 +389,9 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 
 	plate = wtype.NewLHPlate("nunc1536", "Unknown", 32, 48, 7, "mm", welltype1536, wellxoffset, wellyoffset, xstart, ystart, zstart)
 	plates = append(plates, plate)
-	// 250ml box reservoir (working vol estimated to be 100ml to prevent spillage on moving decks)
-	reservoirbox := wtype.NewShape("box", "mm", 71, 107, 38) // 39?
-	welltypereservoir := wtype.NewLHWell("Reservoir", "", "", "ul", 100000, 10000, reservoirbox, 0, 107, 71, 38, 3, "mm")
-	plate = wtype.NewLHPlate("reservoir", "unknown", 1, 1, 45, "mm", welltypereservoir, 58, 13, 0, 0, 10)
-	plates = append(plates, plate)
+
+
+
 
 	// Onewell SBS format Agarplate with colonies on riser (50ml agar) high res
 

--- a/inventory/testinventory/make_plate_library.go
+++ b/inventory/testinventory/make_plate_library.go
@@ -176,13 +176,13 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	// deep well reservoir
 	rshp := wtype.NewShape("box", "mm", 115.0, 72.0, 41.3)
 	singlewelltrough := wtype.NewLHWell("DWR1", "", "", "ul", 300000, 20000, rshp, wtype.LHWBV, 115, 72, 41.3, 4.7, "mm")
-	plate = wtype.NewLHPlate("DWR1", "Unknown", 1, 1, 44.1, "mm", singlewelltrough, 9, 9, 49.5, 0.0, 0.0)
+	plate = wtype.NewLHPlate("DWR1", "Unknown", 1, 1, 44.1, "mm", singlewelltrough, 9, 9, 0.0, 0.0, 0.0)
 	plates = append(plates, plate)
 
-	// 250ml box reservoir (working vol estimated to be 100ml to prevent spillage on moving decks)
+	// 250ml box reservoir
 	reservoirbox := wtype.NewShape("box", "mm", 121, 80, 40) // 39?
-	welltypereservoir := wtype.NewLHWell("Reservoir", "", "", "ul", 100000, 10000, reservoirbox, wtype.LHWBFLAT, 121, 80, 40, 3, "mm")
-	plate = wtype.NewLHPlate("reservoir", "unknown", 1, 1, 40, "mm", welltypereservoir, 1, 1, 0.0, 0.0, 0.0)
+	welltypereservoir := wtype.NewLHWell("Reservoir", "", "", "ul", 200000, 40000, reservoirbox, wtype.LHWBFLAT, 121, 80, 40, 3, "mm")
+	plate = wtype.NewLHPlate("reservoir", "unknown", 1, 1, 40, "mm", welltypereservoir, 1, 1, 49.5, 31.0, 0.0)
 	plates = append(plates, plate)
 
 	// well area function

--- a/inventory/testinventory/make_plate_library.go
+++ b/inventory/testinventory/make_plate_library.go
@@ -176,7 +176,7 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	// deep well reservoir
 	rshp := wtype.NewShape("box", "mm", 115.0, 72.0, 41.3)
 	singlewelltrough := wtype.NewLHWell("DWR1", "", "", "ul", 300000, 20000, rshp, wtype.LHWBV, 115, 72, 41.3, 4.7, "mm")
-	plate = wtype.NewLHPlate("DWR1", "Unknown", 1, 1, 44.1, "mm", singlewelltrough, 9, 9, 0.0, 0.0, 0.0)
+	plate = wtype.NewLHPlate("DWR1", "Unknown", 1, 1, 44.1, "mm", singlewelltrough, 9, 9, 49.5, 0.0, 0.0)
 	plates = append(plates, plate)
 
 	// 250ml box reservoir

--- a/inventory/testinventory/make_plate_library_test.go
+++ b/inventory/testinventory/make_plate_library_test.go
@@ -16,7 +16,7 @@ type platetest struct {
 }
 
 var tests = []platetest{
-	platetest{TestPlateName: "reservoir", ExpectedZStart: 10.0, ExpectedHeight: 45.0},
+	platetest{TestPlateName: "reservoir", ExpectedZStart: 0.0, ExpectedHeight: 40.0},
 	platetest{TestPlateName: "pcrplate_skirted", ExpectedZStart: 0.636, ExpectedHeight: 15.5},
 	platetest{TestPlateName: "greiner384", ExpectedZStart: 2.5, ExpectedHeight: 14.0},
 	platetest{TestPlateName: "Nuncon12well", ExpectedZStart: 4.0, ExpectedHeight: 19.0},


### PR DESCRIPTION
Fixed reservoir plate type dimensions.

Physically verified residual volume and maximum volume. Maximum volume not the actual maximum volume of the plate (350 ml) but the approximate maximum volume of which a plate being moved on the deck will not overspill when using water.