### PR TITLE
Refactor/move constants to wutil

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/doe/doe.go
+++ b/antha/AnthaStandardLibrary/Packages/doe/doe.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/search"
-	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
@@ -925,7 +924,7 @@ func mergeFactorLevels(run1 Run, run2 Run, factors []string, newLevel interface{
 }
 
 func mergeStrings(factorNames []string) (combinedFactor string) {
-	combinedFactor = strings.Join(factorNames, wtype.MIXDELIMITER)
+	combinedFactor = strings.Join(factorNames, wutil.MIXDELIMITER)
 	return
 }
 

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -26,8 +26,8 @@ package solutions
 import (
 	"strings"
 
-	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 // if the component name contains a concentration the concentration name will be normalised
@@ -35,7 +35,7 @@ import (
 // A concatanenated name such as 10g/L glucose + 10g/L yeast extract will be returned with no modifications
 func NormaliseName(name string) (normalised string) {
 
-	if strings.Contains(name, wtype.MIXDELIMITER) {
+	if strings.Contains(name, wutil.MIXDELIMITER) {
 		return name
 	}
 

--- a/antha/anthalib/wtype/lhpolicy.go
+++ b/antha/anthalib/wtype/lhpolicy.go
@@ -25,8 +25,10 @@ package wtype
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"reflect"
+
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 const (
@@ -551,7 +553,7 @@ func (lhnc LHNumericCondition) Match(v interface{}) bool {
 		}
 
 		for _, f := range v.([]float64) {
-			if !lhnc.Match(f) && f > EPSILON_64() {
+			if !lhnc.Match(f) && f > wutil.EPSILON_64() {
 				return false
 			}
 		}
@@ -587,7 +589,7 @@ func numInStringArray(a []string) int {
 func numInFloatArray(a []float64) int {
 	c := 0
 	for _, f := range a {
-		if f > EPSILON_64() {
+		if f > wutil.EPSILON_64() {
 			c += 1
 		}
 	}

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 func NormaliseUnit(unit string) (normalisedunit string) {
@@ -133,6 +135,9 @@ func ParseConcentration(componentname string) (containsconc bool, conc Concentra
 			if concfields[0] == "" {
 				value = 0.0
 			} else {
+				if strings.Contains(componentname, wutil.MIXDELIMITER) {
+					return false, conc, componentname
+				}
 				panic(fmt.Sprint("error parsing componentname: ", componentname, ": ", err.Error()))
 				return false, conc, componentNameOnly
 			}

--- a/antha/anthalib/wutil/constants.go
+++ b/antha/anthalib/wutil/constants.go
@@ -20,17 +20,17 @@
 // Synthace Ltd. The London Bioscience Innovation Centre
 // 2 Royal College St, London NW1 0NH UK
 
-package wtype
+package wutil
 
 import (
 	"math"
 )
 
-// the standard delimiter to be used when concatenating mixed components into a new component name
+// MIXDELIMITER is the standard delimiter to be used when concatenating mixed components into a new component name
 const MIXDELIMITER = "+"
 
 //constasafunc
-
+// EPSILON_64 returns the machine epsilon.
 func EPSILON_64() float64 {
 	return math.Nextafter(1, 2) - 1
 }


### PR DESCRIPTION
Move constants to wutil to avoid circular import issue between wunit and wtype. 
