### PR TITLE
Rounding when output of GetComponents is very close to desired volume

### DIFF
--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -383,12 +383,9 @@ func makeMatchSafe(dst wtype.ComponentVector, match wtype.Match, mpv wunit.Volum
 			checkVol -= match.Vols[i].ConvertToString(dst[i].Vunit)
 
 			if checkVol > 0.0 && checkVol < mpv.ConvertToString(dst[i].Vunit) {
-				mpv.Subtract(wunit.NewVolume(checkVol, dst[i].Vunit))
-				match.Vols[i].Subtract(mpv)
-
-				if match.Vols[i].LessThanFloat(0.0) {
-					panic(fmt.Sprintf("Serious volume issue -- try a manual plate layout with some additional volume for %s", dst[i].CName))
-				}
+				//'got' volume is closer to 'want' volume than the tolerance of the machine
+				//set it equal to avoid numerical instability
+				match.Vols[i] = wunit.NewVolume(dst[i].Vol, dst[i].Vunit)
 			}
 		}
 	}


### PR DESCRIPTION
Output of GetComponents can be numerically unstable, e.g. a request for
100ul will return 99.99999ul available, which causes an unnecessary
transfer instruction to be generated.
Fix rounds available volume to the requested volume when it is within
the robot's reported minimum possible volume.