### PR TITLE
Fixed counting error in CentreToQuery fn in bioinformatics.go

### DIFF
--- a/antha/anthalib/wtype/bioinformatics.go
+++ b/antha/anthalib/wtype/bioinformatics.go
@@ -196,14 +196,24 @@ func (aln SimpleAlignment) Column(i int) string {
 	return r
 }
 
+// Trim aligned (subject) sequences to only those residues/nucleotides aligned
+// to those in the query. This removes inserts (wrt the query) from aligned
+// sequences. Gaps within the interior of the aligned sequence are already
+// represented by '-' characters, however gaps at the ends of the aligned
+// sequence must be added here as well. The resulting aligned sequences will 
+// have the same length as the query.
 func (aln AlignedSequence) CentreToQuery(q string) (string, string) {
-	s := ""
-	r := ""
+
+	s := "" // query
+	r := "" // aligned
+
+  // Add any gaps to the start of the aligned sequence.
 	for i := 1; i < aln.Qstart; i++ {
 		r += "-"
 		s += string(q[i-1])
 	}
 
+  // Remove any inserts from the aligned sequence.
 	for i := 0; i < len(aln.Qseq); i++ {
 		if aln.Qseq[i] != '-' {
 			r += string(aln.Sseq[i])
@@ -211,10 +221,12 @@ func (aln AlignedSequence) CentreToQuery(q string) (string, string) {
 		}
 	}
 
+  // Add any gaps to the end of the aligned sequence.
 	for i := aln.Qend + 1; i <= len(q); i++ {
 		r += "-"
 		s += string(q[i-1])
 	}
 
+  // Return query, aligned.
 	return s, r
 }

--- a/antha/anthalib/wtype/bioinformatics.go
+++ b/antha/anthalib/wtype/bioinformatics.go
@@ -211,7 +211,7 @@ func (aln AlignedSequence) CentreToQuery(q string) (string, string) {
 		}
 	}
 
-	for i := aln.Qend; i < len(q); i++ {
+	for i := aln.Qend + 1; i <= len(q); i++ {
 		r += "-"
 		s += string(q[i-1])
 	}


### PR DESCRIPTION
Was counting indicies wrong by 1 when writing the end portion of the query seq after the alignment portion. To see the effects of this, I've attached an the output file (originally the json file) from the Blastp element in the original prot-eng branch. These are the Query Centred Alignments. You can see that for subject sequences ending with gaps.... e.g., --", that the corresponding query sequences are incorrect at the end. 


[outputs_BLASTp_QCA_1000.txt](https://github.com/antha-lang/antha/files/1707138/outputs_BLASTp_QCA_1000.txt)

