### PR TITLE
Plate library/cooler as incubator

### DIFF
--- a/inventory/testinventory/devices.go
+++ b/inventory/testinventory/devices.go
@@ -65,10 +65,6 @@ var defaultDevices = map[string]device{
 					SpecialOffset: -0.636,
 				},
 				plateWithConstraint{
-					Name:          "pcrplate_skirted",
-					SpecialOffset: 0.0,
-				},
-				plateWithConstraint{
 					Name:          "pcrplate_semi_skirted",
 					SpecialOffset: 0.0,
 				},

--- a/inventory/testinventory/devices.go
+++ b/inventory/testinventory/devices.go
@@ -53,11 +53,11 @@ var defaultDevices = map[string]device{
 		Synonyms:     []string{"riser18", "shallowriser18"},
 	},
 
-	"496rack": riser{
-		Name:         "496rack",
+	"with_496rack": riser{
+		Name:         "with_496rack",
 		Manufacturer: "Gilson",
 		Heightinmm:   pcrtuberack496HeightInmm,
-		Synonyms:     []string{"496rack"},
+		Synonyms:     []string{"with_496rack"},
 		PlateConstraints: plateConstraints{
 			OnlyThesePlates: []plateWithConstraint{
 				plateWithConstraint{
@@ -138,12 +138,12 @@ var defaultDevices = map[string]device{
 		},
 	},
 
-	"cooler": incubator{
+	"with_cooler": incubator{
 		Riser: riser{
-			Name:         "cooler",
+			Name:         "with_cooler",
 			Manufacturer: "Eppendorf",
 			Heightinmm:   coolerheight,
-			Synonyms:     []string{"cooler"},
+			Synonyms:     []string{"with_cooler"},
 			PlateConstraints: plateConstraints{
 				OnlyThesePlates: []plateWithConstraint{
 					plateWithConstraint{
@@ -171,12 +171,12 @@ var defaultDevices = map[string]device{
 		PositionConstraints: map[string][]string{},
 	},
 
-	"isofreeze_cooler": incubator{
+	"with_isofreeze_cooler": incubator{
 		Riser: riser{
-			Name:         "isofreeze_cooler",
+			Name:         "with_isofreeze_cooler",
 			Manufacturer: "Isofreeze",
 			Heightinmm:   isofreezecoolerheight,
-			Synonyms:     []string{"isofreeze_cooler"},
+			Synonyms:     []string{"with_isofreeze_cooler"},
 			PlateConstraints: plateConstraints{
 				OnlyThesePlates: []plateWithConstraint{
 					plateWithConstraint{

--- a/inventory/testinventory/make_plate_library.go
+++ b/inventory/testinventory/make_plate_library.go
@@ -200,10 +200,13 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	afb, _ := json.Marshal(areaf)
 	afs := string(afb)
 
+	pcrPlateMinVol := 0.0 //5.0
+	pcrPlateMaxVol := 200.0
+
 	// pcr plate with cooler
 	cone := wtype.NewShape("cylinder", "mm", 5.5, 5.5, 15)
 
-	pcrplatewell := wtype.NewLHWell("pcrplate", "", "", "ul", 200, 5, cone, wtype.LHWBU, 5.5, 5.5, 15, 1.4, "mm")
+	pcrplatewell := wtype.NewLHWell("pcrplate", "", "", "ul", pcrPlateMaxVol, pcrPlateMinVol, cone, wtype.LHWBU, 5.5, 5.5, 15, 1.4, "mm")
 	pcrplatewell.SetAfVFunc(afs)
 
 	//LiquidLevel model for LL Following: vol_f estimates volume given height
@@ -682,6 +685,8 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	plate = makeGreinerFlatBottomBlackPlate()
 	plates = append(plates, plate)
 
+	plates = append(plates, makeNunc96UPlate())
+
 	return
 }
 
@@ -704,6 +709,51 @@ func makeGreinerVBottomPlate() *wtype.LHPlate {
 	welltype := wtype.NewLHWell("GreinerSWVBottom", "", "", "ul", 230, 10, rwshp, bottomtype, xdim, ydim, zdim, bottomh, "mm")
 
 	plate := wtype.NewLHPlate("GreinerSWVBottom", "Greiner", 8, 12, 15, "mm", welltype, wellxoffset, wellyoffset, xstart, ystart, zstart)
+
+	return plate
+}
+
+// Nunc U96 Microplate PolyStyrene Sterile U-Bottom, Clear, Cat Num: 262162
+func makeNunc96UPlate() *wtype.LHPlate {
+
+	xstartOffset := 11.25
+	ystartOffset := 7.75
+
+	plateName := "nunc_96_U_PS_Clear"
+	wellName := "Nunc96U"
+	manufacturer := "Nunc"
+
+	numberOfRows := 8
+	numberOfColumns := 12
+
+	wellShape := "cylinder"
+	bottomtype := wtype.LHWBU
+
+	dimensionUnit := "mm"
+
+	xdim := 7.1  // G1: diameter at top of well
+	ydim := 7.1  // G1: diameter at top of well
+	zdim := 10.2 // L: depth of well from top to bottom
+
+	bottomh := 1.0 // ?
+
+	minVolume := 20.0
+	maxVolume := 250.0
+
+	volUnit := "ul"
+
+	wellxoffset := 9.0             // K: centre of well to centre of neighbouring well in x direction
+	wellyoffset := 9.0             // K?: centre of well to centre of neighbouring well in y direction
+	xstart := 10.75 - xstartOffset // H - (G1/2): distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
+	ystart := 7.75 - ystartOffset  // J - (G1/2):  distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
+	zstart := 3.0                  // F - L: offset of bottom of deck to bottom of well
+	overallHeight := 14.4          // F: height of plate
+
+	nunc96UShape := wtype.NewShape(wellShape, dimensionUnit, xdim, ydim, zdim)
+
+	welltype := wtype.NewLHWell(wellName, "", "", volUnit, maxVolume, minVolume, nunc96UShape, bottomtype, xdim, ydim, zdim, bottomh, dimensionUnit)
+
+	plate := wtype.NewLHPlate(plateName, manufacturer, numberOfRows, numberOfColumns, overallHeight, dimensionUnit, welltype, wellxoffset, wellyoffset, xstart, ystart, zstart)
 
 	return plate
 }

--- a/inventory/testinventory/make_plate_library.go
+++ b/inventory/testinventory/make_plate_library.go
@@ -200,7 +200,7 @@ func makeBasicPlates() (plates []*wtype.LHPlate) {
 	afb, _ := json.Marshal(areaf)
 	afs := string(afb)
 
-	pcrPlateMinVol := 0.0 //5.0
+	pcrPlateMinVol := 5.0
 	pcrPlateMaxVol := 200.0
 
 	// pcr plate with cooler
@@ -714,10 +714,12 @@ func makeGreinerVBottomPlate() *wtype.LHPlate {
 }
 
 // Nunc U96 Microplate PolyStyrene Sterile U-Bottom, Clear, Cat Num: 262162
+// Source of dimensions: https://www.thermofisher.com/order/catalog/product/262162
 func makeNunc96UPlate() *wtype.LHPlate {
 
-	xstartOffset := 11.25
-	ystartOffset := 7.75
+	// These corrections are necessary to subtract from the official (correct) dimensions in order obtain correct pipetting behaviour.
+	xstartOffsetCorrection := 11.25
+	ystartOffsetCorrection := 7.75
 
 	plateName := "nunc_96_U_PS_Clear"
 	wellName := "Nunc96U"
@@ -742,12 +744,12 @@ func makeNunc96UPlate() *wtype.LHPlate {
 
 	volUnit := "ul"
 
-	wellxoffset := 9.0             // K: centre of well to centre of neighbouring well in x direction
-	wellyoffset := 9.0             // K?: centre of well to centre of neighbouring well in y direction
-	xstart := 10.75 - xstartOffset // H - (G1/2): distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
-	ystart := 7.75 - ystartOffset  // J - (G1/2):  distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
-	zstart := 3.0                  // F - L: offset of bottom of deck to bottom of well
-	overallHeight := 14.4          // F: height of plate
+	wellxoffset := 9.0                       // K: centre of well to centre of neighbouring well in x direction
+	wellyoffset := 9.0                       // K?: centre of well to centre of neighbouring well in y direction
+	xstart := 10.75 - xstartOffsetCorrection // H - (G1/2): distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
+	ystart := 7.75 - ystartOffsetCorrection  // J - (G1/2):  distance from top left side of plate to first well (looks like this value does not reflect reality and has an offest applied)
+	zstart := 3.0                            // F - L: offset of bottom of deck to bottom of well
+	overallHeight := 14.4                    // F: height of plate
 
 	nunc96UShape := wtype.NewShape(wellShape, dimensionUnit, xdim, ydim, zdim)
 

--- a/inventory/testinventory/make_plate_library_test.go
+++ b/inventory/testinventory/make_plate_library_test.go
@@ -25,12 +25,12 @@ var tests = []platetest{
 }
 
 var testsofPlateWithRiser = []platetest{
-	platetest{TestPlateName: "pcrplate_cooler", ExpectedZStart: coolerheight + 0.636, ExpectedHeight: 15.5},
-	platetest{TestPlateName: "pcrplate_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight, ExpectedHeight: 15.5},
-	platetest{TestPlateName: "pcrplate_skirted_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight + 2.0, ExpectedHeight: 15.5},
-	platetest{TestPlateName: "pcrplate_496rack", ExpectedZStart: pcrtuberack496HeightInmm, ExpectedHeight: 15.5},
-	platetest{TestPlateName: "pcrplate_semi_skirted_496rack", ExpectedZStart: pcrtuberack496HeightInmm + 1.0, ExpectedHeight: 15.5},
-	platetest{TestPlateName: "strip_tubes_0.2ml_496rack", ExpectedZStart: pcrtuberack496HeightInmm - 2.5, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_with_cooler", ExpectedZStart: coolerheight + 0.636, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_with_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_skirted_with_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight + 2.0, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_with_496rack", ExpectedZStart: pcrtuberack496HeightInmm, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_semi_skirted_with_496rack", ExpectedZStart: pcrtuberack496HeightInmm + 1.0, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "strip_tubes_0.2ml_with_496rack", ExpectedZStart: pcrtuberack496HeightInmm - 2.5, ExpectedHeight: 15.5},
 }
 
 func TestAddRiser(t *testing.T) {

--- a/inventory/testinventory/make_plate_library_test.go
+++ b/inventory/testinventory/make_plate_library_test.go
@@ -18,9 +18,19 @@ type platetest struct {
 var tests = []platetest{
 	platetest{TestPlateName: "reservoir", ExpectedZStart: 0.0, ExpectedHeight: 40.0},
 	platetest{TestPlateName: "pcrplate_skirted", ExpectedZStart: 0.636, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate", ExpectedZStart: 0.636, ExpectedHeight: 15.5},
 	platetest{TestPlateName: "greiner384", ExpectedZStart: 2.5, ExpectedHeight: 14.0},
 	platetest{TestPlateName: "Nuncon12well", ExpectedZStart: 4.0, ExpectedHeight: 19.0},
 	platetest{TestPlateName: "Nuncon12wellAgar", ExpectedZStart: 9.0, ExpectedHeight: 19.0},
+}
+
+var testsofPlateWithRiser = []platetest{
+	platetest{TestPlateName: "pcrplate_cooler", ExpectedZStart: coolerheight + 0.636, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_skirted_isofreeze_cooler", ExpectedZStart: isofreezecoolerheight + 2.0, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_496rack", ExpectedZStart: pcrtuberack496HeightInmm, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "pcrplate_semi_skirted_496rack", ExpectedZStart: pcrtuberack496HeightInmm + 1.0, ExpectedHeight: 15.5},
+	platetest{TestPlateName: "strip_tubes_0.2ml_496rack", ExpectedZStart: pcrtuberack496HeightInmm - 2.5, ExpectedHeight: 15.5},
 }
 
 func TestAddRiser(t *testing.T) {
@@ -38,7 +48,9 @@ func TestAddRiser(t *testing.T) {
 
 			newPlates := addRiser(testPlate, device)
 			if e, f := 0, len(newPlates); e == f {
-				t.Errorf("expected some plates but none found")
+				if !doNotAddThisRiserToThisPlate(testPlate, device) {
+					t.Errorf("expected some plates resulting from adding riser %s to plate %s but none found", device.GetName(), testPlate.Type)
+				}
 				continue
 			}
 
@@ -77,7 +89,7 @@ func TestAddRiser(t *testing.T) {
 				)
 			}
 
-			if f, e := newPlate.WellZStart, test.ExpectedZStart+device.GetHeightInmm()-offset; e != f {
+			if f, e := newPlate.WellZStart, test.ExpectedZStart+device.GetHeightInmm()-offset+plateRiserSpecificOffset(testPlate, device); e != f {
 				t.Error(
 					"for", device, "\n",
 					"testname", testname, "\n",
@@ -182,7 +194,9 @@ func TestSetConstraints(t *testing.T) {
 				}
 			} else if !containsRiser(testplate) {
 				if e, f := 1, len(newPlates); e != f {
-					t.Errorf("expecting %d plates found %d", e, f)
+					if !doNotAddThisRiserToThisPlate(testplate, device) {
+						t.Errorf("expecting %d plates found %d", e, f)
+					}
 					continue
 				} else if e, f := testplate.Type+"_"+device.GetName(), newPlates[0].Type; e != f {
 					t.Errorf("expecting type %s found %s", e, f)
@@ -195,7 +209,10 @@ func TestSetConstraints(t *testing.T) {
 			for _, testplate := range newPlates {
 				positionsinterface, found := testplate.Welltype.Extra[platform]
 				positions, ok := positionsinterface.([]string)
-				if !ok || !found || positions == nil || len(positions) != len(expectedpositions) || positions[0] != expectedpositions[0] {
+
+				if doNotAddThisRiserToThisPlate(testplate, device) {
+					// skip this case
+				} else if !ok || !found || len(positions) == 0 {
 					t.Error(
 						"for", device, "\n",
 						"testname", testplate.Type, "\n",
@@ -206,6 +223,17 @@ func TestSetConstraints(t *testing.T) {
 						"Constraints expected :", device.GetConstraints()[platform], "\n",
 						"Constraints got :", testplate.Welltype.Extra[platform], "\n",
 					)
+				} else if len(positions) != len(expectedpositions) {
+					t.Error(
+						"for", device, "\n",
+						"testname", testplate.Type, "\n",
+						"Positions got: ", positions, "\n",
+						"Positions expected: ", expectedpositions, "\n",
+						"Constraints expected :", device.GetConstraints()[platform], "\n",
+						"Constraints got :", testplate.Welltype.Extra[platform], "\n",
+					)
+				} else if positions[0] != expectedpositions[0] {
+
 				}
 			}
 		}
@@ -227,7 +255,6 @@ func TestGetConstraints(t *testing.T) {
 			if search.InStrings(exceptions[device.GetName()], testplate.Type) {
 				continue
 			}
-
 			var testname string
 			if strings.Contains(testplate.Type, device.GetName()) {
 				testname = testplate.Type
@@ -239,24 +266,28 @@ func TestGetConstraints(t *testing.T) {
 
 			testplate, err := inventory.NewPlate(ctx, testname)
 			if err != nil {
-				t.Error(err)
+				if !doNotAddThisRiserToThisPlate(testplate, device) {
+					t.Error(err)
+				}
 				continue
 			}
 
 			positionsinterface, found := testplate.Welltype.Extra[platform]
 			positions, ok := positionsinterface.([]string)
 			if !ok || !found || positions == nil || len(positions) != len(expectedpositions) || positions[0] != expectedpositions[0] {
-				t.Error(
-					"for", device, "\n",
-					"testname", testname, "\n",
+				if doNotAddThisRiserToThisPlate(testplate, device) && len(device.GetConstraints()[platform]) > 0 {
+					t.Error(
+						"for", device, "\n",
+						"testname", testname, "\n",
 
-					"Extra found", found, "\n",
-					"[]string?: ", ok, "\n",
-					"Positions: ", positions, "\n",
-					"expected positions: ", expectedpositions, "\n",
-					"Constraints expected :", device.GetConstraints()[platform], "\n",
-					"Constraints got :", testplate.Welltype.Extra[platform], "\n",
-				)
+						"Extra found", found, "\n",
+						"[]string?: ", ok, "\n",
+						"Positions: ", positions, "\n",
+						"expected positions: ", expectedpositions, "\n",
+						"Constraints expected :", device.GetConstraints()[platform], "\n",
+						"Constraints got :", testplate.Welltype.Extra[platform], "\n",
+					)
+				}
 			}
 		}
 	}
@@ -265,7 +296,12 @@ func TestGetConstraints(t *testing.T) {
 func TestPlateZs(t *testing.T) {
 	ctx := NewContext(context.Background())
 
-	for _, test := range tests {
+	var allTests []platetest
+
+	allTests = append(allTests, testsofPlateWithRiser...)
+	allTests = append(allTests, tests...)
+
+	for _, test := range allTests {
 
 		testplate, err := inventory.NewPlate(ctx, test.TestPlateName)
 		if err != nil {


### PR DESCRIPTION
Refactored PCR plate holders/coolers to be treated as a riser which have a plateConstraints field to indicate that only certain plates can be added to them.

Added tests which ensure heights of previous plates in the library are maintained. This required the ability to specify SpecialOffsets for a plate/riser combination. This is undesirable but probably necessary since certain tubes will sit differently in a rack depending on the diameter of the tube, and in some cases there is a solid base which ensures all tubes sit at the same height, regardless of the tube diameter.

Untested in lab at present but any previous heights have CI tests added to check the heights are equivalent to before.
