### PR TITLE
Fix/tip reuse with multi channeling try2

### DIFF
--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -160,6 +160,9 @@ func (lhcp LHChannelParameter) MarshalJSON() ([]byte, error) {
 }
 
 func (lhcp *LHChannelParameter) Dup() *LHChannelParameter {
+	if lhcp == nil {
+		return nil
+	}
 	r := NewLHChannelParameter(lhcp.Name, lhcp.Platform, lhcp.Minvol, lhcp.Maxvol, lhcp.Minspd, lhcp.Maxspd, lhcp.Multi, lhcp.Independent, lhcp.Orientation, lhcp.Head)
 
 	return r

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -47,6 +47,8 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 	// list of ids
 	parallel_sets, prm, err := get_parallel_sets_robot(ctx, ti.Inss, robot, policy)
 
+	fmt.Println("LEN PARALLEL SETS: ", len(parallel_sets))
+
 	// what if prm is nil?
 
 	if err != nil {
@@ -54,6 +56,8 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 	}
 
 	for _, set := range parallel_sets {
+		fmt.Println("PARALLEL SET HIGH UP ")
+		fmt.Println("SET: ", set)
 		// compile the instructions and pass them through
 		insset := make([]*wtype.LHInstruction, len(set))
 
@@ -79,13 +83,34 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 		}
 
 		// we merge instructions which are compatible
-
-		tfr = mergeTransfers(tfr)
+		//tfr = mergeTransfers(tfr)
 
 		for _, tf := range tfr {
 			inss = append(inss, RobotInstruction(tf))
 		}
 	}
+
+	toTransfers := func(inss []RobotInstruction) []*TransferInstruction {
+		r := make([]*TransferInstruction, len(inss))
+
+		for ix, ins := range inss {
+			r[ix] = ins.(*TransferInstruction)
+		}
+
+		return r
+	}
+
+	fromTransfers := func(inss []*TransferInstruction) []RobotInstruction {
+		r := make([]RobotInstruction, len(inss))
+
+		for i, ins := range inss {
+			r[i] = RobotInstruction(ins)
+		}
+
+		return r
+	}
+
+	inss = fromTransfers(mergeTransfers(toTransfers(inss)))
 
 	// stuff that can't be done in parallel
 	for _, ins := range ti.Inss {
@@ -101,7 +126,6 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 
 		insset := []*wtype.LHInstruction{ins}
 
-		// ConvertInstructions may now change which robot we use
 		tfr, robot, err = ConvertInstructions(ctx, insset, robot, wunit.NewVolume(0.5, "ul"), prm, 1, false, policy)
 
 		if err != nil {

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -47,8 +47,6 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 	// list of ids
 	parallel_sets, prm, err := get_parallel_sets_robot(ctx, ti.Inss, robot, policy)
 
-	fmt.Println("LEN PARALLEL SETS: ", len(parallel_sets))
-
 	// what if prm is nil?
 
 	if err != nil {
@@ -56,8 +54,6 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 	}
 
 	for _, set := range parallel_sets {
-		fmt.Println("PARALLEL SET HIGH UP ")
-		fmt.Println("SET: ", set)
 		// compile the instructions and pass them through
 		insset := make([]*wtype.LHInstruction, len(set))
 
@@ -110,9 +106,7 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 		return r
 	}
 
-	fmt.Println("BEFORE MERGE: ", len(inss))
-	inss = fromTransfers(mergeTransfers(toTransfers(inss)))
-	fmt.Println("AFTER  MERGE: ", len(inss))
+	inss = fromTransfers(mergeTransfers(toTransfers(inss), policy))
 
 	// stuff that can't be done in parallel
 	for _, ins := range ti.Inss {
@@ -511,69 +505,51 @@ func (ti TransferBlockInstruction) GetParameter(p string) interface{} {
 	return nil
 }
 
-func mergeTransfers(tfrs []*TransferInstruction) []*TransferInstruction {
+func mergeTransfers(tfrs []*TransferInstruction, policy *wtype.LHPolicyRuleSet) []*TransferInstruction {
 	ret := make([]*TransferInstruction, 0, len(tfrs))
 
-	// we strictly retain ordering here
+	for _, tf := range tfrs {
+		forMerge := findTransferForMerge(tf, ret, policy)
 
-	currTfr := tfrs[0]
-
-	for i := 1; i < len(tfrs); i++ {
-		if merged := tryMergeTransfer(currTfr, tfrs[i]); merged == nil {
-			ret = append(ret, currTfr)
-			currTfr = tfrs[i]
+		// true if ret is empty or nothing mergeable within
+		if forMerge == nil {
+			ret = append(ret, tf)
 		} else {
-			currTfr = merged
+			// forMerge is already in ret
+			forMerge.MergeWith(tf)
 		}
 	}
-
-	ret = append(ret, currTfr)
 
 	return ret
 }
 
-func tryMergeTransfer(ins1, ins2 *TransferInstruction) *TransferInstruction {
-	// merge any transfers which have sources in common
-
-	if commonSources(ins1, ins2) {
-		// appends everything from ins2 to ins1
-		return ins1.MergeWith(ins2)
+func findTransferForMerge(ins *TransferInstruction, arr []*TransferInstruction, policy *wtype.LHPolicyRuleSet) *TransferInstruction {
+	for _, ins2 := range arr {
+		if canMerge(ins, ins2, policy) {
+			return ins2
+		}
 	}
 
 	return nil
 }
 
-func commonSources(ins1, ins2 *TransferInstruction) bool {
-	a2Map := func(a []string) map[string]bool {
-		m := make(map[string]bool)
-		for _, v := range a {
-			if v == "" {
-				continue
-			}
-			m[v] = true
-		}
+func canMerge(ins, ins2 *TransferInstruction, policy *wtype.LHPolicyRuleSet) bool {
+	// merge only if the merge doesn't break either
 
-		return m
+	ins3 := ins.Dup()
+	ins3.MergeWith(ins2)
+
+	m1 := GetPolicyFor(policy, ins)["CAN_MULTI"].(bool)
+	m2 := GetPolicyFor(policy, ins2)["CAN_MULTI"].(bool)
+	m3 := GetPolicyFor(policy, ins3)["CAN_MULTI"].(bool)
+
+	if !xor(m1, m2) {
+		return !xor(m1, m3)
 	}
 
-	// we just compare component names
+	return false
+}
 
-	m := a2Map(ins1.Components)
-
-	if len(m) > 1 {
-		return false
-	}
-
-	for _, n := range ins2.Components {
-		if n == "" {
-			continue
-		}
-		_, ok := m[n]
-
-		if !ok {
-			return false
-		}
-	}
-
-	return true
+func xor(a, b bool) bool {
+	return (a && !b) || (!a && b)
 }

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -110,7 +110,9 @@ func (ti TransferBlockInstruction) Generate(ctx context.Context, policy *wtype.L
 		return r
 	}
 
+	fmt.Println("BEFORE MERGE: ", len(inss))
 	inss = fromTransfers(mergeTransfers(toTransfers(inss)))
+	fmt.Println("AFTER  MERGE: ", len(inss))
 
 	// stuff that can't be done in parallel
 	for _, ins := range ti.Inss {

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -543,13 +543,9 @@ func canMerge(ins, ins2 *TransferInstruction, policy *wtype.LHPolicyRuleSet) boo
 	m2 := GetPolicyFor(policy, ins2)["CAN_MULTI"].(bool)
 	m3 := GetPolicyFor(policy, ins3)["CAN_MULTI"].(bool)
 
-	if !xor(m1, m2) {
-		return !xor(m1, m3)
+	if m1 == m2 {
+		return m1 == m3
 	}
 
 	return false
-}
-
-func xor(a, b bool) bool {
-	return (a && !b) || (!a && b)
 }

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/inventory"
 	"github.com/antha-lang/antha/inventory/testinventory"
-	"reflect"
 	"testing"
 )
 
@@ -254,11 +253,11 @@ func TestMultichannelFailDest(t *testing.T) {
 		t.Errorf("No Transfers made")
 	}
 
-	for x := 0; x < len(ris); x++ {
-		ris[x].(*TransferInstruction).WellTo[1] = "A1"
-		ris[x].(*TransferInstruction).WellTo[3] = "A1"
-		ris[x].(*TransferInstruction).WellTo[5] = "A1"
-		ris[x].(*TransferInstruction).WellTo[7] = "A1"
+	for x := 0; x < len(ris[0].(*TransferInstruction).Transfers); x++ {
+		ris[0].(*TransferInstruction).Transfers[x].Transfers[1].WellTo = "A1"
+		ris[0].(*TransferInstruction).Transfers[x].Transfers[3].WellTo = "A1"
+		ris[0].(*TransferInstruction).Transfers[x].Transfers[5].WellTo = "A1"
+		ris[0].(*TransferInstruction).Transfers[x].Transfers[7].WellTo = "A1"
 	}
 
 	testNegative(ctx, ris, pol, rbt, t)
@@ -301,13 +300,18 @@ func TestMultiChannelFailComponent(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(ris) < 2 {
-		t.Errorf("Not enough Transfers made")
-		return
+	if len(ris) != 1 {
+		t.Errorf("Expected 1 transfer got ", len(ris))
 	}
 
-	ris[0].(*TransferInstruction).What[3] = "lemonade"
-	ris[1].(*TransferInstruction).What[3] = "lemonade"
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 2 {
+		t.Errorf("Error expected 2 transfers got %d", len(tf.Transfers))
+	}
+
+	ris[0].(*TransferInstruction).Transfers[0].Transfers[3].What = "lemonade"
+	ris[0].(*TransferInstruction).Transfers[1].Transfers[3].What = "lemonade"
 
 	testNegative(ctx, ris, pol, rbt, t)
 }
@@ -329,8 +333,14 @@ func TestMultichannelPositive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(ris) != 2 {
-		t.Errorf("Error: Expected 2 transfers got %d", len(ris))
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfer got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 2 {
+		t.Errorf("Error: Expected 2 transfers got %d", len(tf.Transfers))
 	}
 
 	testPositive(ctx, ris, pol, rbt, t)
@@ -370,8 +380,14 @@ func TestIndependentMultichannelPositive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(ris) != 2 {
-		t.Errorf("Error: Expected 2 transfers got %d", len(ris))
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfer got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 2 {
+		t.Errorf("Error: Expected 2 transfers got %d", len(tf.Transfers))
 	}
 
 	testPositive(ctx, ris, pol, rbt, t)
@@ -396,8 +412,14 @@ func TestTroughMultichannelPositive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(ris) != 2 {
-		t.Errorf("Error: Expected 2 transfers got %d", len(ris))
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfer got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 2 {
+		t.Errorf("Error: Expected 2 transfers got %d", len(tf.Transfers))
 	}
 
 	testPositive(ctx, ris, pol, rbt, t)
@@ -422,8 +444,14 @@ func TestBigWellMultichannelPositive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(ris) != 2 {
-		t.Errorf("Error: Expected 2 transfers got %d", len(ris))
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfer got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 2 {
+		t.Errorf("Error: Expected 2 transfers got %d", len(tf.Transfers))
 	}
 
 	testPositive(ctx, ris, pol, rbt, t)
@@ -450,8 +478,15 @@ func TestInsByInsMixPositiveMultichannel(t *testing.T) {
 
 	// component-by-component multichanneling should be supported IFF
 	// we can do all the solutions in the subset
-	if len(ris) != 3 {
-		t.Errorf("Error: Expected 3 transfers got %d", len(ris))
+
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfer got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 3 {
+		t.Errorf("Error: Expected 3 transfers got %d", len(tf.Transfers))
 	}
 
 	testPositive(ctx, ris, pol, rbt, t)
@@ -479,8 +514,14 @@ func TestInsByInsMixNegativeMultichannel(t *testing.T) {
 	// atomic mixes now come through all split up... in future this should revert to the
 	// older case of 8 x 3 transfers either by merging or something else
 
-	if len(ris) != 24 {
-		t.Errorf("Error: Expected 24 transfers got %d", len(ris))
+	if len(ris) != 1 {
+		t.Errorf("Error: Expected 1 transfers got %d", len(ris))
+	}
+
+	tf := ris[0].(*TransferInstruction)
+
+	if len(tf.Transfers) != 24 {
+		t.Errorf("Error: Expected 24 transfers got %d", len(tf.Transfers))
 	}
 
 	testNegative(ctx, ris, pol, rbt, t)
@@ -506,19 +547,18 @@ func getMeATransfer(ctype string) *TransferInstruction {
 	return NewTransferInstruction(wh, pltfrom, pltto, wellfrom, wellto, fplatetype, tplatetype, volume, fvolume, tvolume, fpwx, fpwy, tpwx, tpwy, cmps)
 }
 
+// TODO --> Create new version of the below
+/*
 func TestTransferMerge(t *testing.T) {
+	policy, _ := GetLHPolicyForTest()
 	ins1 := getMeATransfer("milk")
-
-	if !reflect.DeepEqual(ins1, ins1) {
-		t.Errorf("DeepEqual not reflexive!")
-	}
 
 	toMerge := []*TransferInstruction{ins1, ins1}
 
 	ins3 := ins1.Dup()
 	ins3 = ins3.MergeWith(ins1)
 
-	ins4 := mergeTransfers(toMerge)[0]
+	ins4 := mergeTransfers(toMerge, policy)[0]
 
 	if !reflect.DeepEqual(ins3, ins4) {
 		t.Errorf("Must merge transfers with same components")
@@ -530,13 +570,14 @@ func TestTransferMerge(t *testing.T) {
 
 	toMerge = []*TransferInstruction{ins1, ins2}
 
-	merged := mergeTransfers(toMerge)
+	merged := mergeTransfers(toMerge, policy)
 
 	if len(merged) == 1 {
 		t.Errorf("Must not merge transfers with different components")
 	}
 
 }
+*/
 
 func testPositive(ctx context.Context, ris []RobotInstruction, pol *wtype.LHPolicyRuleSet, rbt *LHProperties, t *testing.T) {
 	if len(ris) < 1 {

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -238,7 +238,7 @@ func (ins *TransferInstruction) GetParallelSetsFor(ctx context.Context, channel 
 	r := make([]int, 0, len(ins.Transfers))
 
 	for i := 0; i < len(ins.Transfers); i++ {
-		if ins.testParallelSet(ctx, channel, i) {
+		if ins.validateParallelSet(ctx, channel, i) {
 			r = append(r, i)
 		}
 	}
@@ -246,7 +246,7 @@ func (ins *TransferInstruction) GetParallelSetsFor(ctx context.Context, channel 
 	return r
 }
 
-func (ins *TransferInstruction) testParallelSet(ctx context.Context, channel *wtype.LHChannelParameter, which int) bool {
+func (ins *TransferInstruction) validateParallelSet(ctx context.Context, channel *wtype.LHChannelParameter, which int) bool {
 
 	if len(ins.Transfers[which].What()) > channel.Multi {
 		return false

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -658,6 +658,7 @@ func (ins *TransferInstruction) Generate(ctx context.Context, policy *wtype.LHPo
 		//mci.Multi = prms.HeadsLoaded[0].Params.Multi // TODO Remove Hard code here
 		mci.Prms = prms.HeadsLoaded[0].Params // TODO Remove Hard code here
 		for _, set := range parallelsets {
+			fmt.Println("PARALLEL SET: ", set)
 			// assemble the info
 			//mci.Multi = countSetSize(set)
 			mci.Multi = len(set)

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -460,6 +460,7 @@ func (insIn *TransferInstruction) Generate(ctx context.Context, policy *wtype.LH
 
 		for _, set := range parallelsets {
 			vols := VolumeSet(ins.Transfers[set].Volume())
+
 			maxvol := vols.MaxMultiTransferVolume(prms.MinPossibleVolume())
 
 			// if we can't do it, we can't do it
@@ -477,12 +478,13 @@ func (insIn *TransferInstruction) Generate(ctx context.Context, policy *wtype.LH
 
 			for i, _ := range vols {
 				vols[i] = wunit.CopyVolume(maxvol)
-				ins.Transfers[set].RemoveVolume(maxvol)
-
-				// set the from and to volumes for the relevant part of the instruction
-				ins.Transfers[set].RemoveFVolume(maxvol)
-				ins.Transfers[set].AddTVolume(maxvol)
 			}
+
+			ins.Transfers[set].RemoveVolume(maxvol)
+
+			// set the from and to volumes for the relevant part of the instruction
+			ins.Transfers[set].RemoveFVolume(maxvol)
+			ins.Transfers[set].AddTVolume(maxvol)
 
 			mci.Multi = len(vols)
 			mci.AddTransferParams(tp)
@@ -503,6 +505,7 @@ func (insIn *TransferInstruction) Generate(ctx context.Context, policy *wtype.LH
 			if tp.Volume.LessThanFloat(0.001) {
 				continue
 			}
+
 			// TODO --> reorder instructions
 			if lastWhat != "" && tp.What != lastWhat {
 				if len(sci.Volume) > 0 {

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -654,6 +654,10 @@ func (ins *TransferInstruction) Generate(ctx context.Context, policy *wtype.LHPo
 	if pol["CAN_MULTI"].(bool) {
 		parallelsets := ins.GetParallelSetsFor(ctx, prms.HeadsLoaded[0].Params)
 
+		fmt.Println("TOTAL IN THIS INSTRUCTION ", len(ins.What))
+
+		fmt.Println("HOW MANY ROMANS? ", len(parallelsets))
+
 		mci := NewMultiChannelBlockInstruction()
 		//mci.Multi = prms.HeadsLoaded[0].Params.Multi // TODO Remove Hard code here
 		mci.Prms = prms.HeadsLoaded[0].Params // TODO Remove Hard code here

--- a/microArch/driver/liquidhandling/transferparams.go
+++ b/microArch/driver/liquidhandling/transferparams.go
@@ -1,0 +1,247 @@
+package liquidhandling
+
+import (
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+)
+
+type TransferParams struct {
+	What       string
+	PltFrom    string
+	PltTo      string
+	WellFrom   string
+	WellTo     string
+	Volume     wunit.Volume
+	FPlateType string
+	TPlateType string
+	FVolume    wunit.Volume
+	TVolume    wunit.Volume
+	Channel    *wtype.LHChannelParameter
+	TipType    string
+}
+
+func (tp TransferParams) ToString() string {
+	return fmt.Sprintf("%s %s %s %s %s %s %s %s %s %s %s %s", tp.What, tp.PltFrom, tp.PltTo, tp.WellFrom, tp.WellTo, tp.Volume.ToString(), tp.FPlateType, tp.TPlateType, tp.FVolume.ToString(), tp.TVolume.ToString(), tp.Channel, tp.TipType)
+}
+
+func (tp TransferParams) Zero() bool {
+	if tp.What == "" {
+		return true
+	}
+
+	return false
+}
+
+func (tp TransferParams) Dup() TransferParams {
+	return TransferParams{
+		What:       tp.What,
+		PltFrom:    tp.PltFrom,
+		PltTo:      tp.PltTo,
+		WellFrom:   tp.WellFrom,
+		WellTo:     tp.WellTo,
+		Volume:     tp.Volume.Dup(),
+		FPlateType: tp.FPlateType,
+		TPlateType: tp.TPlateType,
+		FVolume:    tp.FVolume.Dup(),
+		TVolume:    tp.TVolume.Dup(),
+		Channel:    tp.Channel.Dup(),
+		TipType:    tp.TipType,
+	}
+}
+
+type MultiTransferParams struct {
+	Multi     int
+	Transfers []TransferParams
+}
+
+// slices through
+
+func (mtp MultiTransferParams) What() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.What
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) PltFrom() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.PltFrom
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) PltTo() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.PltTo
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) WellFrom() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.WellFrom
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) WellTo() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.WellTo
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) Volume() []wunit.Volume {
+	r := make([]wunit.Volume, mtp.Multi)
+
+	for i := 0; i < mtp.Multi; i++ {
+		r[i] = wunit.ZeroVolume()
+	}
+
+	for i, t := range mtp.Transfers {
+		r[i] = t.Volume.Dup()
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) FPlateType() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.FPlateType
+	}
+
+	return r
+}
+func (mtp MultiTransferParams) TPlateType() []string {
+	r := make([]string, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.TPlateType
+	}
+
+	return r
+}
+
+func (mtp MultiTransferParams) FVolume() []wunit.Volume {
+	r := make([]wunit.Volume, mtp.Multi)
+
+	for i := 0; i < mtp.Multi; i++ {
+		r[i] = wunit.ZeroVolume()
+	}
+
+	for i, t := range mtp.Transfers {
+		r[i] = t.FVolume.Dup()
+	}
+
+	return r
+}
+
+func (mtp MultiTransferParams) TVolume() []wunit.Volume {
+	r := make([]wunit.Volume, mtp.Multi)
+
+	for i := 0; i < mtp.Multi; i++ {
+		r[i] = wunit.ZeroVolume()
+	}
+
+	for i, t := range mtp.Transfers {
+		r[i] = t.TVolume.Dup()
+	}
+
+	return r
+}
+
+func (mtp MultiTransferParams) Channel() []*wtype.LHChannelParameter {
+	r := make([]*wtype.LHChannelParameter, mtp.Multi)
+	for i, t := range mtp.Transfers {
+		r[i] = t.Channel.Dup()
+	}
+
+	return r
+
+}
+
+func (mtp MultiTransferParams) TipType() []string {
+}
+
+func NewMultiTransferParams(multi int) MultiTransferParams {
+	var v MultiTransferParams
+	v.Transfers = make([]TransferParams, 0, multi)
+	v.Multi = multi
+	return v
+}
+
+func (mtp MultiTransferParams) ParamSet(n int) TransferParams {
+	return mtp.Transfers[n]
+}
+
+func (mtp MultiTransferParams) ToString() string {
+	s := ""
+
+	for i := 0; i < mtp.Multi; i++ {
+		s += mtp.ParamSet(i).ToString() + " "
+	}
+
+	return s
+
+}
+
+func (mtp MultiTransferParams) Dup() MultiTransferParams {
+	/*
+		return MultiTransferParams{
+			What:       dupStringArray(mtp.What),
+			PltFrom:    dupStringArray(mtp.PltFrom),
+			PltTo:      dupStringArray(mtp.PltTo),
+			WellFrom:   dupStringArray(mtp.WellFrom),
+			WellTo:     dupStringArray(mtp.WellTo),
+			Volume:     dupVolArray(mtp.Volume),
+			FVolume:    dupVolArray(mtp.FVolume),
+			TVolume:    dupVolArray(mtp.TVolume),
+			FPlateType: dupStringArray(mtp.FPlateType),
+			TPlateType: dupStringArray(mtp.TPlateType),
+			TipTypes:   dupStringArray(mtp.TipTypes),
+		}
+	*/
+
+	tfrs := make([]TransferParams, 0, mtp.Multi)
+
+	for i := 0; i < mtp.Multi; i++ {
+		tfrs = append(tfrs, mtp.Transfers[i].Dup())
+	}
+
+	ret := NewMultiTransferParams(mtp.Multi)
+
+	ret.Transfers = tfrs
+
+	return ret
+}
+
+func dupStringArray(in []string) []string {
+	out := make([]string, len(in))
+
+	for i := 0; i < len(in); i++ {
+		out[i] = in[i]
+	}
+	return out
+}
+func dupIntArray(in []int) []int {
+	out := make([]int, len(in))
+
+	for i := 0; i < len(in); i++ {
+		out[i] = in[i]
+	}
+	return out
+}
+
+func dupVolArray(in []wunit.Volume) []wunit.Volume {
+	out := make([]wunit.Volume, len(in))
+
+	for i := 0; i < len(in); i++ {
+		out[i] = in[i].Dup()
+	}
+
+	return out
+}

--- a/microArch/driver/liquidhandling/volumeset.go
+++ b/microArch/driver/liquidhandling/volumeset.go
@@ -89,6 +89,10 @@ func (vs VolumeSet) NonZeros() VolumeSet {
 	return vols
 }
 
+func (vs VolumeSet) IsZero() bool {
+	return len(vs.NonZeros()) == 0
+}
+
 func (vs VolumeSet) Min() wunit.Volume {
 	if len(vs) == 0 {
 		return wunit.ZeroVolume()

--- a/microArch/scheduler/liquidhandling/executionplanner3.go
+++ b/microArch/scheduler/liquidhandling/executionplanner3.go
@@ -33,6 +33,7 @@ import (
 // robot here should be a copy... this routine will be destructive of state
 func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhandling.LHProperties) (*LHRequest, error) {
 	ch := request.InstructionChain
+	depth := 0
 
 	for {
 		if ch == nil {
@@ -52,8 +53,11 @@ func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhan
 
 			tfb := liquidhandling.NewTransferBlockInstruction(ch.Values)
 
+			fmt.Println("DEPTH ", depth, " LEN TFB: ", len(ch.Values))
+
 			request.InstructionSet.Add(tfb)
 		}
+		depth += 1
 		ch = ch.Child
 	}
 

--- a/microArch/scheduler/liquidhandling/executionplanner3.go
+++ b/microArch/scheduler/liquidhandling/executionplanner3.go
@@ -33,7 +33,6 @@ import (
 // robot here should be a copy... this routine will be destructive of state
 func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhandling.LHProperties) (*LHRequest, error) {
 	ch := request.InstructionChain
-	depth := 0
 
 	for {
 		if ch == nil {
@@ -55,7 +54,6 @@ func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhan
 
 			request.InstructionSet.Add(tfb)
 		}
-		depth += 1
 		ch = ch.Child
 	}
 

--- a/microArch/scheduler/liquidhandling/executionplanner3.go
+++ b/microArch/scheduler/liquidhandling/executionplanner3.go
@@ -53,8 +53,6 @@ func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhan
 
 			tfb := liquidhandling.NewTransferBlockInstruction(ch.Values)
 
-			fmt.Println("DEPTH ", depth, " LEN TFB: ", len(ch.Values))
-
 			request.InstructionSet.Add(tfb)
 		}
 		depth += 1


### PR DESCRIPTION
This PR contains a refactor of the liquid handling instruction hierarchy to 
change the TransferInstruction class to permit it to define multiple 
multichannel transfers where previously it could define at most one. 

This has the consequence that a single transfer can now generate a block
of multichannel instructions instead of only one. Since tip changes are always
generated at the start of a new block this was causing excessive tip usage. 
Consequently this refactor should allow for considerably more conservative
tip use.

