### PR TITLE
Fix/washes omega

### DIFF
--- a/antha/anthalib/mixer/mixer.go
+++ b/antha/anthalib/mixer/mixer.go
@@ -60,8 +60,6 @@ func Sample(l *wtype.LHComponent, v wunit.Volume) *wtype.LHComponent {
 func SplitSample(l *wtype.LHComponent, v wunit.Volume) (moving, remaining *wtype.LHComponent) {
 	remaining = l.Dup()
 
-	fmt.Println("REMAINING LOC: ", remaining.Loc)
-
 	moving = Sample(remaining, v)
 
 	remaining.Vol -= v.ConvertToString(remaining.Vunit)
@@ -179,13 +177,12 @@ func GenericMix(opt MixOptions) *wtype.LHInstruction {
 		r.AddResult(opt.Result)
 	} else {
 		cmpR := wtype.NewLHComponent()
+		r.AddResult(cmpR)
 
 		if !r.Components[0].IsSample() {
-			// mix-in-place
-			cmpR = r.Components[0].Dup()
+			r.Results[0].Loc = r.Components[0].Loc
 		}
 
-		r.AddResult(cmpR)
 		mx := 0
 		for _, c := range opt.Components {
 			//r.Result.MixPreserveTvol(c)

--- a/antha/anthalib/mixer/mixer.go
+++ b/antha/anthalib/mixer/mixer.go
@@ -60,6 +60,8 @@ func Sample(l *wtype.LHComponent, v wunit.Volume) *wtype.LHComponent {
 func SplitSample(l *wtype.LHComponent, v wunit.Volume) (moving, remaining *wtype.LHComponent) {
 	remaining = l.Dup()
 
+	fmt.Println("REMAINING LOC: ", remaining.Loc)
+
 	moving = Sample(remaining, v)
 
 	remaining.Vol -= v.ConvertToString(remaining.Vunit)
@@ -176,7 +178,14 @@ func GenericMix(opt MixOptions) *wtype.LHInstruction {
 	if opt.Result != nil {
 		r.AddResult(opt.Result)
 	} else {
-		r.AddResult(wtype.NewLHComponent())
+		cmpR := wtype.NewLHComponent()
+
+		if !r.Components[0].IsSample() {
+			// mix-in-place
+			cmpR = r.Components[0].Dup()
+		}
+
+		r.AddResult(cmpR)
 		mx := 0
 		for _, c := range opt.Components {
 			//r.Result.MixPreserveTvol(c)

--- a/antha/anthalib/wtype/lhinstruction.go
+++ b/antha/anthalib/wtype/lhinstruction.go
@@ -13,9 +13,10 @@ const (
 	LHIMIX
 	LHIWAI
 	LHIPRM
+	LHISPL
 )
 
-var InsNames = []string{"END", "MIX", "WAIT", "PROMPT"}
+var InsNames = []string{"END", "MIX", "WAIT", "PROMPT", "SPLIT"}
 
 func InsType(i int) string {
 
@@ -31,7 +32,6 @@ func InsType(i int) string {
 //  high-level instruction to a liquid handler
 type LHInstruction struct {
 	ID               string
-	ProductID        string
 	BlockID          BlockID
 	SName            string
 	Order            int
@@ -45,7 +45,7 @@ type LHInstruction struct {
 	Conc             float64
 	Tvol             float64
 	Majorlayoutgroup int
-	Result           *LHComponent
+	Results          []*LHComponent
 	gen              int
 	PlateName        string
 	OutPlate         *LHPlate
@@ -54,7 +54,17 @@ type LHInstruction struct {
 }
 
 func (ins LHInstruction) String() string {
-	return fmt.Sprint(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductID)
+	return fmt.Sprint(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductIDs())
+}
+
+func (lhi *LHInstruction) ProductIDs() []string {
+	r := make([]string, 0, len(lhi.Results))
+
+	for _, p := range lhi.Results {
+		r = append(r, p.ID)
+	}
+
+	return r
 }
 
 func (lhi *LHInstruction) GetPlateType() string {
@@ -89,6 +99,12 @@ func NewLHPromptInstruction() *LHInstruction {
 	return lhi
 }
 
+func NewLHSplitInstruction() *LHInstruction {
+	lhi := newLHInstruction()
+	lhi.Type = LHISPL
+	return lhi
+}
+
 func (inst *LHInstruction) InsType() string {
 	return InsType(inst.Type)
 }
@@ -98,9 +114,12 @@ func (inst *LHInstruction) GetID() string {
 	return inst.ID
 }
 
+func (ins *LHInstruction) AddResult(cmp *LHComponent) {
+	ins.AddProduct(cmp)
+}
+
 func (inst *LHInstruction) AddProduct(cmp *LHComponent) {
-	inst.Result = cmp
-	inst.ProductID = cmp.ID
+	inst.Results = append(inst.Results, cmp)
 }
 
 func (inst *LHInstruction) AddComponent(cmp *LHComponent) {
@@ -217,8 +236,9 @@ func (ins *LHInstruction) AdjustVolumesBy(r float64) {
 	for _, c := range ins.Components {
 		c.Vol *= r
 	}
-
-	ins.Result.Vol *= r
+	for _, rslt := range ins.Results {
+		rslt.Vol *= r
+	}
 }
 
 func (ins *LHInstruction) InputVolumeMap(addition wunit.Volume) map[string]wunit.Volume {

--- a/antha/compile/antha.go
+++ b/antha/compile/antha.go
@@ -219,6 +219,7 @@ func NewAntha(root *AnthaRoot) *Antha {
 		"Prompt":        "execute.Prompt",
 		"ReadEM":        "execute.ReadEM",
 		"SetInputPlate": "execute.SetInputPlate",
+		"SplitSample":   "execute.SplitSample",
 	}
 
 	p.types = map[string]string{

--- a/execute/intrinsics.go
+++ b/execute/intrinsics.go
@@ -354,7 +354,6 @@ func MixTo(ctx context.Context, outplatetype, address string, platenum int, comp
 // SplitSample is essentially an inverse mix: takes one component and a volume and returns two
 // the question is then over what happens subsequently.. unlike mix this does not have a
 // destination as it's intrinsically a source operation
-
 func SplitSample(ctx context.Context, component *wtype.LHComponent, volume wunit.Volume) (removed, remaining *wtype.LHComponent) {
 	// at this point we cannot guarantee that volumes are accurate
 	// so it's a case of best-efforts

--- a/execute/maker.go
+++ b/execute/maker.go
@@ -45,7 +45,7 @@ func (a *maker) makeCommand(in *commandInst) ast.Node {
 		in.Command.From = append(in.Command.From, a.makeComp(arg))
 	}
 
-	out := a.makeComp(in.result)
+	out := a.makeComp(in.result[0]) // MIS --> may need updating
 	out.From = append(out.From, in.Command)
 	return out
 }

--- a/execute/resolver_test.go
+++ b/execute/resolver_test.go
@@ -27,10 +27,10 @@ func TestUseCompChainThroughSample(t *testing.T) {
 		Components: []*wtype.LHComponent{cmp},
 	}))
 	a2 := mix(ctx, mixer.GenericMix(mixer.MixOptions{
-		Components: []*wtype.LHComponent{mixer.Sample(a1.result, vol)},
+		Components: []*wtype.LHComponent{mixer.Sample(a1.result[0], vol)},
 	}))
 	a3 := mix(ctx, mixer.GenericMix(mixer.MixOptions{
-		Components: []*wtype.LHComponent{mixer.Sample(a2.result, vol)},
+		Components: []*wtype.LHComponent{mixer.Sample(a2.result[0], vol)},
 	}))
 
 	var insts []interface{}

--- a/microArch/driver/liquidhandling/convertinstructions.go
+++ b/microArch/driver/liquidhandling/convertinstructions.go
@@ -340,8 +340,8 @@ func makeTransfers(parallelTransfer ParallelTransfer, cmps []*wtype.LHComponent,
 		wellTo.WContents.Loc = wellTo.Plateid + ":" + wellTo.Crds
 
 		// make sure the wellTo gets the right ID (ultimately)
-		cmpFrom.ReplaceDaughterID(wellTo.WContents.ID, inssIn[ci].Result.ID)
-		wellTo.WContents.ID = inssIn[ci].Result.ID
+		cmpFrom.ReplaceDaughterID(wellTo.WContents.ID, inssIn[ci].Results[0].ID)
+		wellTo.WContents.ID = inssIn[ci].Results[0].ID
 		wellTo.WContents.DeclareInstance()
 		//fmt.Println("ADDED :", cmpFrom.CName, " ", cmpFrom.Vol, " TO ", dstPlate.ID, " ", wt[ci])
 	}

--- a/microArch/driver/liquidhandling/robotinstruction.go
+++ b/microArch/driver/liquidhandling/robotinstruction.go
@@ -86,13 +86,14 @@ const (
 	MBL            // MOV BLO	    ""       ""
 	RAP            // RemoveAllPlates
 	APT            // AddPlateTo
+	SPB            // SplitBlock
 )
 
 func InstructionTypeName(ins RobotInstruction) string {
 	return Robotinstructionnames[ins.InstructionType()]
 }
 
-var Robotinstructionnames = []string{"TFR", "TFB", "SCB", "MCB", "SCT", "MCT", "CCC", "LDT", "UDT", "RST", "CHA", "ASP", "DSP", "BLO", "PTZ", "MOV", "MRW", "LOD", "ULD", "SUK", "BLW", "SPS", "SDS", "INI", "FIN", "WAI", "LON", "LOF", "OPN", "CLS", "LAD", "UAD", "MMX", "MIX", "MSG", "MOVASP", "MOVDSP", "MOVMIX", "MOVBLO", "RAP", "APT"}
+var Robotinstructionnames = []string{"TFR", "TFB", "SCB", "MCB", "SCT", "MCT", "CCC", "LDT", "UDT", "RST", "CHA", "ASP", "DSP", "BLO", "PTZ", "MOV", "MRW", "LOD", "ULD", "SUK", "BLW", "SPS", "SDS", "INI", "FIN", "WAI", "LON", "LOF", "OPN", "CLS", "LAD", "UAD", "MMX", "MIX", "MSG", "MOVASP", "MOVDSP", "MOVMIX", "MOVBLO", "RAP", "APT", "SPB"}
 
 var RobotParameters = []string{"HEAD", "CHANNEL", "LIQUIDCLASS", "POSTO", "WELLFROM", "WELLTO", "REFERENCE", "VOLUME", "VOLUNT", "FROMPLATETYPE", "WELLFROMVOLUME", "POSFROM", "WELLTOVOLUME", "TOPLATETYPE", "MULTI", "WHAT", "LLF", "PLT", "TOWELLVOLUME", "OFFSETX", "OFFSETY", "OFFSETZ", "TIME", "SPEED", "MESSAGE", "COMPONENT"}
 

--- a/microArch/driver/liquidhandling/splitblock.go
+++ b/microArch/driver/liquidhandling/splitblock.go
@@ -1,0 +1,32 @@
+package liquidhandling
+
+import (
+	"context"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+)
+
+type SplitBlockInstruction struct {
+	GenericRobotInstruction
+	Inss []*wtype.LHInstruction
+}
+
+func NewSplitBlockInstruction(inss []*wtype.LHInstruction) SplitBlockInstruction {
+	sb := SplitBlockInstruction{}
+	sb.Inss = inss
+	sb.GenericRobotInstruction.Ins = RobotInstruction(&sb)
+	return sb
+}
+
+func (sp SplitBlockInstruction) InstructionType() int {
+	return SPB
+}
+
+func (sp SplitBlockInstruction) GetParameter(p string) interface{} {
+	return nil
+}
+
+// this instruction does not generate anything
+// it just modifies the components in the robot
+func (sp SplitBlockInstruction) Generate(ctx context.Context, policy *wtype.LHPolicyRuleSet, robot *LHProperties) ([]RobotInstruction, error) {
+	return []RobotInstruction{}, nil
+}

--- a/microArch/driver/liquidhandling/splitblock.go
+++ b/microArch/driver/liquidhandling/splitblock.go
@@ -2,6 +2,7 @@ package liquidhandling
 
 import (
 	"context"
+	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 )
 
@@ -28,5 +29,17 @@ func (sp SplitBlockInstruction) GetParameter(p string) interface{} {
 // this instruction does not generate anything
 // it just modifies the components in the robot
 func (sp SplitBlockInstruction) Generate(ctx context.Context, policy *wtype.LHPolicyRuleSet, robot *LHProperties) ([]RobotInstruction, error) {
+	// this may need more work
+
+	for _, ins := range sp.Inss {
+		if ins.Type != wtype.LHISPL {
+			return []RobotInstruction{}, fmt.Errorf("Splitblock fed non-split instruction, type %s", ins.InsType())
+		}
+
+		// if Components is a sample we'll probably want to change ParentID instead
+		// that may not work
+		robot.UpdateComponentID(ins.Components[0].ID, ins.Results[1])
+	}
+
 	return []RobotInstruction{}, nil
 }

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -168,7 +168,7 @@ type InsByComponent []*wtype.LHInstruction
 func (ibc InsByComponent) Len() int      { return len(ibc) }
 func (ibc InsByComponent) Swap(i, j int) { ibc[i], ibc[j] = ibc[j], ibc[i] }
 func (ibc InsByComponent) Less(i, j int) bool {
-	return strings.Compare(ibc[i].Result.CName, ibc[j].Result.CName) < 0
+	return strings.Compare(ibc[i].Results[0].CName, ibc[j].Results[0].CName) < 0
 }
 
 type InsByRow []*wtype.LHInstruction

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -43,7 +43,7 @@ func getTransferBlock2Component(ctx context.Context) (TransferBlockInstruction, 
 
 		c3 := c.Dup()
 		c3.Mix(c2)
-		ins.Result = c3
+		ins.AddResult(c3)
 
 		ins.Platetype = "pcrplate_skirted_riser40"
 		ins.Welladdress = wutil.NumToAlpha(i+1) + "1"
@@ -100,8 +100,7 @@ func getTransferBlock3Component(ctx context.Context) (TransferBlockInstruction, 
 		c4 := c.Dup()
 		c4.Mix(c2)
 		c4.Mix(c3)
-
-		ins.Result = c4
+		ins.AddResult(c4)
 
 		ins.Platetype = "pcrplate_skirted_riser40"
 		ins.Welladdress = wutil.NumToAlpha(i+1) + "1"

--- a/microArch/scheduler/liquidhandling/determinism_test.go
+++ b/microArch/scheduler/liquidhandling/determinism_test.go
@@ -28,7 +28,7 @@ func configure_request_quitebig(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
 		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(43.0, "ul")))
-		ins.Result.CName = fmt.Sprintf("DANGER_MIX_%d", k)
+		ins.Results[0].CName = fmt.Sprintf("DANGER_MIX_%d", k)
 		ins.SetGeneration(k + 1)
 		rq.Add_instruction(ins)
 	}

--- a/microArch/scheduler/liquidhandling/executionhelpers.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers.go
@@ -152,7 +152,7 @@ func (bg ByGenerationOpt) Less(i, j int) bool {
 	if bg[i].Generation() == bg[j].Generation() {
 
 		// compare the names of the resultant components
-		c := strings.Compare(bg[i].Result.CName, bg[j].Result.CName)
+		c := strings.Compare(bg[i].Results[0].CName, bg[j].Results[0].CName)
 
 		if c != 0 {
 			return c < 0
@@ -214,7 +214,7 @@ func (bg ByResultComponent) Less(i, j int) bool {
 	}
 
 	// compare the names of the resultant components
-	c = strings.Compare(bg[i].Result.CName, bg[j].Result.CName)
+	c = strings.Compare(bg[i].Results[0].CName, bg[j].Results[0].CName)
 
 	if c != 0 {
 		return c < 0
@@ -440,11 +440,11 @@ func aggregatePromptsWithSameMessage(inss []*wtype.LHInstruction, topolGraph gra
 		for _, ar := range iar {
 			ins := wtype.NewLHPromptInstruction()
 			ins.Message = msg
-			ins.Result = wtype.NewLHComponent()
+			ins.AddResult(wtype.NewLHComponent())
 			for _, ins2 := range ar {
 				for _, cmp := range ins2.Components {
 					ins.Components = append(ins.Components, cmp)
-					ins.PassThrough[cmp.ID] = ins2.Result
+					ins.PassThrough[cmp.ID] = ins2.Results[0]
 				}
 			}
 			insOut = append(insOut, graph.Node(ins))
@@ -713,7 +713,7 @@ func ConvertInstruction(insIn *wtype.LHInstruction, robot *driver.LHProperties, 
 			wlt.Add(vd)
 
 			// TODO -- danger here, is result definitely set?
-			wlt.WContents.ID = insIn.Result.ID
+			wlt.WContents.ID = insIn.Results[0].ID
 			wlf.WContents.AddDaughterComponent(wlt.WContents)
 
 			//fmt.Println("HERE GOES: ", i, wh[i], vf[i].ToString(), vt[i].ToString(), va[i].ToString(), pt[i], wt[i], pf[i], wf[i], pfwx[i], pfwy[i], ptwx[i], ptwy[i])

--- a/microArch/scheduler/liquidhandling/executionplanner3.go
+++ b/microArch/scheduler/liquidhandling/executionplanner3.go
@@ -32,7 +32,7 @@ import (
 
 func allSplits(inss []*wtype.LHInstruction) bool {
 	for _, ins := range inss {
-		if inss.Type != wtype.LHISPL {
+		if ins.Type != wtype.LHISPL {
 			return false
 		}
 	}
@@ -41,7 +41,7 @@ func allSplits(inss []*wtype.LHInstruction) bool {
 
 func hasSplit(inss []*wtype.LHInstruction) bool {
 	for _, ins := range inss {
-		if inss.Type == wtype.LHISPL {
+		if ins.Type == wtype.LHISPL {
 			return true
 		}
 	}
@@ -67,8 +67,10 @@ func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhan
 				insTypes := func(inss []*wtype.LHInstruction) string {
 					s := ""
 					for _, ins := range inss {
-						s += wtype.InstructionString() + " "
+						s += ins.InsType() + " "
 					}
+
+					return s
 				}
 				return nil, fmt.Errorf("Internal error: Failure in instruction sorting - got types %s in layer starting with split", insTypes(ch.Values))
 			}

--- a/microArch/scheduler/liquidhandling/executionplanner3.go
+++ b/microArch/scheduler/liquidhandling/executionplanner3.go
@@ -30,6 +30,24 @@ import (
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 )
 
+func allSplits(inss []*wtype.LHInstruction) bool {
+	for _, ins := range inss {
+		if inss.Type != wtype.LHISPL {
+			return false
+		}
+	}
+	return true
+}
+
+func hasSplit(inss []*wtype.LHInstruction) bool {
+	for _, ins := range inss {
+		if inss.Type == wtype.LHISPL {
+			return true
+		}
+	}
+	return false
+}
+
 // robot here should be a copy... this routine will be destructive of state
 func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhandling.LHProperties) (*LHRequest, error) {
 	ch := request.InstructionChain
@@ -44,6 +62,19 @@ func ExecutionPlanner3(ctx context.Context, request *LHRequest, robot *liquidhan
 			request.InstructionSet.Add(prm)
 			//		robot.UpdateComponentIDs(ch.Values[0].PassThrough)
 			// thhis is now done in the generation process
+		} else if hasSplit(ch.Values) {
+			if !allSplits(ch.Values) {
+				insTypes := func(inss []*wtype.LHInstruction) string {
+					s := ""
+					for _, ins := range inss {
+						s += wtype.InstructionString() + " "
+					}
+				}
+				return nil, fmt.Errorf("Internal error: Failure in instruction sorting - got types %s in layer starting with split", insTypes(ch.Values))
+			}
+
+			splitBlock := liquidhandling.NewSplitBlockInstruction(ch.Values)
+			request.InstructionSet.Add(splitBlock)
 		} else {
 			// otherwise...
 			// make a transfer block instruction out of the incoming instructions

--- a/microArch/scheduler/liquidhandling/fixvolumes.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes.go
@@ -69,9 +69,9 @@ func passThroughMap(ins *wtype.LHInstruction, wanted, updated map[string]wunit.V
 func findUpdateInstructionVolumes(ch *IChain, wanted map[string]wunit.Volume, plates map[string]*wtype.LHPlate) (map[string]wunit.Volume, error) {
 	newWanted := make(map[string]wunit.Volume)
 	for _, ins := range ch.Values {
-		//wantVol, ok := wanted[ins.Result.FullyQualifiedName()]
+		//wantVol, ok := wanted[ins.Results[0].FullyQualifiedName()]
 
-		wantVol, ok := getWantVol(wanted, ins.Result.FullyQualifiedName())
+		wantVol, ok := getWantVol(wanted, ins.Results[0].FullyQualifiedName())
 
 		if ok {
 			_, reallyOK := plates[ins.PlateID]
@@ -80,16 +80,16 @@ func findUpdateInstructionVolumes(ch *IChain, wanted map[string]wunit.Volume, pl
 				if ins.PlateID != "" {
 					panic("Cannot fix volume for plate ID without corresponding type")
 				}
-			} else if !wantInPlace(wanted, ins.Result.FullyQualifiedName()) {
+			} else if !wantInPlace(wanted, ins.Results[0].FullyQualifiedName()) {
 				wantVol.Add(plates[ins.PlateID].Rows[0][0].ResidualVolume())
 			}
 
-			if wantVol.GreaterThan(ins.Result.Volume()) {
-				r := wantVol.RawValue() / ins.Result.Volume().ConvertTo(wantVol.Unit())
+			if wantVol.GreaterThan(ins.Results[0].Volume()) {
+				r := wantVol.RawValue() / ins.Results[0].Volume().ConvertTo(wantVol.Unit())
 				ins.AdjustVolumesBy(r)
 
-				//delete(wanted, ins.Result.FullyQualifiedName())
-				deleteWantOf(wanted, ins.Result.FullyQualifiedName())
+				//delete(wanted, ins.Results[0].FullyQualifiedName())
+				deleteWantOf(wanted, ins.Results[0].FullyQualifiedName())
 			}
 		}
 

--- a/microArch/scheduler/liquidhandling/fixvolumes_test.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes_test.go
@@ -76,8 +76,8 @@ func TestFixVolumes(t *testing.T) {
 
 	mix1 := req.InstructionChain.Values[0]
 
-	if mix1.Result.Vol != 155.0 {
-		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Result.Volume()))
+	if mix1.Results[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
 	}
 }
 
@@ -195,8 +195,8 @@ func TestFixVolumes3(t *testing.T) {
 
 	mix1 := req.InstructionChain.Values[0]
 
-	if mix1.Result.Vol != 155.0 {
-		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Result.Volume()))
+	if mix1.Results[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
 	}
 }
 

--- a/microArch/scheduler/liquidhandling/fixvolumes_test.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes_test.go
@@ -27,8 +27,7 @@ func TestFixVolumes(t *testing.T) {
 
 	ins := wtype.NewLHMixInstruction()
 	ins.Components = []*wtype.LHComponent{c1, c2}
-	ins.Result = c3
-	ins.ProductID = ins.Result.ID
+	ins.AddResult(c3)
 
 	req.LHInstructions[ins.ID] = ins
 
@@ -57,9 +56,8 @@ func TestFixVolumes(t *testing.T) {
 		ins.Components = []*wtype.LHComponent{smp}
 		res := getComponentWithNameVolume("water+milk", 15.0)
 		res.ParentID = ins.Components[0].ID
-		ins.Result = res
-		ins.Result.DeclareInstance()
-		ins.ProductID = ins.Result.ID
+		res.DeclareInstance()
+		ins.AddResult(res)
 		req.LHInstructions[ins.ID] = ins
 		inss = append(inss, ins)
 	}
@@ -95,8 +93,7 @@ func TestFixVolumes2(t *testing.T) {
 
 	ins := wtype.NewLHMixInstruction()
 	ins.Components = []*wtype.LHComponent{c1, c2}
-	ins.Result = c3
-	ins.ProductID = ins.Result.ID
+	ins.AddResult(c3)
 
 	inss := []*wtype.LHInstruction{ins}
 
@@ -131,8 +128,7 @@ func TestFixVolumes3(t *testing.T) {
 	ins := wtype.NewLHMixInstruction()
 	ins.Components = []*wtype.LHComponent{c1}
 
-	ins.Result = c3
-	ins.ProductID = ins.Result.ID
+	ins.AddResult(c3)
 	req.LHInstructions[ins.ID] = ins
 
 	ic := &IChain{
@@ -151,8 +147,7 @@ func TestFixVolumes3(t *testing.T) {
 	ins.Components = []*wtype.LHComponent{c3, c2}
 	c4 := c3.Dup()
 	c3.Mix(c2)
-	ins.Result = c4
-	ins.ProductID = ins.Result.ID
+	ins.AddResult(c4)
 	req.LHInstructions[ins.ID] = ins
 
 	ic = &IChain{
@@ -180,9 +175,8 @@ func TestFixVolumes3(t *testing.T) {
 		ins.Components = []*wtype.LHComponent{smp}
 		res := getComponentWithNameVolume("water+milk", 15.0)
 		res.ParentID = ins.Components[0].ID
-		ins.Result = res
-		ins.Result.DeclareInstance()
-		ins.ProductID = ins.Result.ID
+		res.DeclareInstance()
+		ins.AddResult(res)
 		req.LHInstructions[ins.ID] = ins
 		inss = append(inss, ins)
 	}
@@ -217,8 +211,7 @@ func TestFixVolumes4(t *testing.T) {
 	ins := wtype.NewLHMixInstruction()
 	ins.Components = []*wtype.LHComponent{c1}
 
-	ins.Result = c3
-	ins.ProductID = ins.Result.ID
+	ins.AddResult(c3)
 	req.LHInstructions[ins.ID] = ins
 
 	ic := &IChain{
@@ -249,8 +242,7 @@ func TestFixVolumes4(t *testing.T) {
 	c5.Vol = 200.0
 
 	ins.Components = []*wtype.LHComponent{c4}
-	ins.Result = c5
-	ins.ProductID = c5.ID
+	ins.AddResult(c5)
 
 	ic.Child.Child = &IChain{
 		Parent: ic.Child,

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -3,6 +3,7 @@ package liquidhandling
 import (
 	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"strings"
 )
 
 type IChain struct {
@@ -104,7 +105,7 @@ func (it *IChain) Print() {
 				for i := 0; i < len(it.Values[j].Components); i++ {
 					fmt.Print(" ", it.Values[j].Components[i].FullyQualifiedName(), "@", it.Values[j].Components[i].Volume().ToString(), " ")
 				}
-				fmt.Print(":", it.Values[j].Result.ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
+				fmt.Print(":", it.Values[j].Results[0].ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
 				fmt.Printf("-- ")
 			} else if it.Values[j].Type == wtype.LHIPRM {
 				fmt.Print("PROMPT ", it.Values[j].Message, "-- ")
@@ -137,7 +138,7 @@ func (it *IChain) ProductIDs() string {
 	s := ""
 
 	for _, ins := range it.Values {
-		s += ins.ProductID + "   "
+		s += strings.Join(ins.ProductIDs(), " ") + "   "
 	}
 	return s
 }

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -23,6 +23,15 @@ func NewIChain(parent *IChain) *IChain {
 	return &it
 }
 
+// depth from here
+func (it *IChain) Height() int {
+	if it == nil {
+		return 0
+	}
+
+	return it.Child.Height() + 1
+}
+
 func (it *IChain) PruneOut(Remove map[string]bool) *IChain {
 	if it == nil || len(Remove) == 0 || len(it.Values) == 0 {
 		return it
@@ -109,6 +118,12 @@ func (it *IChain) Print() {
 				fmt.Printf("-- ")
 			} else if it.Values[j].Type == wtype.LHIPRM {
 				fmt.Print("PROMPT ", it.Values[j].Message, "-- ")
+			} else if it.Values[j].Type == wtype.LHISPL {
+				fmt.Printf("SPLIT %2d: %s ", j, it.Values[j].ID)
+				fmt.Print(" ", it.Values[j].Components[0].FullyQualifiedName(), " : ", it.Values[j].PlateName, " ", it.Values[j].Welladdress, " ")
+				fmt.Print(" MOVE:", it.Values[j].Results[0].FullyQualifiedName(), "@", it.Values[j].Results[0].Volume().ToString())
+				fmt.Print(" STAY:", it.Values[j].Results[1].FullyQualifiedName(), "@", it.Values[j].Results[1].Volume().ToString())
+				fmt.Printf("-- ")
 			} else {
 				fmt.Print("WTF?   ", wtype.InsType(it.Values[j].Type), "-- ")
 			}

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -112,17 +112,20 @@ func (it *IChain) Print() {
 			if it.Values[j].Type == wtype.LHIMIX {
 				fmt.Printf("MIX    %2d: %s ", j, it.Values[j].ID)
 				for i := 0; i < len(it.Values[j].Components); i++ {
-					fmt.Print(" ", it.Values[j].Components[i].FullyQualifiedName(), "@", it.Values[j].Components[i].Volume().ToString(), " ")
+					fmt.Print(" ", it.Values[j].Components[i].ID, ":", it.Values[j].Components[i].FullyQualifiedName(), "@", it.Values[j].Components[i].Volume().ToString(), " ")
 				}
 				fmt.Print(":", it.Values[j].Results[0].ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
 				fmt.Printf("-- ")
 			} else if it.Values[j].Type == wtype.LHIPRM {
 				fmt.Print("PROMPT ", it.Values[j].Message, "-- ")
+				for in, out := range it.Values[j].PassThrough {
+					fmt.Print(in, ":::", out.ID, " --")
+				}
 			} else if it.Values[j].Type == wtype.LHISPL {
 				fmt.Printf("SPLIT %2d: %s ", j, it.Values[j].ID)
-				fmt.Print(" ", it.Values[j].Components[0].FullyQualifiedName(), " : ", it.Values[j].PlateName, " ", it.Values[j].Welladdress, " ")
-				fmt.Print(" MOVE:", it.Values[j].Results[0].FullyQualifiedName(), "@", it.Values[j].Results[0].Volume().ToString())
-				fmt.Print(" STAY:", it.Values[j].Results[1].FullyQualifiedName(), "@", it.Values[j].Results[1].Volume().ToString())
+				fmt.Print(" ", it.Values[j].Components[0].ID, ":", it.Values[j].Components[0].FullyQualifiedName(), " : ", it.Values[j].PlateName, " ", it.Values[j].Welladdress, " ")
+				fmt.Print(" MOVE:", it.Values[j].Results[0].ID, ":", it.Values[j].Results[0].FullyQualifiedName(), "@", it.Values[j].Results[0].Volume().ToString())
+				fmt.Print(" STAY:", it.Values[j].Results[1].ID, ":", it.Values[j].Results[1].FullyQualifiedName(), "@", it.Values[j].Results[1].Volume().ToString())
 				fmt.Printf("-- ")
 			} else {
 				fmt.Print("WTF?   ", wtype.InsType(it.Values[j].Type), "-- ")

--- a/microArch/scheduler/liquidhandling/ichain_test.go
+++ b/microArch/scheduler/liquidhandling/ichain_test.go
@@ -19,7 +19,7 @@ func TestIChain(t *testing.T) {
 		cmp.ID = k
 
 		ins.AddComponent(cmp)
-		ins.Result = wtype.NewLHComponent()
+		ins.AddResult(wtype.NewLHComponent())
 		chain.Add(ins)
 	}
 }
@@ -52,7 +52,7 @@ func TestIChain2(t *testing.T) {
 		if i != len(s)-1 {
 			ins.AddProduct(cmps[i+1])
 		} else {
-			ins.Result = wtype.NewLHComponent()
+			ins.AddResult(wtype.NewLHComponent())
 		}
 		chain.Add(ins)
 	}

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -247,7 +247,7 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 		}
 
 		lkp[v.ID] = make([]*wtype.LHComponent, 0, 1) //v.Result
-		lk2[v.Result.ID] = v.ID
+		lk2[v.Results[0].ID] = v.ID
 	}
 
 	for _, id := range order {
@@ -265,7 +265,7 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 		}
 
 		// now we put the actual result in
-		lkp[v.ID] = append(lkp[v.ID], v.Result)
+		lkp[v.ID] = append(lkp[v.ID], v.Results[0])
 	}
 
 	sampletracker := sampletracker.GetSampleTracker()
@@ -428,8 +428,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 			request.LHInstructions[k].SetPlateID(tx[0])
 			request.LHInstructions[k].Platetype = lookUp.Type
 			request.LHInstructions[k].OutPlate = lookUp
-
-			request.LHInstructions[k].Result.Loc = addr
+			request.LHInstructions[k].Results[0].Loc = addr
 
 			// same as condition 1 except we get the plate id somewhere else
 			i := defined(tx[0], s)
@@ -446,7 +445,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 						if s[i].Output[i2] {
 							s[i].Assigned[i2] = v.ID
 						} else {
-							s[i].Assigned[i2] = v.ProductID
+							s[i].Assigned[i2] = v.ProductIDs()[0]
 						}
 					*/
 					s[i].Assigned[i2] = v.ID

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -233,9 +233,8 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 	for _, id := range order {
 		v := request.LHInstructions[id]
 		// pass ID through chain if not a mix
-		if v.Type != wtype.LHIMIX {
-			// the current contract on non-mix instructions is to pass in just one
-			// component as an input and one as an output
+		if v.Type == wtype.LHIPRM {
+			// the current contract on prompt instructions is to pass through a set of components
 			// on which basis we need only make sure the result has the same location
 			// as the input
 			// set pass throughs
@@ -244,6 +243,10 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 				v.PassThrough[v.Components[i].ID].Loc = v.Components[i].Loc
 			}
 			continue
+		} else if v.Type == wtype.LHISPL {
+			// similar to the above, just ensure the results both have the right location set
+			v.Results[0].Loc = v.Components[0].Loc
+			v.Results[1].Loc = v.Components[0].Loc
 		}
 
 		lkp[v.ID] = make([]*wtype.LHComponent, 0, 1) //v.Result
@@ -401,6 +404,8 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 			if len(v.Components) == 0 {
 				continue
 			}
+
+			fmt.Println("MIX IN PLACE FOR ", v.Components[0].CName, " ID: ", v.Components[0].ID, " R: ", v.Results[0].CName, " ", v.Results[0].Loc)
 
 			if v.Components[0].Loc == "" {
 				addr, ok := st.GetLocationOf(v.Components[0].ID)

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -405,8 +405,6 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 				continue
 			}
 
-			fmt.Println("MIX IN PLACE FOR ", v.Components[0].CName, " ID: ", v.Components[0].ID, " R: ", v.Results[0].CName, " ", v.Results[0].Loc)
-
 			if v.Components[0].Loc == "" {
 				addr, ok := st.GetLocationOf(v.Components[0].ID)
 

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -510,7 +510,7 @@ func checkSanityIns(request *LHRequest) {
 					v.Add(c.Volume())
 				} else if c.Tvol != 0.0 {
 					if !tv.IsZero() && !tv.EqualTo(c.TotalVolume()) {
-						fmt.Println("ERROR: MULTIPLE DISTINCT TOTAL VOLUMES SPECIFIED FOR ", ins.ID, " ", ins.Result.CName, " COMPONENT ", c)
+						fmt.Println("ERROR: MULTIPLE DISTINCT TOTAL VOLUMES SPECIFIED FOR ", ins.ID, " ", ins.Results[0].CName, " COMPONENT ", c)
 						good = false
 					}
 
@@ -518,11 +518,11 @@ func checkSanityIns(request *LHRequest) {
 				}
 			}
 
-			if tv.IsZero() && !v.EqualTo(ins.Result.Volume()) {
-				fmt.Println("OH DEAR DEAR DEAR: VOLUME INCONSISTENCY FOR ", ins.ID, " ", ins.Result.CName, " COMP: ", v, " PROD: ", ins.Result.Volume())
+			if tv.IsZero() && !v.EqualTo(ins.Results[0].Volume()) {
+				fmt.Println("OH DEAR DEAR DEAR: VOLUME INCONSISTENCY FOR ", ins.ID, " ", ins.Results[0].CName, " COMP: ", v, " PROD: ", ins.Results[0].Volume())
 				good = false
-			} else if !tv.IsZero() && !tv.EqualTo(ins.Result.Volume()) {
-				fmt.Println("ERROR: VOLUME INCONSISTENCY FOR ", ins.ID, " ", ins.Result.CName, " COMP: ", tv, " PROD: ", ins.Result.Volume())
+			} else if !tv.IsZero() && !tv.EqualTo(ins.Results[0].Volume()) {
+				fmt.Println("ERROR: VOLUME INCONSISTENCY FOR ", ins.ID, " ", ins.Results[0].CName, " COMP: ", tv, " PROD: ", ins.Results[0].Volume())
 				good = false
 			} else if ins.PlateID != "" {
 				// compare result volume to the well volume
@@ -531,8 +531,8 @@ func checkSanityIns(request *LHRequest) {
 
 				if !ok {
 					// possibly an issue
-				} else if plat.Welltype.MaxVolume().LessThan(ins.Result.Volume()) {
-					fmt.Println("WARNING: EXCESS VOLUME REQUIRED FOR ", ins.ID, " ", ins.Result.CName, " WANT: ", ins.Result.Volume(), " MAX FOR PLATE OF TYPE ", plat.Type, ": ", plat.Welltype.MaxVolume())
+				} else if plat.Welltype.MaxVolume().LessThan(ins.Results[0].Volume()) {
+					fmt.Println("WARNING: EXCESS VOLUME REQUIRED FOR ", ins.ID, " ", ins.Results[0].CName, " WANT: ", ins.Results[0].Volume(), " MAX FOR PLATE OF TYPE ", plat.Type, ": ", plat.Welltype.MaxVolume())
 					//good = false
 				}
 			}
@@ -601,13 +601,13 @@ func anotherSanityCheck(request *LHRequest) {
 			p[c] = ins
 		}
 
-		ins2, ok := p[ins.Result]
+		ins2, ok := p[ins.Results[0]]
 
 		if ok {
-			panic(fmt.Sprintf("POINTER REUSE: Instructions %s %s for component %s %s", ins.ID, ins2.ID, ins.Result.ID, ins.Result.CName))
+			panic(fmt.Sprintf("POINTER REUSE: Instructions %s %s for component %s %s", ins.ID, ins2.ID, ins.Results[0].ID, ins.Results[0].CName))
 		}
 
-		p[ins.Result] = ins
+		p[ins.Results[0]] = ins
 	}
 }
 
@@ -617,7 +617,7 @@ func forceSanity(request *LHRequest) {
 			ins.Components[i] = ins.Components[i].Dup()
 		}
 
-		ins.Result = ins.Result.Dup()
+		ins.Results[0] = ins.Results[0].Dup()
 	}
 }
 
@@ -633,7 +633,7 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 	if request.Options.PrintInstructions {
 		for _, insID := range request.Output_order {
 			ins := request.LHInstructions[insID]
-			fmt.Print(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", wtype.ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductID)
+			fmt.Print(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", wtype.ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductIDs())
 
 			if ins.IsMixInPlace() {
 				fmt.Print(" INPLACE")
@@ -693,7 +693,7 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 			fmt.Println("")
 			for _, insID := range request.Output_order {
 				ins := request.LHInstructions[insID]
-				fmt.Print(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", wtype.ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductID)
+				fmt.Print(ins.InsType(), " G:", ins.Generation(), " ", ins.ID, " ", wtype.ComponentVector(ins.Components), " ", ins.PlateName, " ID(", ins.PlateID, ") ", ins.Welladdress, ": ", ins.ProductIDs())
 
 				if ins.IsMixInPlace() {
 					fmt.Print(" INPLACE")
@@ -1065,7 +1065,7 @@ func (lh *Liquidhandler) fix_post_names(rq *LHRequest) error {
 			continue
 		}
 
-		tx := strings.Split(inst.Result.Loc, ":")
+		tx := strings.Split(inst.Results[0].Loc, ":")
 		newid, ok := lh.plateIDMap[tx[0]]
 		if !ok {
 			return wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("No output plate mapped to %s", tx[0]))
@@ -1089,13 +1089,13 @@ func (lh *Liquidhandler) fix_post_names(rq *LHRequest) error {
 		oldInst := assignment[well]
 		if oldInst == nil {
 			assignment[well] = inst
-		} else if prev, cur := oldInst.Result.Generation(), inst.Result.Generation(); prev < cur {
+		} else if prev, cur := oldInst.Results[0].Generation(), inst.Results[0].Generation(); prev < cur {
 			assignment[well] = inst
 		}
 	}
 
 	for well, inst := range assignment {
-		well.WContents.CName = inst.Result.CName
+		well.WContents.CName = inst.Results[0].CName
 	}
 
 	return nil

--- a/microArch/scheduler/liquidhandling/set_output_order_test.go
+++ b/microArch/scheduler/liquidhandling/set_output_order_test.go
@@ -1,0 +1,70 @@
+package liquidhandling
+
+import (
+	"github.com/antha-lang/antha/antha/anthalib/mixer"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"testing"
+)
+
+func TestSetOutputOrder(t *testing.T) {
+	// we go mix, prompt, split, mix
+
+	rq := GetLHRequestForTest()
+
+	c1 := wtype.NewLHComponent()
+	c1.CName = "water"
+	c1.Vol = 10
+
+	c2 := wtype.NewLHComponent()
+	c2.CName = "washBuffer"
+	c2.Vol = 20
+
+	c3 := c1.Dup()
+	c3.Mix(c2)
+
+	ins := wtype.NewLHMixInstruction()
+	ins.AddComponent(c1)
+	ins.AddComponent(c2)
+	ins.AddProduct(c3)
+
+	rq.LHInstructions[ins.ID] = ins
+
+	c4 := c3.Cp()
+	c4.ParentID = c3.ID
+	c3.DaughterID = c4.ID
+
+	prm := wtype.NewLHPromptInstruction()
+	prm.Message = "Wait for 10 minutes"
+	prm.AddComponent(c3)
+	prm.AddResult(c4)
+
+	rq.LHInstructions[prm.ID] = prm
+
+	split := wtype.NewLHSplitInstruction()
+	c5, c4a := mixer.SplitSample(c4, wunit.NewVolume(10, "ul"))
+
+	split.AddComponent(c4)
+	split.AddProduct(c5)
+	split.AddProduct(c4a)
+
+	rq.LHInstructions[split.ID] = split
+
+	mix2 := wtype.NewLHMixInstruction()
+	// put them back together again!
+
+	c6 := c4a.Dup()
+	c6.Mix(c5)
+
+	mix2.AddComponent(c4a)
+	mix2.AddComponent(c5)
+	mix2.AddProduct(c6)
+
+	rq.LHInstructions[mix2.ID] = mix2
+
+	set_output_order(rq)
+
+	if rq.InstructionChain.Height() != 4 {
+		t.Errorf("Expected instruction chain of length 4, instead got %d", rq.InstructionChain.Height())
+	}
+}

--- a/microArch/scheduler/liquidhandling/set_output_order_test.go
+++ b/microArch/scheduler/liquidhandling/set_output_order_test.go
@@ -1,9 +1,11 @@
 package liquidhandling
 
 import (
+	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"reflect"
 	"testing"
 )
 
@@ -23,12 +25,16 @@ func TestSetOutputOrder(t *testing.T) {
 	c3 := c1.Dup()
 	c3.Mix(c2)
 
-	ins := wtype.NewLHMixInstruction()
-	ins.AddComponent(c1)
-	ins.AddComponent(c2)
-	ins.AddProduct(c3)
+	expectedIDOrder := make([]string, 0, 5)
 
-	rq.LHInstructions[ins.ID] = ins
+	mix1 := wtype.NewLHMixInstruction()
+	mix1.AddComponent(c1)
+	mix1.AddComponent(c2)
+	mix1.AddProduct(c3)
+
+	expectedIDOrder = append(expectedIDOrder, mix1.ID)
+
+	rq.LHInstructions[mix1.ID] = mix1
 
 	c4 := c3.Cp()
 	c4.ParentID = c3.ID
@@ -38,6 +44,8 @@ func TestSetOutputOrder(t *testing.T) {
 	prm.Message = "Wait for 10 minutes"
 	prm.AddComponent(c3)
 	prm.AddResult(c4)
+
+	expectedIDOrder = append(expectedIDOrder, "PROMPT") // ID changes but there's only one
 
 	rq.LHInstructions[prm.ID] = prm
 
@@ -51,20 +59,71 @@ func TestSetOutputOrder(t *testing.T) {
 	rq.LHInstructions[split.ID] = split
 
 	mix2 := wtype.NewLHMixInstruction()
-	// put them back together again!
 
-	c6 := c4a.Dup()
-	c6.Mix(c5)
+	c6 := wtype.NewLHComponent()
+	c6.CName = "turps"
+	c6.Vol = 100
 
-	mix2.AddComponent(c4a)
+	// mix the sample with c6
+
+	c7 := c6.Dup()
+	c7.Mix(c5)
+
+	mix2.AddComponent(c6)
 	mix2.AddComponent(c5)
-	mix2.AddProduct(c6)
+	mix2.AddProduct(c7)
+
+	expectedIDOrder = append(expectedIDOrder, mix2.ID)
+	expectedIDOrder = append(expectedIDOrder, split.ID)
 
 	rq.LHInstructions[mix2.ID] = mix2
 
+	// mix the static component with some more water
+
+	c8 := wtype.NewLHComponent()
+	c8.CName = "water"
+	c8.Vol = 200
+
+	c9 := c4a.Dup()
+	c9.Mix(c8)
+
+	mix3 := wtype.NewLHMixInstruction()
+	mix3.AddComponent(c4a)
+	mix3.AddComponent(c8)
+	mix3.AddProduct(c9)
+
+	expectedIDOrder = append(expectedIDOrder, mix3.ID)
+
+	rq.LHInstructions[mix3.ID] = mix3
+
 	set_output_order(rq)
 
-	if rq.InstructionChain.Height() != 4 {
-		t.Errorf("Expected instruction chain of length 4, instead got %d", rq.InstructionChain.Height())
+	if rq.InstructionChain.Height() != 5 {
+		t.Errorf("Expected instruction chain of length 5, instead got %d", rq.InstructionChain.Height())
 	}
+
+	gotIDOrder := flatten(rq.InstructionChain)
+
+	if !reflect.DeepEqual(expectedIDOrder, gotIDOrder) {
+		t.Errorf(fmt.Sprintf("Expected %v got %v", expectedIDOrder, gotIDOrder))
+	}
+
+}
+
+func flatten(ic *IChain) []string {
+	if ic == nil {
+		return []string{}
+	}
+
+	r := make([]string, 0, len(ic.Values))
+
+	for _, v := range ic.Values {
+		if v.Type == wtype.LHIPRM {
+			r = append(r, "PROMPT")
+		} else {
+			r = append(r, v.ID)
+		}
+	}
+
+	return append(r, flatten(ic.Child)...)
 }

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -115,7 +115,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 			if ins.Type != wtype.LHIMIX {
 				continue
 			}
-			tx := strings.Split(ins.Result.Loc, ":")
+			tx := strings.Split(ins.Results[0].Loc, ":")
 
 			if len(tx) == 2 {
 				pa := tx[0]

--- a/microArch/scheduler/liquidhandling/tgraph.go
+++ b/microArch/scheduler/liquidhandling/tgraph.go
@@ -54,7 +54,7 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 	res := make(map[string]*wtype.LHInstruction, len(inss))
 	for _, ins := range inss {
 		if ins.Type == wtype.LHIMIX {
-			res[ins.Result.ID] = ins
+			res[ins.Results[0].ID] = ins
 		} else if ins.Type == wtype.LHIPRM {
 			// we use passthrough instead
 			for _, cmp := range ins.PassThrough {

--- a/microArch/scheduler/liquidhandling/tgraph.go
+++ b/microArch/scheduler/liquidhandling/tgraph.go
@@ -60,6 +60,10 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 			for _, cmp := range ins.PassThrough {
 				res[cmp.ID] = ins
 			}
+		} else if ins.Type == wtype.LHISPL {
+			// two results here
+			res[ins.Results[0].ID] = ins
+			res[ins.Results[1].ID] = ins
 		}
 	}
 

--- a/microArch/scheduler/liquidhandling/tgraph.go
+++ b/microArch/scheduler/liquidhandling/tgraph.go
@@ -1,6 +1,7 @@
 package liquidhandling
 
 import (
+	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/graph"
 )
@@ -8,9 +9,10 @@ import (
 func MakeTGraph(inss []*wtype.LHInstruction) tGraph {
 	edges := make(map[*wtype.LHInstruction][]*wtype.LHInstruction, len(inss))
 	rcm := resultCmpMap(inss)
+	ccm := cmpInsMap(inss)
 
 	for _, ins := range inss {
-		edges[ins] = getEdges(ins, rcm)
+		edges[ins] = getEdges(ins, rcm, ccm)
 	}
 
 	return tGraph{Nodes: inss, Edges: edges}
@@ -50,6 +52,7 @@ func (tg *tGraph) Add(n *wtype.LHInstruction, edges []*wtype.LHInstruction) {
 
 // for mixes this is 1:1
 // but prompts may be aggregated first
+// splits are more complex
 func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 	res := make(map[string]*wtype.LHInstruction, len(inss))
 	for _, ins := range inss {
@@ -61,8 +64,8 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 				res[cmp.ID] = ins
 			}
 		} else if ins.Type == wtype.LHISPL {
-			// two results here
-			res[ins.Results[0].ID] = ins
+			// Splits need to go after the use of result 0
+			// and before the use of result 1
 			res[ins.Results[1].ID] = ins
 		}
 	}
@@ -70,22 +73,60 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 	return res
 }
 
+func cmpInsMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
+	res := make(map[string]*wtype.LHInstruction, len(inss))
+	for _, ins := range inss {
+		if ins.Type == wtype.LHIMIX {
+			for _, c := range ins.Components {
+				res[c.ID] = ins
+			}
+		} else if ins.Type == wtype.LHIPRM {
+			// we use passthrough instead
+			for ID, _ := range ins.PassThrough {
+				res[ID] = ins
+			}
+		}
+	}
+
+	return res
+
+}
+
 // inss maps result (i.e. component) IDs to instructions
-func getEdges(n *wtype.LHInstruction, inss map[string]*wtype.LHInstruction) []*wtype.LHInstruction {
+func getEdges(n *wtype.LHInstruction, resultMap, cmpMap map[string]*wtype.LHInstruction) []*wtype.LHInstruction {
 	ret := make([]*wtype.LHInstruction, 0, 1)
+
+	// don't make cycles containing split instructions
+
+	if n.Type == wtype.LHISPL {
+		// cmpMap answers the question "which instruction *uses* this?"
+		cmp := n.Results[0]
+
+		var lhi *wtype.LHInstruction
+		var ok bool
+
+		lhi, ok = cmpMap[cmp.ID]
+
+		if ok {
+			ret = append(ret, lhi)
+		} else {
+			panic(fmt.Sprintf("Split called without use of component. Moving components must be moved using Mix. Component name %s ID %s", cmp.CName, cmp.ID))
+		}
+		return ret
+	}
 
 	// we make this backwards since it's easier to say where something's coming from than where
 	// it's going to
 
 	for _, cmp := range n.Components {
-		// inss answers the question "which instruction made this?"
+		// resultMap answers the question "which instruction *makes* this?"
 		// for samples we need to ask for the parent component
 		var lhi *wtype.LHInstruction
 		var ok bool
 		if cmp.IsSample() {
-			lhi, ok = inss[cmp.ParentID]
+			lhi, ok = resultMap[cmp.ParentID]
 		} else {
-			lhi, ok = inss[cmp.ID]
+			lhi, ok = resultMap[cmp.ID]
 		}
 		if ok {
 			ret = append(ret, lhi)


### PR DESCRIPTION
This Pull Request introduces a new intrinsic: SplitSample, which is a two-return version of the previous Sample method 

This was the most straightforward way to allow proper tracking of both the sample and the samplee post splitting. 

The major changes are 
- multiple returns to commandInsts and LHInstructions
- instruction sorting modifications to facilitate the new instruction type which ensure that the split 
   instructions go in their own layer AFTER use of the sample and BEFORE use of the remainder of the 
   samplee
- new robot instruction type (SampleBlock) which updates IDs of remaining components 

This is tested with its intended use and works fine so far, apart from any minor test failures not in sync with the compile changes this should not cause much collateral damage since it is opt-in based on use of the new intrinsic
