### PR TITLE
Fix/tip waste logic

### DIFF
--- a/microArch/driver/liquidhandling/choosechannel_test.go
+++ b/microArch/driver/liquidhandling/choosechannel_test.go
@@ -112,7 +112,7 @@ func makeTestLH() *LHProperties {
 		}
 		yp += yi
 	}
-	lhp := NewLHProperties(9, "Pipetmax", "Gilson", "discrete", "disposable", layout)
+	lhp := NewLHProperties(9, "Pipetmax", "Gilson", LLLiquidHandler, DisposableTips, layout)
 	// get tips permissible from the factory
 	SetUpTipsFor(lhp)
 

--- a/microArch/driver/liquidhandling/lhl_test.go
+++ b/microArch/driver/liquidhandling/lhl_test.go
@@ -35,7 +35,7 @@ func makeGilson() *LHProperties {
 		}
 		yp += yi
 	}
-	lhp := NewLHProperties(9, "Pipetmax", "Gilson", "discrete", "disposable", layout)
+	lhp := NewLHProperties(9, "Pipetmax", "Gilson", LLLiquidHandler, DisposableTips, layout)
 	// get tips permissible from the factory
 	SetUpTipsFor(lhp)
 

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -537,6 +537,7 @@ func (lhp *LHProperties) AddTipWasteTo(pos string, tipwaste *wtype.LHTipwaste) e
 	if lhp.PosLookup[pos] != "" {
 		return wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, fmt.Sprintf("Trying to add tip waste to full position %s", pos))
 	}
+
 	lhp.Tipwastes[pos] = tipwaste
 	lhp.PlateLookup[tipwaste.ID] = tipwaste
 	lhp.PosLookup[pos] = tipwaste.ID

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -435,6 +435,20 @@ func NewLHProperties(num_positions int, model, manufacturer, lhtype, tiptype str
 	return &lhp
 }
 
+// GetLHType returns the declared type of liquid handler for driver selection purposes
+// e.g. High-Level (HLLiquidHandler) or Low-Level (LLLiquidHandler)
+// see lhtype.go in this directory
+func (lhp *LHProperties) GetLHType() string {
+	return lhp.LHType
+}
+
+// GetTipType returns the tip requirements of the liquid handler
+// options are None, Disposable, Fixed, Mixed
+// see lhtype.go in this directory
+func (lhp *LHProperties) GetTipType() string {
+	return lhp.TipType
+}
+
 func (lhp *LHProperties) TipsLeftOfType(tiptype string) int {
 	n := 0
 

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -389,6 +389,15 @@ func (lhp *LHProperties) dup(keepIDs bool) *LHProperties {
 
 // constructor for the above
 func NewLHProperties(num_positions int, model, manufacturer, lhtype, tiptype string, layout map[string]wtype.Coordinates) *LHProperties {
+	// assert validity of lh and tip types
+
+	if !IsValidLiquidHandlerType(lhtype) {
+		panic(fmt.Sprintf("Invalid liquid handling type requested: %s", lhtype))
+	}
+	if !IsValidTipType(tiptype) {
+		panic(fmt.Sprintf("Invalid tip usage type requested: %s", tiptype))
+	}
+
 	var lhp LHProperties
 
 	lhp.ID = wtype.GetUUID()

--- a/microArch/driver/liquidhandling/lhtype.go
+++ b/microArch/driver/liquidhandling/lhtype.go
@@ -2,13 +2,14 @@ package liquidhandling
 
 // consts for generic liquid handling types
 const (
-	LLLiquidHandler string = "LLLiquidHandler"
-	HLLiquidHandler string = "HLLiquidHandler"
+	LLLiquidHandler string = "LLLiquidHandler" // requires detailed programming e.g. move, aspirate, move dispense etc.
+	HLLiquidHandler string = "HLLiquidHandler" // can orchestrate liquid transfers itself
 )
 
 // consts for tip requirements of liquid handlers
 const (
-	DisposableTips              string = "Disposable"
-	MixedDisposableAndFixedTips string = "Mixed"
-	NoTips                      string = "None"
+	DisposableTips              string = "Disposable" // disposable system	-- needs tip boxes & waste
+	FixedTips                   string = "Fixed"      // fixed tip system	-- needs tip wash
+	MixedDisposableAndFixedTips string = "Mixed"      // both disposable and mixed	-- needs all of the above
+	NoTips                      string = "None"       // does not use tips
 )

--- a/microArch/driver/liquidhandling/lhtype.go
+++ b/microArch/driver/liquidhandling/lhtype.go
@@ -6,6 +6,17 @@ const (
 	HLLiquidHandler string = "HLLiquidHandler" // can orchestrate liquid transfers itself
 )
 
+func IsValidLiquidHandlerType(s string) bool {
+	switch s {
+	case LLLiquidHandler:
+		fallthrough
+	case HLLiquidHandler:
+		return true
+	default:
+		return false
+	}
+}
+
 // consts for tip requirements of liquid handlers
 const (
 	DisposableTips              string = "Disposable" // disposable system	-- needs tip boxes & waste
@@ -13,3 +24,18 @@ const (
 	MixedDisposableAndFixedTips string = "Mixed"      // both disposable and mixed	-- needs all of the above
 	NoTips                      string = "None"       // does not use tips
 )
+
+func IsValidTipType(s string) bool {
+	switch s {
+	case DisposableTips:
+		fallthrough
+	case FixedTips:
+		fallthrough
+	case MixedDisposableAndFixedTips:
+		fallthrough
+	case NoTips:
+		return true
+	default:
+		return false
+	}
+}

--- a/microArch/driver/liquidhandling/lhtype.go
+++ b/microArch/driver/liquidhandling/lhtype.go
@@ -1,6 +1,14 @@
 package liquidhandling
 
+// consts for generic liquid handling types
 const (
 	LLLiquidHandler string = "LLLiquidHandler"
 	HLLiquidHandler string = "HLLiquidHandler"
+)
+
+// consts for tip requirements of liquid handlers
+const (
+	DisposableTips              string = "Disposable"
+	MixedDisposableAndFixedTips string = "Mixed"
+	NoTips                      string = "None"
 )

--- a/microArch/driver/liquidhandling/lhtype_test.go
+++ b/microArch/driver/liquidhandling/lhtype_test.go
@@ -1,0 +1,46 @@
+package liquidhandling
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsValidLiquidHandlerType(t *testing.T) {
+
+	validTypes := []string{LLLiquidHandler, HLLiquidHandler}
+
+	for _, c := range validTypes {
+		if !IsValidLiquidHandlerType(c) {
+			t.Errorf(fmt.Sprintf("error: Type %s must return as valid, returns invalid", c))
+		}
+	}
+
+	invalidTypes := []string{"anythingElse", ""}
+
+	for _, c := range invalidTypes {
+		if IsValidLiquidHandlerType(c) {
+			t.Errorf(fmt.Sprintf("error: Type %s must return as invalid, returns valid", c))
+
+		}
+	}
+
+}
+
+func TestIsValidTipType(t *testing.T) {
+	validTypes := []string{FixedTips, DisposableTips, MixedDisposableAndFixedTips, NoTips}
+
+	for _, c := range validTypes {
+		if !IsValidTipType(c) {
+			t.Errorf(fmt.Sprintf("error: Type %s must return as valid, returns invalid", c))
+		}
+	}
+
+	invalidTypes := []string{"anythingElse", ""}
+
+	for _, c := range invalidTypes {
+		if IsValidTipType(c) {
+			t.Errorf(fmt.Sprintf("error: Type %s must return as invalid, returns valid", c))
+
+		}
+	}
+}

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -461,7 +461,7 @@ func (ins *TransferInstruction) Generate(ctx context.Context, policy *wtype.LHPo
 	// if the liquid handler is of the high-level type we cut the tree here
 	// after ensuring that the transfers are within limitations of the liquid handler
 
-	if prms.LHType == HLLiquidHandler {
+	if prms.GetLHType() == HLLiquidHandler {
 		err := ins.ReviseTransferVolumes(prms)
 
 		if err != nil {

--- a/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
+++ b/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
@@ -52,7 +52,7 @@ func makeGilson(ctx context.Context) *liquidhandling.LHProperties {
 		}
 		yp += yi
 	}
-	lhp := liquidhandling.NewLHProperties(9, "Pipetmax", "Gilson", "discrete", "disposable", layout)
+	lhp := liquidhandling.NewLHProperties(9, "Pipetmax", "Gilson", liquidhandling.LLLiquidHandler, liquidhandling.DisposableTips, layout)
 	// get tips permissible from the factory
 	setUpTipsFor(ctx, lhp)
 

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -207,36 +207,46 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 			err := wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, fmt.Sprint("No position left for input ", p.Name(), " Type: ", p.Type, " Constrained: ", isConstrained, " allowed positions: ", allowed))
 			return request, err
 		}
-		//fmt.Println("PLAATE: ", position)
 		setup[position] = p
 		plate_lookup[p.ID] = position
 		params.AddPlate(position, p)
 		fmt.Println(fmt.Sprintf("Input plate of type %s in position %s", p.Type, position))
 	}
 
-	// add the waste
-	s := params.TipWastesMounted()
+	// add the waste if required...
 
-	if s == 0 {
-		var waste *wtype.LHTipwaste
-		var err error
-		// this should be added to the automagic config setup... however it will require adding to the
-		// representation of the liquid handler
-		if params.Model == "Pipetmax" {
-			waste, err = inventory.NewTipwaste(ctx, "Gilsontipwaste")
-		} else if params.Model == "GeneTheatre" || params.Model == "Felix" {
-			waste, err = inventory.NewTipwaste(ctx, "CyBiotipwaste")
-		} else if params.Model == "Human" {
-			waste, err = inventory.NewTipwaste(ctx, "Manualtipwaste")
-		} else if params.Model == "Evo" {
-			waste, err = inventory.NewTipwaste(ctx, "Tecantipwaste")
-		}
+	if params.TipType == liquidhandling.DisposableTips || params.TipType == liquidhandling.MixedDisposableAndFixedTips {
+		s := params.TipWastesMounted()
 
-		if err != nil {
-			return nil, wtype.LHError(wtype.LH_ERR_OTHER, fmt.Sprintf("No tip waste defined for model %s: %s", params.Model, err))
+		if s == 0 {
+			var waste *wtype.LHTipwaste
+			var err error
+			// this should be added to the automagic config setup... however it will require adding to the
+			// representation of the liquid handler
+			if params.Model == "Pipetmax" {
+				waste, err = inventory.NewTipwaste(ctx, "Gilsontipwaste")
+			} else if params.Model == "GeneTheatre" || params.Model == "Felix" {
+				waste, err = inventory.NewTipwaste(ctx, "CyBiotipwaste")
+			} else if params.Model == "Human" {
+				waste, err = inventory.NewTipwaste(ctx, "Manualtipwaste")
+			} else if params.Model == "Evo" {
+				waste, err = inventory.NewTipwaste(ctx, "Tecantipwaste")
+			}
+
+			if err != nil {
+				return nil, wtype.LHError(wtype.LH_ERR_OTHER, fmt.Sprintf("No tip waste defined for model %s: %s", params.Model, err))
+			}
+
+			err = params.AddTipWaste(waste)
+
+			if err != nil {
+				return nil, wtype.LHError(wtype.LH_ERR_OTHER, fmt.Sprintf("Error for liquid handler of model %s: %s", params.Model, err))
+			}
 		}
-		params.AddTipWaste(waste)
 	}
+
+	// TODO -- similar logic here to add / check for wash station if tips are fixed or mixed
+
 	//request.Setup = setup
 	request.Plate_lookup = plate_lookup
 	return request, nil

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -215,7 +215,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 
 	// add the waste if required...
 
-	if params.TipType == liquidhandling.DisposableTips || params.TipType == liquidhandling.MixedDisposableAndFixedTips {
+	if params.GetTipType() == liquidhandling.DisposableTips || params.GetTipType() == liquidhandling.MixedDisposableAndFixedTips {
 		s := params.TipWastesMounted()
 
 		if s == 0 {


### PR DESCRIPTION
This PR improves the centralisation of liquid handler capability specifications by including the platform's use (or otherwise) of tips, on which basis the setup logic can determine whether to add accessories such as tip wastes and when it needs to mount, unmount or wash tips. 