### PR TITLE
Reduce maxvol for 30ul filter tips to 20ul

### DIFF
--- a/inventory/testinventory/make_tip_library.go
+++ b/inventory/testinventory/make_tip_library.go
@@ -92,11 +92,13 @@ func makeGilsonTipboxes() []*wtype.LHTipbox {
 	tb = wtype.NewLHTipbox(8, 12, 60.13, "Gilson", "DF200 Tip Rack (PIPETMAX 8x200)", tip, w, 9.0, 9.0, 0.0, 0.0, 24.78)
 	ret = append(ret, tb)
 
-	w = wtype.NewLHWell("DF30 Tip Rack (PIPETMAX 8x20)", "", "A1", "ul", 30.0, 2.0, shp, 0, 7.3, 7.3, 51.2, 0.0, "mm")
+	//DF30 tip has 20ul max volume to avoid attempts to pick it up with the high volume head which currently causes a crash
+	//HJK (20/3/18)
+	w = wtype.NewLHWell("DF30 Tip Rack (PIPETMAX 8x20)", "", "A1", "ul", 20.0, 2.0, shp, 0, 7.3, 7.3, 51.2, 0.0, "mm")
 	w.Extra["InnerL"] = 5.6
 	w.Extra["InnerW"] = 5.6
 	w.Extra["Tipeffectiveheight"] = 39.3
-	tip = wtype.NewLHTip("gilson", "GilsonFilter30", 2.0, 30.0, "ul", true)
+	tip = wtype.NewLHTip("gilson", "GilsonFilter30", 2.0, 20.0, "ul", true)
 	tb = wtype.NewLHTipbox(8, 12, 60.13, "Gilson", "DF30 Tip Rack (PIPETMAX 8x20)", tip, w, 9.0, 9.0, 0.0, 0.0, 24.78)
 	ret = append(ret, tb)
 


### PR DESCRIPTION
Otherwise 30ul tips are (correctly) picked up by the high volume head on
gilson which (incorrectly) causes a crash

Have tested in trilution that this avoids the issue