### PR TITLE
prevent index out of range error and report back useful error message…

### DIFF
--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -57,7 +57,7 @@ func ImprovedLayoutAgent(ctx context.Context, request *LHRequest, params *liquid
 
 		k += 1
 		if err != nil {
-			break
+			return request, err
 		}
 		ch = ch.Child
 	}
@@ -723,6 +723,15 @@ func make_layouts(ctx context.Context, request *LHRequest, pc []PlateChoice) err
 		for _, w := range c.Wells {
 			if w != "" {
 				wc := wtype.MakeWellCoords(w)
+
+				if wc.X >= len(plat.Cols) {
+					return fmt.Errorf("well (%s) specified is out of range of available wells for plate type %s", w, plat.Type)
+				}
+
+				if wc.Y >= len(plat.Cols[wc.X]) {
+					return fmt.Errorf("well (%s) specified is out of range of available wells for plate type %s", w, plat.Type)
+				}
+
 				dummycmp := wtype.NewLHComponent()
 				dummycmp.SetVolume(plat.Cols[wc.X][wc.Y].MaxVolume())
 				plat.Cols[wc.X][wc.Y].Add(dummycmp)


### PR DESCRIPTION
Prevent index out of range error and report back useful error message when specified well is out of range of plate:

**Old error Message:**
```
Error: runtime error: invalid memory address or nil pointer dereference at:
goroutine 50 [running]:
runtime/debug.Stack(0xc42332ebd8, 0x4ca1040, 0x585c210)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/trace.(*trace).signalWithLock.func1(0xc42332feb8)
	/Users/theukshowdown/go/src/github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/trace/trace.go:172 +0x57
panic(0x4ca1040, 0x585c210)
	/usr/local/go/src/runtime/panic.go:491 +0x283
github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling.ImprovedLayoutAgent(0x55aae60, 0xc423315200, 0x0, 0xc4270261e0, 0x0, 0x0, 0x0)
	/Users/theukshowdown/go/src/github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling/layoutagent2.go:68 +0x256
github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling.(*Liquidhandler).Layout(0xc4233d75c0, 0x55aae60, 0xc423315200, 0xc420441c00, 0x0, 0x0, 0x4013057)
	/Users/theukshowdown/go/src/github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling/liquidhandler.go:1027 +0x50
github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling.(*Liquidhandler).Plan(0xc4233d75c0, 0x55aae60, 0xc423315200, 0xc420441c00, 0x1, 0x0)
	/Users/theukshowdown/go/src/github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling/liquidhandler.go:707 +0x79f
github.com/antha-lang/elements/vendor/github.com/antha-lang/antha/microArch/scheduler/liquidhandling.(*Liquidhandler).MakeSolutions(0xc4233d75c0, 0x55aae60, 0xc423315200, 0xc420441c00, 0xc42345a2f8, 0x0)
```

**New error Message:** 
```Error: error planning: well (A15) specified is out of range of available wells for plate type pcrplate_skirted_riser20```