### PR TITLE
Reports name, number and tipbox count used

### DIFF
--- a/antha/anthalib/wtype/tipestimate.go
+++ b/antha/anthalib/wtype/tipestimate.go
@@ -1,0 +1,8 @@
+package wtype
+
+// A Tip Estimate provides information on how many tips and tip boxes of a given type are expected to be used
+type TipEstimate struct {
+	TipType   string // identifier describing which tips are to be used
+	NTips     int    // count of tips used total
+	NTipBoxes int    // count of tip boxes to be used
+}

--- a/microArch/scheduler/liquidhandling/count_tips_used.go
+++ b/microArch/scheduler/liquidhandling/count_tips_used.go
@@ -1,0 +1,71 @@
+package liquidhandling
+
+import (
+	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	driver "github.com/antha-lang/antha/microArch/driver/liquidhandling"
+)
+
+func (lh Liquidhandler) countTipsUsed(rq *LHRequest) (*LHRequest, error) {
+	teHash := make(map[string]wtype.TipEstimate)
+
+	for _, ins := range rq.Instructions {
+		if ins.InstructionType() == driver.LOD {
+			ldt, ok := ins.(*driver.LoadTipsInstruction)
+
+			if !ok {
+				return nil, fmt.Errorf("Instruction declared wrong type (LOD) but is %T", ins)
+			}
+
+			for i := 0; i < len(ldt.Pos); i++ {
+				if ldt.Pos[i] == "" {
+					continue
+				}
+				bx, ok := lh.Properties.Tipboxes[ldt.Pos[i]]
+
+				if !ok {
+					return nil, fmt.Errorf("Instruction %s requests tips from an empty position", driver.InsToString(ldt))
+				}
+
+				tt := bx.Type
+				te, ok := teHash[tt]
+
+				if !ok {
+					te = wtype.TipEstimate{TipType: tt, NTipBoxes: bx.NTips}
+				}
+
+				te.NTips += 1
+
+				teHash[te.TipType] = te
+			}
+
+		}
+	}
+
+	// output to the request
+
+	for _, te := range teHash {
+		if te.NTips == 0 {
+			// should not be possible but I don't want to generate confusion
+			continue
+		}
+		// above we have recorded the total number of tips in a box of lh type
+		// in NTipBoxes, here we use it to determine how many boxes are needed
+		te.NTipBoxes = 1 + te.NTips/te.NTipBoxes
+
+		rq.TipsUsed = append(rq.TipsUsed, te)
+	}
+
+	return rq, nil
+}
+
+func countWellMulti(sa []string) int {
+	r := 0
+	for _, s := range sa {
+		if s != "" {
+			r += 1
+		}
+	}
+
+	return r
+}

--- a/microArch/scheduler/liquidhandling/count_tips_used_test.go
+++ b/microArch/scheduler/liquidhandling/count_tips_used_test.go
@@ -1,0 +1,36 @@
+package liquidhandling
+
+import (
+	"context"
+	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/inventory/testinventory"
+	"reflect"
+	"testing"
+)
+
+func TestTipCounting(t *testing.T) {
+	ctx := testinventory.NewContext(context.Background())
+
+	lh := GetLiquidHandlerForTest(ctx)
+	lh.ExecutionPlanner = ExecutionPlanner3
+	rq := GetLHRequestForTest()
+	configure_request_simple(ctx, rq)
+	rq.Input_platetypes = append(rq.Input_platetypes, GetPlateForTest())
+	rq.Output_platetypes = append(rq.Output_platetypes, GetPlateForTest())
+
+	rq.ConfigureYourself()
+	err := lh.Plan(ctx, rq)
+
+	if err != nil {
+		t.Fatal(fmt.Sprint("Got planning error: ", err))
+	}
+
+	// [{DFL10 Tip Rack (PIPETMAX 8x20) 27 1}]
+
+	expected := []wtype.TipEstimate{{TipType: "DFL10 Tip Rack (PIPETMAX 8x20)", NTips: 27, NTipBoxes: 1}}
+
+	if !reflect.DeepEqual(expected, rq.TipsUsed) {
+		t.Errorf("Expected %v Got %v", expected, rq.TipsUsed)
+	}
+}

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -69,6 +69,7 @@ type LHRequest struct {
 	Options               LHOptions
 	NUserPlates           int
 	Output_sort           bool
+	TipsUsed              []wtype.TipEstimate
 }
 
 func (req *LHRequest) GetPlate(id string) (*wtype.LHPlate, bool) {
@@ -203,6 +204,7 @@ func NewLHRequest() *LHRequest {
 	lhr.Input_setup_weights["RESIDUAL_VOLUME_WEIGHT"] = 1.0
 	lhr.Policies, _ = liquidhandling.GetLHPolicyForTest()
 	lhr.Options = NewLHOptions()
+	lhr.TipsUsed = make([]wtype.TipEstimate, 0)
 	return &lhr
 }
 

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -782,7 +782,15 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 		return err
 	}
 
-	// sorts out tip boxes etc.
+	// counts tips used in this run -- reads instructions generated above so must happen
+	// after execution planning
+	request, err = this.countTipsUsed(request)
+
+	if err != nil {
+		return err
+	}
+
+	// Ensures tip boxes and wastes are correct for initial and final robot states
 	this.Refresh_tipboxes_tipwastes(request)
 
 	// revise the volumes - this makes sure the volumes requested are correct

--- a/microArch/scheduler/liquidhandling/refresh_tipboxes.go
+++ b/microArch/scheduler/liquidhandling/refresh_tipboxes.go
@@ -1,7 +1,6 @@
 package liquidhandling
 
 // no longer need to supply tipboxes after the fact
-
 func (lh *Liquidhandler) Refresh_tipboxes_tipwastes(rq *LHRequest) {
 
 	// dead simple

--- a/target/inst.go
+++ b/target/inst.go
@@ -36,6 +36,12 @@ type TimeEstimator interface {
 	GetTimeEstimate() float64
 }
 
+// A TipEstimator is an instruction that uses tips and provides information on how many
+type TipEstimator interface {
+	// GetTipEstimates returns an estimate of how many tips this instruction will use
+	GetTipEstimates() []wtype.TipEstimate
+}
+
 type dependsMixin struct {
 	Depends []Inst
 }
@@ -115,6 +121,17 @@ func (a *Mix) GetTimeEstimate() float64 {
 	}
 
 	return est
+}
+
+// GetTipEstimates implements a TipEstimator
+func (a *Mix) GetTipEstimates() []wtype.TipEstimate {
+	ret := []wtype.TipEstimate{}
+
+	if a.Request != nil {
+		copy(ret, a.Request.TipsUsed)
+	}
+
+	return ret
 }
 
 // GetInitializers implements an Initializer


### PR DESCRIPTION
This adds a simple count of tips used which is reported via the mix task 

Tip use is counted from the instructions generated using the load tips (LOD) instruction