### PR TITLE
Workaround for float discrepancies

### DIFF
--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -4,6 +4,7 @@ package liquidhandling
 
 import (
 	"fmt"
+
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )
@@ -389,7 +390,7 @@ func makeMatchSafe(dst wtype.ComponentVector, match wtype.Match, mpv wunit.Volum
 
 			checkVol -= match.Vols[i].ConvertToString(dst[i].Vunit)
 
-			if checkVol > 0.0 && checkVol < mpv.ConvertToString(dst[i].Vunit) {
+			if checkVol > 0.0001 && checkVol < mpv.ConvertToString(dst[i].Vunit) {
 				mpv.Subtract(wunit.NewVolume(checkVol, dst[i].Vunit))
 				match.Vols[i].Subtract(mpv)
 
@@ -407,7 +408,7 @@ func updateDests(dst wtype.ComponentVector, match wtype.Match) wtype.ComponentVe
 	for i := 0; i < len(match.M); i++ {
 		if match.M[i] != -1 {
 			dst[i].Vol -= match.Vols[i].ConvertToString(dst[i].Vunit)
-			if dst[i].Vol < 0.0 {
+			if dst[i].Vol < 0.0001 {
 				dst[i].Vol = 0.0
 			}
 		}


### PR DESCRIPTION
0.0001 is elsewhere also used to check for float discrepancies so this
should be in line with other checks.