### PR TITLE
add element name to Errorf messages

### DIFF
--- a/antha/compile/antha.go
+++ b/antha/compile/antha.go
@@ -1152,6 +1152,7 @@ type Element struct {
 }
 
 func (Element) Run(_ctx context.Context, request *{{ .ModelPackage }}.Input) (response *{{ .ModelPackage }}.Output, err error) {
+	_ctx = execute.WithElementName(_ctx, {{ .ElementName }})
 	bs, err := json.Marshal(request)
 	if err != nil {
 		return nil, err

--- a/cmd/antha/cmd/run.go
+++ b/cmd/antha/cmd/run.go
@@ -47,9 +47,10 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "Run an antha workflow",
-	RunE:  runWorkflow,
+	Use:           "run",
+	Short:         "Run an antha workflow",
+	RunE:          runWorkflow,
+	SilenceErrors: true,
 }
 
 func makeMixerOpt(ctx context.Context) (mixer.Opt, error) {
@@ -105,7 +106,7 @@ func makeContext() (context.Context, error) {
 			return nil, fmt.Errorf("component %q has unexpected type %T", desc.Name, obj)
 		}
 		if err := inject.Add(ctx, inject.Name{Repo: desc.Name, Stage: desc.Stage}, runner); err != nil {
-			return nil, fmt.Errorf("error adding protocol %q: %s", desc.Name, err)
+			return nil, fmt.Errorf("adding protocol %q: %s", desc.Name, err)
 		}
 	}
 	return testinventory.NewContext(ctx), nil
@@ -343,7 +344,7 @@ func runWorkflow(cmd *cobra.Command, args []string) error {
 		TargetConfigFile:       viper.GetString("target"),
 		MixInstructionFileName: viper.GetString("mixInstructionFileName"),
 		TestBundleFileName:     viper.GetString("makeTestBundle"),
-		RunTest:                viper.GetBool("RunTest"),
+		RunTest:                viper.GetBool("runTest"),
 	}
 
 	return opt.Run()
@@ -374,5 +375,6 @@ func init() {
 	flags.StringSlice("inputPlates", nil, "File containing input plates")
 	flags.StringSlice("outputPlateTypes", nil, "Default output plate types (in order of preference)")
 	flags.StringSlice("tipTypes", nil, "Names of permitted tip types")
+	flags.Bool("runTest", false, "run tests")
 	flags.Bool("fixVolumes", true, "Make all volumes sufficient for later uses")
 }

--- a/cmd/antha/main.go
+++ b/cmd/antha/main.go
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(nil); err != nil {
-		fmt.Fprintln(os.Stderr, err) // nolint
+		fmt.Fprintln(os.Stderr, "error:", err) // nolint
 		os.Exit(1)
 	}
 }

--- a/execute/context.go
+++ b/execute/context.go
@@ -4,21 +4,29 @@ import (
 	"context"
 )
 
-type contextKey int
+type idContextKey int
 
-const theContextKey contextKey = 0
+const theIDContextKey idContextKey = 0
 
 type withExecute struct {
 	ID    string
 	Maker *maker
 }
 
+type elementNameKey int
+
+const theElementNameKey elementNameKey = 0
+
+type withElementName struct {
+	Name string
+}
+
 func getMaker(ctx context.Context) *maker {
-	return ctx.Value(theContextKey).(*withExecute).Maker
+	return ctx.Value(theIDContextKey).(*withExecute).Maker
 }
 
 func getID(ctx context.Context) string {
-	v, ok := ctx.Value(theContextKey).(*withExecute)
+	v, ok := ctx.Value(theIDContextKey).(*withExecute)
 	if !ok {
 		return ""
 	}
@@ -26,8 +34,23 @@ func getID(ctx context.Context) string {
 }
 
 func withID(parent context.Context, id string) context.Context {
-	return context.WithValue(parent, theContextKey, &withExecute{
+	return context.WithValue(parent, theIDContextKey, &withExecute{
 		ID:    id,
 		Maker: newMaker(),
 	})
+}
+
+// WithElementName returns a new context that stores the current element name
+func WithElementName(parent context.Context, name string) context.Context {
+	return context.WithValue(parent, theElementNameKey, &withElementName{
+		Name: name,
+	})
+}
+
+func getElementName(ctx context.Context) string {
+	v, ok := ctx.Value(theElementNameKey).(*withElementName)
+	if !ok {
+		return ""
+	}
+	return v.Name
 }

--- a/execute/error.go
+++ b/execute/error.go
@@ -3,19 +3,45 @@ package execute
 import (
 	"context"
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 // An Error reported by user code
 type Error struct {
-	Message string
+	message string
 }
 
 // Error returns the error message
 func (a *Error) Error() string {
-	return a.Message
+	return a.message
 }
 
 // Errorf reports an execution error. Does not return
 func Errorf(ctx context.Context, format string, args ...interface{}) {
-	panic(&Error{Message: fmt.Sprintf(format, args...)})
+	userMsg := fmt.Sprintf(format, args...)
+	elementName := getElementName(ctx)
+
+	msg := userMsg
+	if len(elementName) != 0 {
+		msg = "element " + elementName + ": " + userMsg
+	}
+
+	var err error = &Error{message: msg}
+	err = errors.WithStack(err)
+	panic(err)
+}
+
+// unwrapError unpacks the result of Errorf
+func unwrapError(obj interface{}) (error, bool) {
+	err, ok := obj.(error)
+	if !ok {
+		return nil, false
+	}
+
+	if _, ok := errors.Cause(err).(*Error); !ok {
+		return nil, false
+	}
+
+	return err, true
 }

--- a/execute/error.go
+++ b/execute/error.go
@@ -33,7 +33,7 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 }
 
 // unwrapError unpacks the result of Errorf
-func unwrapError(obj interface{}) (error, bool) {
+func unwrapError(obj interface{}) (error, bool) { // nolint
 	err, ok := obj.(error)
 	if !ok {
 		return nil, false

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -63,8 +63,8 @@ func Run(parent context.Context, opt Opt) (*Result, error) {
 
 	// Unwrap execute.Error
 	if terr, ok := err.(*trace.Error); ok {
-		if eerr, ok := terr.BaseError.(*Error); ok {
-			err = eerr
+		if unwrapped, ok := unwrapError(terr.BaseError); ok {
+			err = unwrapped
 		}
 	}
 


### PR DESCRIPTION
`Errorf("some error")` will print `element XXX: some error`.

If you do `fmt.Printf("%+v", err)` you'll get a stack track too. Whether that should be the default, I can handle in a separate PR.