### PR TITLE
Fixes to splitsample

### DIFF
--- a/antha/anthalib/mixer/mixer.go
+++ b/antha/anthalib/mixer/mixer.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"github.com/antha-lang/antha/microArch/sampletracker"
 )
 
 // SampleAll takes all of this liquid
@@ -64,6 +65,10 @@ func SplitSample(l *wtype.LHComponent, v wunit.Volume) (moving, remaining *wtype
 
 	remaining.Vol -= v.ConvertToString(remaining.Vunit)
 	remaining.ID = wtype.GetUUID()
+
+	sampletracker := sampletracker.GetSampleTracker()
+
+	sampletracker.UpdateIDOf(l.ID, remaining.ID)
 
 	return
 }

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -1165,7 +1165,6 @@ func (p *LHPlate) GetFilteredContentVector(wv []WellCoords, cmps ComponentVector
 	fcv := make([]*LHComponent, len(cv))
 
 	for i := 0; i < len(cv); i++ {
-
 		identifier := cv[i].IDOrName()
 
 		// ignoreInstances can only work for initial inputs

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -255,12 +255,6 @@ func (lhp *LHProperties) GetComponents(opt GetComponentsOptions) (GetComponentsR
 	rep := newReply()
 	// build list of possible sources -- this is a list of ComponentVectors
 
-	for _, cmp := range opt.Cmps {
-		if cmp == nil {
-			continue
-		}
-	}
-
 	srcs := lhp.GetSourcesFor(opt.Cmps, opt.Ori, opt.Multi, lhp.MinPossibleVolume(), opt.IgnoreInstances)
 
 	// keep taking chunks until either we get everything or run out

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -255,6 +255,12 @@ func (lhp *LHProperties) GetComponents(opt GetComponentsOptions) (GetComponentsR
 	rep := newReply()
 	// build list of possible sources -- this is a list of ComponentVectors
 
+	for _, cmp := range opt.Cmps {
+		if cmp == nil {
+			continue
+		}
+	}
+
 	srcs := lhp.GetSourcesFor(opt.Cmps, opt.Ori, opt.Multi, lhp.MinPossibleVolume(), opt.IgnoreInstances)
 
 	// keep taking chunks until either we get everything or run out

--- a/microArch/scheduler/liquidhandling/executionhelpers.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers.go
@@ -274,6 +274,10 @@ func convertToInstructionChain(sortedNodes []graph.Node, tg graph.Graph, sort bo
 		addToIChain(ic, n, tg)
 	}
 
+	// finally we need to ensure that splits and mixes are kept separate by fissioning nodes
+
+	ic.SplitMixedNodes()
+
 	sortOutputs(ic, sort)
 
 	return ic

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -176,3 +176,47 @@ func (it *IChain) Flatten() []string {
 
 	return ret
 }
+
+func (it *IChain) SplitMixedNodes() {
+	if nodesMixedOK(it.Values) {
+		it.splitMixedNode()
+	}
+
+	// stop if we reach the end
+	if it.Child == nil {
+		return
+	}
+
+	// carry on
+	it.Child.SplitMixedNodes()
+}
+
+func (it *IChain) splitMixedNode() {
+	// put mixes first, then splits
+
+	mixValues := make([]*wtype.LHInstruction, 0, len(it.Values))
+	splitValues := make([]*wtype.LHInstruction, 0, len(it.Values))
+
+	for _, v := range it.Values {
+		if v.Type == wtype.LHIMIX {
+			mixValues = append(mixValues, v)
+		} else if v.Type == wtype.LHISPL {
+			splitValues = append(splitValues, v)
+		} else {
+			panic("Wrong instruction type passed through to instruction chain split")
+		}
+	}
+
+	it.Values = mixValues
+	ch := NewIChain(it)
+	ch.Values = splitValues
+	ch.Child = it.Child
+	it.Child = ch
+}
+
+func nodesMixedOK(values []*wtype.LHInstruction) bool {
+	/// true iff we have exactly two types of node: split and mix
+	insTypes := countInstructionTypes(values)
+
+	return len(insTypes) == 2 && insTypes[wtype.InsNames[wtype.LHIMIX]] && insTypes[wtype.InsNames[wtype.LHISPL]]
+}

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -673,13 +673,18 @@ func checkInstructionOrdering(request *LHRequest) {
 	}
 }
 
-func onlyAllowOneInstructionType(c *IChain) {
+func countInstructionTypes(inss []*wtype.LHInstruction) map[string]bool {
 	m := make(map[string]bool)
-	inss := c.Values
 
 	for _, i := range inss {
 		m[i.InsType()] = true
 	}
+
+	return m
+}
+
+func onlyAllowOneInstructionType(c *IChain) {
+	m := countInstructionTypes(c.Values)
 
 	if len(m) != 1 {
 		panic(fmt.Errorf("Only one instruction type per stage is allowed, found %v at stage %d", m, c.Depth))
@@ -764,8 +769,7 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 		return fmt.Errorf("Error with instruction sorting: Have %d want %d instructions", len(request.Output_order), len(request.LHInstructions))
 	}
 
-	// assert that we must keep prompts separate from mixes
-
+	// assert that we must keep prompts and splits separate from mixes
 	checkInstructionOrdering(request)
 
 	forceSanity(request)

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -105,6 +105,10 @@ func ValidateRequest(request *LHRequest) error {
 	// no component can have all three of Conc, Vol and TVol set to 0:
 
 	for _, ins := range request.LHInstructions {
+		// the check below makes sense only for mixes
+		if ins.Type != wtype.LHIMIX {
+			continue
+		}
 		for i, cmp := range ins.Components {
 			if cmp.Vol == 0.0 && cmp.Conc == 0.0 && cmp.Tvol == 0.0 {
 				errstr := fmt.Sprintf("Nil mix (no volume, concentration or total volume) requested: %d : ", i)

--- a/microArch/scheduler/liquidhandling/tgraph_test.go
+++ b/microArch/scheduler/liquidhandling/tgraph_test.go
@@ -1,7 +1,9 @@
 package liquidhandling
 
 import (
+	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"testing"
 )
 
@@ -46,6 +48,78 @@ func TestTGraph(t *testing.T) {
 	// edge check... we should have 9->8->7->6->5
 
 	for k := 9; k >= 1; k-- {
+		expect := tgraph.Node(k - 1)
+		got := tgraph.Out(tgraph.Node(k), 0)
+
+		if expect != got {
+			t.Errorf("this graph should be a chain - failed between nodes %d %d", k, k-1)
+		}
+	}
+}
+
+// TestTGraphSplit checks whether split instructions are working correctly
+// these are sorted so that they occur after use of their first return and
+// before the use of their second - this is because they update the ID of their
+// input component
+func TestTGraphSplit(t *testing.T) {
+	tIns := make([]*wtype.LHInstruction, 0, 3)
+
+	cmpIn := wtype.NewLHComponent()
+	moving, remaining := mixer.SplitSample(cmpIn, wunit.NewVolume(100.0, "ul"))
+
+	cmpOut := wtype.NewLHComponent()
+
+	// mix
+	ins := wtype.NewLHMixInstruction()
+
+	ins.AddComponent(moving)
+	ins.AddProduct(cmpOut)
+	tIns = append(tIns, ins)
+
+	// split
+	ins = wtype.NewLHSplitInstruction()
+	ins.AddComponent(cmpOut)
+
+	ins.AddProduct(moving)
+	ins.AddProduct(remaining)
+
+	tIns = append(tIns, ins)
+
+	// mix again
+
+	ins = wtype.NewLHMixInstruction()
+
+	ins.AddComponent(remaining)
+	ins.AddProduct(wtype.NewLHComponent())
+	tIns = append(tIns, ins)
+
+	tgraph := MakeTGraph(tIns)
+
+	arrEq := func(ar1 []*wtype.LHInstruction, ar2 []*wtype.LHInstruction) bool {
+		if len(ar1) != len(ar2) {
+			return false
+		}
+
+		for i := 0; i < len(ar1); i++ {
+			if ar1[i].ID != ar2[i].ID {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if !arrEq(tIns, tgraph.Nodes) {
+		t.Errorf("Nodes in tGraph should be identical to nodes inputted")
+	}
+
+	if tgraph.NumNodes() != 3 {
+		t.Errorf("NumNodes should report 3, instead reports %d", tgraph.NumNodes)
+	}
+
+	// edge check... we should have 3->2->1
+
+	for k := 2; k >= 1; k-- {
 		expect := tgraph.Node(k - 1)
 		got := tgraph.Out(tgraph.Node(k), 0)
 


### PR DESCRIPTION
- there was an error when the "stationary" component (i.e. the remainder after sampling) was not used which led to mixes and splits being combined into a single node of the execution graph. This causes downstream issues and so these are now separated into two nodes wherever this happens.

- remainders were also not registering as having locations set if their parent component's location is assigned automatically since these are copies rather than references. Invoking the sample tracker's ID-forwarding mechanism during the SplitSample command definition was sufficient to get the right behaviour. 