### PR TITLE
normalise the component name with subcomponents

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/solutions/ContainsComponent.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/ContainsComponent.go
@@ -120,9 +120,28 @@ func ContainsComponent(components []*wtype.LHComponent, component *wtype.LHCompo
 	return false, -1, fmt.Errorf("component %s not found in list: %s. : Errors for each: %s", componentSummary(component), componentNames(components), strings.Join(errs, "\n"))
 }
 
+func nonZeroComponents(compList ComponentList) int {
+	var nonZero int
+	for _, conc := range compList.Components {
+		if conc.RawValue() > 0 {
+			nonZero++
+		}
+	}
+	return nonZero
+}
+
 // EqualLists compares two ComponentLists and returns an error if the lists are not identical.
 func EqualLists(list1, list2 ComponentList) error {
 	var notEqual []string
+
+	if nonZeroComponents(list1) == 0 && nonZeroComponents(list2) == 0 {
+		return nil
+	}
+
+	if nonZeroComponents(list1) != nonZeroComponents(list2) {
+		return fmt.Errorf("componentlists unequal length: %d, %d", nonZeroComponents(list1), nonZeroComponents(list2))
+	}
+
 	for key, value1 := range list1.Components {
 		if value2, found := list2.Components[key]; found {
 			if fmt.Sprintf("%.2e", value1.SIValue()) != fmt.Sprintf("%.2e", value2.SIValue()) {

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -24,6 +24,7 @@
 package solutions
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
@@ -58,12 +59,25 @@ func NormaliseName(name string) (normalised string) {
 // An LB solution with no concentration and components is returned as LB.
 // Warning: if a component name already contains a concentration it will be possible to return duplicate concentration values. e.g. 10X 10X LB or 10X LB 10X.
 // To avoid this, when first declaring a component name the NormaliseName function should be used first.
-func NormaliseComponentName(component *wtype.LHComponent) string {
+func NormaliseComponentName(component *wtype.LHComponent) error {
 
 	compList, _ := GetSubComponents(component)
 
 	if component.HasConcentration() {
-		return component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false)
+		component.SetName(component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false))
+		if len(component.Name()) >= 100 {
+			component.SetName(component.Name()[:99])
+			return fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
+		}
+		return nil
 	}
-	return component.Name() + compList.List(false)
+
+	component.SetName(component.Name() + compList.List(false))
+
+	if len(component.Name()) >= 100 {
+		component.SetName(component.Name()[:99])
+		return fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
+	}
+
+	return nil
 }

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -58,7 +58,8 @@ func removeConcUnitFromName(name string) string {
 	for n := 0; n < 9; n++ {
 		_, _, name = wunit.ParseConcentration(strings.TrimSpace(name))
 	}
-	return name
+	newName := name
+	return newName
 }
 
 // ReturnNormalisedComponentName will return the component name in a normalised form.
@@ -66,19 +67,19 @@ func removeConcUnitFromName(name string) string {
 // e.g. a solution called LB with a concentration of 10X and components 10g/L Yeast Extract and 5g/L Tryptone will be normalised to 10g/L Yeast Extract + 5g/L Tryptone.
 // An LB solution with concentration 1 X and no components is returned as 1X LB.
 // An LB solution with no concentration and no components is returned as LB.
-func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error) {
+func ReturnNormalisedComponentName(component *wtype.LHComponent) string {
 	originalcompList, _ := GetSubComponents(component)
 
 	compList := originalcompList.removeConcsFromSubComponentNames()
 
 	if component.HasConcentration() && len(compList.Components) == 0 {
 		name := component.Concentration().ToString() + " " + removeConcUnitFromName(component.Name()) + " " + compList.List(false)
-		return name, nil
+		return name
 	}
 
 	name := compList.List(false, true)
 
-	return name, nil
+	return name
 }
 
 // NormaliseComponentName will change the name of the component to the normalised form returned by ReturnNormalisedComponentName.
@@ -88,9 +89,9 @@ func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error)
 // An LB solution with no concentration and no components is returned as LB.
 func NormaliseComponentName(component *wtype.LHComponent) error {
 
-	newName, err := ReturnNormalisedComponentName(component)
+	newName := ReturnNormalisedComponentName(component)
 
 	component.SetName(newName)
 
-	return err
+	return nil
 }

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -61,13 +61,18 @@ func removeConcUnitFromName(name string) string {
 	return name
 }
 
+// ReturnNormalisedComponentName will return the component name in a normalised form.
+// If sub components exist the name will be changed to the list of sub components with concentrations.
+// e.g. a solution called LB with a concentration of 10X and components 10g/L Yeast Extract and 5g/L Tryptone will be normalised to 10g/L Yeast Extract + 5g/L Tryptone.
+// An LB solution with concentration 1 X and no components is returned as 1X LB.
+// An LB solution with no concentration and no components is returned as LB.
 func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error) {
 	originalcompList, _ := GetSubComponents(component)
 
 	compList := originalcompList.removeConcsFromSubComponentNames()
 
 	if component.HasConcentration() && len(compList.Components) == 0 {
-		name := component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false)
+		name := component.Concentration().ToString() + " " + removeConcUnitFromName(component.Name()) + " " + compList.List(false)
 		return name, nil
 	}
 
@@ -76,11 +81,11 @@ func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error)
 	return name, nil
 }
 
-// NormaliseComponentName will return the concentration of the component followed by the unmodified component name followed by the full list of sub components with concentrations.
-// e.g. a solution called LB with a concentration of 10X and components 10g/L Yeast Extract and 5g/L Tryptone will be normalised to 10X LB---10g/L Yeast Extract---5g/L Tryptone.
-// An LB solution with no concentration and components is returned as LB.
-// Warning: if a component name already contains a concentration it will be possible to return duplicate concentration values. e.g. 10X 10X LB or 10X LB 10X.
-// To avoid this, when first declaring a component name the NormaliseName function should be used first.
+// NormaliseComponentName will change the name of the component to the normalised form returned by ReturnNormalisedComponentName.
+// If sub components exist the name will be changed to the list of sub components with concentrations.
+// e.g. a solution called LB with a concentration of 10X and components 10g/L Yeast Extract and 5g/L Tryptone will be normalised to 10g/L Yeast Extract + 5g/L Tryptone.
+// An LB solution with concentration 1 X and no components is returned as 1X LB.
+// An LB solution with no concentration and no components is returned as LB.
 func NormaliseComponentName(component *wtype.LHComponent) error {
 
 	newName, err := ReturnNormalisedComponentName(component)

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -24,7 +24,6 @@
 package solutions
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
@@ -69,19 +68,11 @@ func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error)
 
 	if component.HasConcentration() && len(compList.Components) == 0 {
 		name := component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false)
-		if len(component.Name()) >= 100 {
-			name = name[:99]
-			return name, fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
-		}
 		return name, nil
 	}
 
 	name := compList.List(false, true)
 
-	if len(component.Name()) >= 100 {
-		name = name[:99]
-		return name, fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
-	}
 	return name, nil
 }
 

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName.go
@@ -62,6 +62,29 @@ func removeConcUnitFromName(name string) string {
 	return name
 }
 
+func ReturnNormalisedComponentName(component *wtype.LHComponent) (string, error) {
+	originalcompList, _ := GetSubComponents(component)
+
+	compList := originalcompList.removeConcsFromSubComponentNames()
+
+	if component.HasConcentration() && len(compList.Components) == 0 {
+		name := component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false)
+		if len(component.Name()) >= 100 {
+			name = name[:99]
+			return name, fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
+		}
+		return name, nil
+	}
+
+	name := compList.List(false, true)
+
+	if len(component.Name()) >= 100 {
+		name = name[:99]
+		return name, fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
+	}
+	return name, nil
+}
+
 // NormaliseComponentName will return the concentration of the component followed by the unmodified component name followed by the full list of sub components with concentrations.
 // e.g. a solution called LB with a concentration of 10X and components 10g/L Yeast Extract and 5g/L Tryptone will be normalised to 10X LB---10g/L Yeast Extract---5g/L Tryptone.
 // An LB solution with no concentration and components is returned as LB.
@@ -69,25 +92,9 @@ func removeConcUnitFromName(name string) string {
 // To avoid this, when first declaring a component name the NormaliseName function should be used first.
 func NormaliseComponentName(component *wtype.LHComponent) error {
 
-	originalcompList, _ := GetSubComponents(component)
+	newName, err := ReturnNormalisedComponentName(component)
 
-	compList := originalcompList.removeConcsFromSubComponentNames()
+	component.SetName(newName)
 
-	if component.HasConcentration() && len(compList.Components) == 0 {
-		component.SetName(component.Concentration().ToString() + " " + component.Name() + " " + compList.List(false))
-		if len(component.Name()) >= 100 {
-			component.SetName(component.Name()[:99])
-			return fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
-		}
-		return nil
-	}
-
-	component.SetName(compList.List(false, true))
-
-	if len(component.Name()) >= 100 {
-		component.SetName(component.Name()[:99])
-		return fmt.Errorf("component name %s truncated to first 100 characters", component.Name())
-	}
-
-	return nil
+	return err
 }

--- a/antha/AnthaStandardLibrary/Packages/solutions/normaliseName_test.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/normaliseName_test.go
@@ -1,0 +1,60 @@
+// Part of the Antha language
+// Copyright (C) 2015 The Antha authors. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// For more information relating to the software or licensing issues please
+// contact license@antha-lang.org or write to the Antha team c/o
+// Synthace Ltd. The London Bioscience Innovation Centre
+// 2 Royal College St, London NW1 0NH UK
+
+// solutions is a utility package for working with solutions of LHComponents
+package solutions
+
+import "testing"
+
+type nameTest struct {
+	OriginalName    string
+	ExpectedNewName string
+}
+
+var nameTests = []nameTest{
+	{
+		OriginalName:    "1 X SolutionA",
+		ExpectedNewName: "SolutionA",
+	},
+	{
+		OriginalName:    "1 X 1 X 1 X SolutionA",
+		ExpectedNewName: "SolutionA",
+	},
+	{
+		OriginalName:    "1 X SolutionA+SolutionB",
+		ExpectedNewName: "SolutionA+SolutionB",
+	},
+}
+
+func TestRemoveConcUnitFromName(t *testing.T) {
+	for _, test := range nameTests {
+		newName := removeConcUnitFromName(test.OriginalName)
+
+		if newName != test.ExpectedNewName {
+			t.Error(
+				"for ", test.OriginalName, "\n",
+				"expected Conc free name: ", test.ExpectedNewName, "\n",
+				"got: ", newName, "\n",
+			)
+		}
+	}
+}

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
@@ -523,8 +523,6 @@ func setHistory(comp *wtype.LHComponent, compList ComponentList) (*wtype.LHCompo
 func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.LHComponent) error {
 	var warnings []string
 
-	originalName := productOfMixes.Name()
-
 	subComponents, _, err := SimulateMix(mixes...)
 
 	if err != nil {

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
@@ -31,8 +31,6 @@ import (
 
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/pubchem"
 
-	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/text"
-
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
@@ -519,13 +517,11 @@ func setHistory(comp *wtype.LHComponent, compList ComponentList) (*wtype.LHCompo
 	return comp, nil
 }
 
-// UpdateComponentDetails corrects the sub component list and name of a component with the details
+// UpdateComponentDetails corrects the sub component list and nromalises the name of a component with the details
 // of all sample mixes which are specified to be the source of that component.
 // This must currently be updated manually using this function.
 func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.LHComponent) error {
 	var warnings []string
-
-	originalName := productOfMixes.Name()
 
 	subComponents, _, err := SimulateMix(mixes...)
 
@@ -551,6 +547,5 @@ func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.L
 		return fmt.Errorf(strings.Join(warnings, "/n"))
 	}
 
-	text.Print(originalName+":\n", text.PrettyPrint(subComponents))
 	return nil
 }

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
@@ -489,3 +489,31 @@ func setHistory(comp *wtype.LHComponent, compList ComponentList) (*wtype.LHCompo
 
 	return comp, nil
 }
+
+// UpdateComponentDetails corrects the sub component list and name of a component with the details of all samples which made up that component.
+func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.LHComponent) error {
+	var warnings []string
+
+	subComponents, _, err := SimulateMix(mixes...)
+
+	if err != nil {
+		warnings = append(warnings, err.Error())
+	}
+
+	productOfMixes, err = AddSubComponents(productOfMixes, subComponents)
+
+	if err != nil {
+		warnings = append(warnings, err.Error())
+	}
+
+	err = NormaliseComponentName(productOfMixes)
+
+	if err != nil {
+		warnings = append(warnings, err.Error())
+	}
+
+	if len(warnings) > 0 {
+		return fmt.Errorf(strings.Join(warnings, "/n"))
+	}
+	return nil
+}

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
@@ -490,7 +490,9 @@ func setHistory(comp *wtype.LHComponent, compList ComponentList) (*wtype.LHCompo
 	return comp, nil
 }
 
-// UpdateComponentDetails corrects the sub component list and name of a component with the details of all samples which made up that component.
+// UpdateComponentDetails corrects the sub component list and name of a component with the details
+// of all sample mixes which are specified to be the source of that component.
+// This must currently be updated manually using this function.
 func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.LHComponent) error {
 	var warnings []string
 

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents.go
@@ -517,11 +517,13 @@ func setHistory(comp *wtype.LHComponent, compList ComponentList) (*wtype.LHCompo
 	return comp, nil
 }
 
-// UpdateComponentDetails corrects the sub component list and nromalises the name of a component with the details
+// UpdateComponentDetails corrects the sub component list and normalises the name of a component with the details
 // of all sample mixes which are specified to be the source of that component.
 // This must currently be updated manually using this function.
 func UpdateComponentDetails(productOfMixes *wtype.LHComponent, mixes ...*wtype.LHComponent) error {
 	var warnings []string
+
+	originalName := productOfMixes.Name()
 
 	subComponents, _, err := SimulateMix(mixes...)
 

--- a/antha/AnthaStandardLibrary/Packages/solutions/subcomponents_test.go
+++ b/antha/AnthaStandardLibrary/Packages/solutions/subcomponents_test.go
@@ -286,18 +286,8 @@ func TestUpdateComponentDetails(t *testing.T) {
 		return c
 	}
 
-	//x1 := wunit.NewConcentration(1, "X")
 	gPerL0 := wunit.NewConcentration(0.0, "g/L")
 	gPerL1 := wunit.NewConcentration(1, "g/L")
-	/*
-		x10 := wunit.NewConcentration(10, "X")
-		x100 := wunit.NewConcentration(100, "X")
-
-		gPerL01 := wunit.NewConcentration(0.1, "g/L")
-
-		gPerL10 := wunit.NewConcentration(10, "g/L")
-		gPerL100 := wunit.NewConcentration(100, "g/L")
-	*/
 
 	var nilComponentList ComponentList
 

--- a/antha/anthalib/wunit/interface.go
+++ b/antha/anthalib/wunit/interface.go
@@ -121,11 +121,11 @@ func UnitBySymbol(sym string) GenericUnit {
 // generate an initial unit library
 func Make_units() map[string]GenericUnit {
 
-	units := []string{"M", "min", "l", "L", "g", "V", "J", "A", "N", "s", "radians", "degrees", "rads", "Hz", "rpm", "℃", "M/l", "g/l", "J/kg", "Pa", "kg/m^3", "/s", "/min", "per", `/`, "m/s", "m^2", "mm^2", "ml/min", "kg/l", "X", "U/l", "m"}
-	unitnames := []string{"mole", "minute", "litre", "litre", "Gramme", "Volt", "Joule", "Ampere", "Newton", "second", "radian", "degree", "radian", "Herz", "revolutions per minute", "Celsius", "Mol/litre", "g/litre", "Joule/kilogram", "Pascal", "kg per cubic meter", "per second", "per minute", "per", "per", "metres per second", "square metres", "square metres", "millilitres/minute", "kilogram per litre", "times", "Units	 per L", "metres"}
+	units := []string{"M", "min", "l", "L", "g", "V", "J", "A", "N", "s", "radians", "degrees", "rads", "Hz", "rpm", "℃", "M/l", "g/l", "J/kg", "Pa", "kg/m^3", "/s", "/min", "per", `/`, "m/s", "m^2", "mm^2", "ml/min", "kg/l", "X", "U/l", "m", "v/v"}
+	unitnames := []string{"mole", "minute", "litre", "litre", "Gramme", "Volt", "Joule", "Ampere", "Newton", "second", "radian", "degree", "radian", "Herz", "revolutions per minute", "Celsius", "Mol/litre", "g/litre", "Joule/kilogram", "Pascal", "kg per cubic meter", "per second", "per minute", "per", "per", "metres per second", "square metres", "square metres", "millilitres/minute", "kilogram per litre", "times", "Units	 per L", "metres", "volume/volume"}
 	//unitdimensions:=[]string{"amount", "time", "length^3", "length^3", "mass", "mass*length/time^2*charge", "mass*length^2/time^2", "charge/time", "charge", "mass*length/time^2", "time", "angle", "angle", "angle", "time^-1", "angle/time", "temperature", "velocity}
 
-	unitbaseconvs := []float64{1, 0.1666666666666666667, 1, 1, 0.001, 1, 1, 1, 1, 1, 1, 0.01745329251994, 1, 1, 1, 1, 1, 0.001, 1, 1, 1, 1, 0.1666666666666666667, 1, 1, 1, 1, 0.000001, 1., 1, 1, 1, 1}
+	unitbaseconvs := []float64{1, 0.1666666666666666667, 1, 1, 0.001, 1, 1, 1, 1, 1, 1, 0.01745329251994, 1, 1, 1, 1, 1, 0.001, 1, 1, 1, 1, 0.1666666666666666667, 1, 1, 1, 1, 0.000001, 1., 1, 1, 1, 1, 1}
 
 	unit_map := make(map[string]GenericUnit, len(units))
 

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -579,6 +579,8 @@ var UnitMap = map[string]map[string]Unit{
 		"U/L":     Unit{Base: "U/l", Prefix: "", Multiplier: 1.0},
 		"U/ml":    Unit{Base: "U/l", Prefix: "", Multiplier: 1000.0},
 		"U/mL":    Unit{Base: "U/l", Prefix: "", Multiplier: 1000.0},
+		"v/v":     Unit{Base: "v/v", Prefix: "", Multiplier: 1.0},
+		"w/v":     Unit{Base: "g/l", Prefix: "k", Multiplier: 1.0},
 	},
 	"Mass": map[string]Unit{
 		"ng": Unit{Base: "g", Prefix: "n", Multiplier: 1.0},


### PR DESCRIPTION
Fixes issue with component names with concentrations being misleading when several mix steps occur:

relates to: https://repos.antha.com/antha-ninja/elements-westeros/merge_requests/346/diffs