### PR TITLE
Fixes for golang 1.10

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/buffers/order/order.go
+++ b/antha/AnthaStandardLibrary/Packages/buffers/order/order.go
@@ -85,7 +85,34 @@ type StorageConditions struct {
 
 // String returns a summary of any storage restrictions.
 func (s StorageConditions) String() string {
-	return fmt.Sprintf("%+v", s)
+	var sensitive []string
+	var notSensitive []string
+
+	names := map[string]bool{
+		"light":       s.LightSensitive,
+		"moisture":    s.MoistureSensistive,
+		"oxygen":      s.OxygenSensistive,
+		"freeze/thaw": s.FreezeThawSensitive,
+	}
+
+	for name, s := range names {
+		if s {
+			sensitive = append(sensitive, name)
+		} else {
+			notSensitive = append(notSensitive, name)
+		}
+	}
+
+	sensitivities := ""
+	if len(sensitive) > 0 {
+		sensitivities = fmt.Sprintf(", sensitive to %s", strings.Join(sensitive, ", "))
+	}
+	insensitivities := ""
+	if len(notSensitive) > 0 {
+		insensitivities = fmt.Sprintf(", not sensitive to %s", strings.Join(notSensitive, ", "))
+	}
+
+	return fmt.Sprintf("Temperature Range: [%v - %v]%s%s.", s.MinTemp, s.MaxTemp, sensitivities, insensitivities)
 }
 
 // GetOrderDetails returns order Details for a component.

--- a/antha/AnthaStandardLibrary/Packages/eng/Evaporation.go
+++ b/antha/AnthaStandardLibrary/Packages/eng/Evaporation.go
@@ -35,15 +35,15 @@ func Θ(liquid string, airvelocity wunit.Velocity) (float64, error) {
 	var ok bool
 	liquiddetails, ok := liquidclasses.Liquidclass[liquid]
 	if !ok {
-		return 0.0, fmt.Errorf("liquid,", liquid, "not found in map", "liquidclasses.Liquidclass[liquid]")
+		return 0.0, fmt.Errorf("liquid \"%s\" not found in map liquidclasses.Liquidclass[liquid]", liquid)
 	}
 	c, ok := liquiddetails["c"]
 	if !ok {
-		return 0.0, fmt.Errorf("liquid,", liquid, "not found in map", "no value c found for liquid in liquidclasses.Liquidclass[liquid][c]")
+		return 0.0, fmt.Errorf("liquid \"%s\" not found in map no value c found for liquid in liquidclasses.Liquidclass[liquid][c]", liquid)
 	}
 	d, ok := liquiddetails["d"]
 	if !ok {
-		return 0.0, fmt.Errorf("liquid,", liquid, "not found in map", "no value d found for liquid in liquidclasses.Liquidclass[liquid][d]")
+		return 0.0, fmt.Errorf("liquid \"%s\" not found in map no value d found for liquid in liquidclasses.Liquidclass[liquid][d]", liquid)
 	}
 	return (c) + ((d) * airvelocity.SIValue()), nil
 

--- a/antha/AnthaStandardLibrary/Packages/sequences/kmer/kmer_test.go
+++ b/antha/AnthaStandardLibrary/Packages/sequences/kmer/kmer_test.go
@@ -22,17 +22,17 @@ func Test1(t *testing.T) {
 	sr := hdb.SearchWith(&s3)
 
 	if sr[0].Name != "There" {
-		t.Errorf("Expected first hit to be sequence 'There', instead got '", sr[0].Name, "'")
+		t.Errorf("Expected first hit to be sequence \"There\", instead got \"%s\"", sr[0].Name)
 	}
 	sr = hdb.SearchWith(ss[0])
 
 	if sr[0].Name != "Hi" {
-		t.Errorf("Expected first hit to be sequence 'Hi', instead got '", sr[0].Name, "'")
+		t.Errorf("Expected first hit to be sequence \"Hi\", instead got \"%s\"", sr[0].Name)
 	}
 
 	sr = hdb.SearchWith(ss[1])
 
 	if sr[0].Name != "There" {
-		t.Errorf("Expected first hit to be sequence 'There', instead got '", sr[0].Name, "'")
+		t.Errorf("Expected first hit to be sequence \"There\", instead got \"%s\"", sr[0].Name)
 	}
 }

--- a/antha/AnthaStandardLibrary/Packages/sequences/parse/genbank/genbank_parser.go
+++ b/antha/AnthaStandardLibrary/Packages/sequences/parse/genbank/genbank_parser.go
@@ -26,6 +26,7 @@ package genbank
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -166,7 +167,7 @@ func locusLine(line string) (name string, seqlength int, seqtype string, circula
 	fields = newarray
 	if len(fields) > 1 {
 		if len(fields) < 5 {
-			err = fmt.Errorf("The locusline does not contain enough elements or is not formatted correctly. Please check file.")
+			err = errors.New("the locusline does not contain enough elements or is not formatted correctly. Please check file.")
 			return
 		}
 		name = fields[0]
@@ -190,7 +191,7 @@ func locusLine(line string) (name string, seqlength int, seqtype string, circula
 		}
 		return
 	} else {
-		err = fmt.Errorf("invalid genbank line: ", line)
+		err = fmt.Errorf("invalid genbank locus line: \"%s\"", line)
 	}
 
 	return
@@ -224,7 +225,7 @@ func featureline1(line string) (reverse bool, class string, startposition int, e
 		}
 		var warning error
 		if strings.Contains(s, `join`) {
-			warning = fmt.Errorf("double position of feature!!", s, "adding as one feature only for now")
+			warning = fmt.Errorf("feature \"%s\" contains join location, adding as one feature only for now", s)
 			s = strings.Replace(s, "Join(", "", -1)
 			s = strings.Replace(s, ")", "", -1)
 			joinhandler := strings.Split(s, `,`)

--- a/antha/AnthaStandardLibrary/Packages/sequences/parse/genbank/genbankparser_test.go
+++ b/antha/AnthaStandardLibrary/Packages/sequences/parse/genbank/genbankparser_test.go
@@ -373,7 +373,7 @@ func TestGenbanktoAnnotatedSeq(t *testing.T) {
 						"For", test.testname, "\n",
 						"feature:", name, "\n",
 						"expected positions:", test.featurePositionMap[name], "\n",
-						"got more positions: ", len(features), "\n",
+						"got more positions: ", len(features),
 					)
 				}
 				for _, feature := range features {

--- a/antha/anthalib/wtype/biology.go
+++ b/antha/anthalib/wtype/biology.go
@@ -728,11 +728,11 @@ type AminoAcid string
 func SetAminoAcid(aa string) (AminoAcid, error) {
 
 	if len(aa) != 1 {
-		return "", fmt.Errorf("amino acid %s not valid. Please use single letter code.")
+		return "", fmt.Errorf("amino acid \"%s\" not valid. Please use single letter code.", aa)
 	}
 
 	if err := ValidAA(aa); err != nil {
-		return "", fmt.Errorf("amino acid %s not valid: %s", aa, err.Error())
+		return "", fmt.Errorf("amino acid \"%s\" not valid: %s", aa, err.Error())
 	}
 	return AminoAcid(strings.ToUpper(strings.TrimSpace(aa))), nil
 }
@@ -746,11 +746,11 @@ type Codon string
 func SetCodon(dna string) (Codon, error) {
 
 	if len(dna) != 3 {
-		return "", fmt.Errorf("codon %s not valid. must be three nucleotides.")
+		return "", fmt.Errorf("codon \"%s\" not valid. must be three nucleotides.", dna)
 	}
 
 	if err := ValidDNA(dna); err != nil {
-		return "", fmt.Errorf("codon %s not valid: %s", dna, err.Error())
+		return "", fmt.Errorf("codon \"%s\" not valid: %s", dna, err.Error())
 	}
 	return Codon(strings.ToUpper(strings.TrimSpace(dna))), nil
 }

--- a/antha/anthalib/wtype/lhplate_test.go
+++ b/antha/anthalib/wtype/lhplate_test.go
@@ -100,7 +100,7 @@ func validatePlate(t *testing.T, plate *LHPlate) {
 		}
 		for w, count := range seen {
 			if count != 2 {
-				t.Errorf("%s: no matching well found (%d != %d) for %p %s:%s", what, count, 2, w, w.ID, w.Crds)
+				t.Errorf("%s: no matching well found (%d != %d) for %p %s:%s", what, count, 2, w, w.ID, w.Crds.FormatA1())
 			}
 		}
 	}

--- a/antha/anthalib/wtype/shape.go
+++ b/antha/anthalib/wtype/shape.go
@@ -84,7 +84,7 @@ func (sh *Shape) MaxCrossSectionalArea() (area wunit.Area, err error) {
 	} else if boxlike {
 		area = wunit.NewArea(sh.H*sh.W, areaunit)
 	} else {
-		err = fmt.Errorf("No method to work out cross sectional area for shape %s yet Circular? %b", sh.ShapeName, circular)
+		err = fmt.Errorf("No method to work out cross sectional area for shape \"%s\" yet Circular? %t", sh.ShapeName, circular)
 	}
 	return
 }

--- a/antha/anthalib/wunit/conversion.go
+++ b/antha/anthalib/wunit/conversion.go
@@ -90,7 +90,7 @@ func VolumeForTargetMass(targetmass Mass, stockConc Concentration) (v Volume, er
 		fmt.Println("starting conc SI ", stockConc.SIValue(), " and target mass SI: ", targetmass.SIValue())
 	} else {
 		fmt.Println("Base units ", stockConc.Unit().BaseSIUnit(), " and ", targetmass.Unit().BaseSIUnit(), " not compatible with this function")
-		err = fmt.Errorf("Convert ", targetmass.ToString(), " to g and ", stockConc.ToString(), " to g/l")
+		err = fmt.Errorf("Convert %s to g and %s to g/l", targetmass.ToString(), stockConc.ToString())
 	}
 
 	return

--- a/driver/lh/client_test.go
+++ b/driver/lh/client_test.go
@@ -84,7 +84,7 @@ func validatePlate(t *testing.T, plate *wtype.LHPlate) {
 		}
 		for w, count := range seen {
 			if count != 2 {
-				t.Errorf("%s: no matching well found (%d != %d) for %p %s:%s", what, count, 2, w, w.ID, w.Crds)
+				t.Errorf("%s: no matching well found (%d != %d) for %p %s:%s", what, count, 2, w, w.ID, w.Crds.FormatA1())
 			}
 		}
 	}

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -290,7 +290,7 @@ func TestMultiChannelFailComponent(t *testing.T) {
 	}
 
 	if len(ris) != 1 {
-		t.Errorf("Expected 1 transfer got ", len(ris))
+		t.Errorf("Expected 1 transfer got %d", len(ris))
 	}
 
 	tf := ris[0].(*TransferInstruction)

--- a/microArch/driver/liquidhandling/transferparams.go
+++ b/microArch/driver/liquidhandling/transferparams.go
@@ -276,12 +276,8 @@ func (mtp MultiTransferParams) ParamSet(n int) TransferParams {
 }
 
 func (mtp MultiTransferParams) ToString() string {
+
 	s := ""
-
-	if mtp.ParamSet == nil {
-		return s
-	}
-
 	for i := 0; i < mtp.Multi; i++ {
 		s += mtp.ParamSet(i).ToString() + " "
 	}

--- a/microArch/logger/logger_test.go
+++ b/microArch/logger/logger_test.go
@@ -90,7 +90,7 @@ func TestMiddlewareCalls(t *testing.T) {
 	}
 	Sensor("")
 	if l := sensorCounter; l != 1 {
-		t.Error("expecting %d sensor calls, got %d", 1, l)
+		t.Errorf("expecting %d sensor calls, got %d", 1, l)
 	}
 }
 
@@ -155,7 +155,7 @@ func TestLogLogger(t *testing.T) {
 
 	Info("test")
 	if buf.Len() == 0 {
-		t.Errorf("default logger output empty. Expecting ", len("test"))
+		t.Errorf("default logger output empty. Expecting %d", len("test"))
 	}
 	cleanMiddleware() //MUST!
 	before := logCounter

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -258,7 +258,7 @@ func (this *Liquidhandler) Execute(request *LHRequest) error {
 		_, ok := ins.(liquidhandling.TerminalRobotInstruction)
 
 		if !ok {
-			fmt.Printf("ERROR: Got instruction ", liquidhandling.InsToString(ins), "which is wrong type")
+			fmt.Printf("ERROR: Got instruction \"%s\" which is wrong type", liquidhandling.InsToString(ins))
 			continue
 		}
 

--- a/microArch/scheduler/liquidhandling/solution_setup.go
+++ b/microArch/scheduler/liquidhandling/solution_setup.go
@@ -85,7 +85,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 					totalvol = tv // not needed
 				} else {
 					// error
-					return nil, nil, wtype.LHError(wtype.LH_ERR_CONC, fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.CName))
+					return nil, nil, wtype.LHErrorf(wtype.LH_ERR_CONC, "Inconsistent total volumes %s and %s at component %s", totalvol, tv, component.CName)
 				}
 			} else {
 				cmpvol.Add(component.Volume())
@@ -166,7 +166,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 	}
 
 	if len(mconcs) > 0 {
-		fmt.Println(text.Green(fmt.Sprint("mconcs: %+v", mconcs)))
+		fmt.Println(text.Green(fmt.Sprintf("mconcs: %+v", mconcs)))
 	}
 
 	for cmp, arr := range mconcs {
@@ -243,7 +243,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 					totalvol = tv
 				} else {
 					// error
-					return nil, nil, wtype.LHError(wtype.LH_ERR_CONC, fmt.Sprintf("Inconsistent total volumes %-6.4f and %-6.4f at component %s", totalvol, tv, component.CName))
+					return nil, nil, wtype.LHErrorf(wtype.LH_ERR_CONC, "Inconsistent total volumes %s and %s at component %s", totalvol, tv, component.CName)
 				}
 			} else {
 				// need to add in the volume taken up by any volume components
@@ -291,7 +291,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 	}
 
 	if len(fixconcs) > 0 {
-		fmt.Println(text.Red(fmt.Sprint("fixconcs: %+v", fixconcs)))
+		fmt.Println(text.Red(fmt.Sprintf("fixconcs: %+v", fixconcs)))
 	}
 
 	stockConcs, err := convertFloatsToConc(stockconcs, minUnit)

--- a/microArch/scheduler/liquidhandling/tgraph_test.go
+++ b/microArch/scheduler/liquidhandling/tgraph_test.go
@@ -42,7 +42,7 @@ func TestTGraph(t *testing.T) {
 	}
 
 	if tgraph.NumNodes() != 10 {
-		t.Errorf("NumNodes should report 10, instead reports %d", tgraph.NumNodes)
+		t.Errorf("NumNodes should report 10, instead reports %d", tgraph.NumNodes())
 	}
 
 	// edge check... we should have 9->8->7->6->5
@@ -114,7 +114,7 @@ func TestTGraphSplit(t *testing.T) {
 	}
 
 	if tgraph.NumNodes() != 3 {
-		t.Errorf("NumNodes should report 3, instead reports %d", tgraph.NumNodes)
+		t.Errorf("NumNodes should report 3, instead reports %d", tgraph.NumNodes())
 	}
 
 	// edge check... we should have 3->2->1

--- a/microArch/simulator/liquidhandling/simulator_testcode_test.go
+++ b/microArch/simulator/liquidhandling/simulator_testcode_test.go
@@ -301,7 +301,7 @@ func test_worst(t *testing.T, errors []*simulator.SimulationError, worst simulat
 	}
 
 	if s != worst {
-		t.Error("Expected maximum severity %v, actual maximum severity %v", worst, s)
+		t.Errorf("Expected maximum severity %v, actual maximum severity %v", worst, s)
 	}
 }
 


### PR DESCRIPTION
fixes build errors in golang1.10

Main cause of changes is that fmt.Printf/Sprintf without format codes, or fmt.println without now generates compile errors

Bigger changes to StorageConditions.String() - golang1.10 detects the loop and raised a compile error