### PR TITLE
Fix/split sample revisions

### DIFF
--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -1152,7 +1152,6 @@ func componentList(vec ComponentVector) map[string]bool {
 
 func (p *LHPlate) GetVolumeFilteredContentVector(wv []WellCoords, cmps ComponentVector, mpv wunit.Volume, ignoreInstances bool) ComponentVector {
 	cv := p.GetFilteredContentVector(wv, cmps, ignoreInstances)
-
 	cv.DeleteAllBelowVolume(mpv)
 	return cv
 }

--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -857,7 +857,6 @@ func (w *LHWell) UpdateContentID(IDBefore string, after *LHComponent) bool {
 		w.WContents.AddParentComponent(w.WContents)
 		w.WContents.ID = after.ID
 		w.WContents.CName = after.CName
-
 		return true
 	}
 

--- a/inventory/testinventory/testinventory.go
+++ b/inventory/testinventory/testinventory.go
@@ -21,7 +21,8 @@ func (i *testInventory) NewComponent(ctx context.Context, name string) (*wtype.L
 	if !ok {
 		return nil, fmt.Errorf("%s: invalid solution: %s", inventory.ErrUnknownType, name)
 	}
-	return c.Dup(), nil
+	// Cp is required here to ensure component IDs are unique
+	return c.Cp(), nil
 }
 
 func (i *testInventory) NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {

--- a/microArch/driver/liquidhandling/choosechannel_test.go
+++ b/microArch/driver/liquidhandling/choosechannel_test.go
@@ -85,8 +85,8 @@ func TestDefaultChooser(t *testing.T) {
 				fmt.Println("V: ", vol.ToString(), " Mn: ", prm.Minvol.ToString(), " Mx: ", prm.Maxvol.ToString(), " TIP: ", tiptype)
 			}
 		*/
-	}
 
+	}
 }
 
 func makeTestLH() *LHProperties {

--- a/microArch/driver/liquidhandling/compareinstructions_test.go
+++ b/microArch/driver/liquidhandling/compareinstructions_test.go
@@ -1,9 +1,8 @@
 package liquidhandling
 
 import (
-	"testing"
-
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"testing"
 )
 
 func testInstructions1() []RobotInstruction {

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -103,7 +103,6 @@ func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi in
 
 		if ok {
 			it := getPlateIterator(p, ori, multi)
-
 			for wv := it.Curr(); it.Valid(); wv = it.Next() {
 				// cmps needs duping here
 				mycmps := p.GetVolumeFilteredContentVector(wv, cmps, minPossibleVolume, ignoreInstances) // dups components

--- a/microArch/driver/liquidhandling/splitblock.go
+++ b/microArch/driver/liquidhandling/splitblock.go
@@ -39,6 +39,14 @@ func (sp SplitBlockInstruction) Generate(ctx context.Context, policy *wtype.LHPo
 		// if Components is a sample we'll probably want to change ParentID instead
 		// that may not work
 		robot.UpdateComponentID(ins.Components[0].ID, ins.Results[1])
+
+		/*
+			question over whether this is needed
+			if !ok {
+				fmt.Printf("Warning: cannot update component ID %s to %s: Not found\n", ins.Components[0].ID, ins.Results[1].ID)
+				//return []RobotInstruction{}, fmt.Errorf("Error updating component ID %s to %s: Not found", ins.Components[0].ID, ins.Results[1].ID)
+			}
+		*/
 	}
 
 	return []RobotInstruction{}, nil

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -768,3 +768,35 @@ func TestMultiChannelTipReuseUgly(t *testing.T) {
 
 	assertNumLoadUnloadInstructions(t, ris, 2)
 }
+
+//TestMultiChannelTipReuseUgly Move water and ethanol to the same columns of wells - should change tips in between
+func BenchmarkMultiChannelTipReuseUgly(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ctx := testinventory.NewContext(context.Background())
+
+		inss, err := getMixInstructions(ctx, 8, []string{inventory.WaterType, "ethanol"}, []float64{50.0, 50.0})
+		if err != nil {
+			panic(err)
+		}
+
+		generateRobotInstructions2(ctx, inss, nil)
+	}
+}
+
+func generateRobotInstructions2(ctx context.Context, inss []*wtype.LHInstruction, pol *wtype.LHPolicyRuleSet) []RobotInstruction {
+
+	tb, dstp := getTransferBlock(ctx, inss, "pcrplate_skirted_riser40")
+
+	rbt := getTestRobot(ctx, dstp, "pcrplate_skirted_riser40")
+	if pol == nil {
+		pol, _ = GetLHPolicyForTest()
+		// allow multi
+		pol.Policies["water"]["CAN_MULTI"] = true
+	}
+
+	//generate the low level instructions
+	instructionSet := NewRobotInstructionSet(tb)
+	ris2, _ := instructionSet.Generate(ctx, pol, rbt)
+
+	return ris2
+}

--- a/microArch/scheduler/liquidhandling/fixvolumes_test.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes_test.go
@@ -2,6 +2,7 @@ package liquidhandling
 
 import (
 	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"testing"
@@ -72,7 +73,7 @@ func TestFixVolumes(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	// check to see if the result of the first mix is now 150.0 ul
+	// check to see if the result of the first mix is now 155.0 ul
 
 	mix1 := req.InstructionChain.Values[0]
 
@@ -255,5 +256,83 @@ func TestFixVolumes4(t *testing.T) {
 
 	if err != nil {
 		t.Errorf(err.Error())
+	}
+}
+
+// test for splitsample fixing
+func TestFixVolumesSplitSample(t *testing.T) {
+	req := NewLHRequest()
+
+	c1 := getComponentWithNameVolume("water", 50.0)
+	c2 := getComponentWithNameVolume("milk", 50.0)
+
+	c3 := c1.Dup()
+	c3.Mix(c2)
+	c3.DeclareInstance()
+
+	ins := wtype.NewLHMixInstruction()
+	ins.Components = []*wtype.LHComponent{c1, c2}
+	ins.AddResult(c3)
+
+	req.LHInstructions[ins.ID] = ins
+
+	ic := &IChain{
+		Parent: nil,
+		Child:  nil,
+		Values: []*wtype.LHInstruction{ins},
+		Depth:  0,
+	}
+
+	req.InstructionChain = ic
+
+	//now take lots of split samples
+	mixInss := make([]*wtype.LHInstruction, 0, 10)
+	splInss := make([]*wtype.LHInstruction, 0, 10)
+
+	for i := 0; i < 10; i++ {
+		ins = wtype.NewLHMixInstruction()
+		//smp, err := c3.Sample(wunit.NewVolume(15.0, "ul"))
+		//smp.SetSample(true)
+		//smp.DeclareInstance()
+		//smp.ParentID = c3.ID
+
+		smp, newC3 := mixer.SplitSample(c3, wunit.NewVolume(15.0, "ul"))
+
+		ins.Components = []*wtype.LHComponent{smp}
+		res := getComponentWithNameVolume("water+milk", 15.0)
+		res.ParentID = ins.Components[0].ID
+		res.DeclareInstance()
+		ins.AddResult(res)
+		req.LHInstructions[ins.ID] = ins
+
+		// make the split instruction
+		splitIns := wtype.NewLHSplitInstruction()
+		splitIns.AddComponent(c3)
+		splitIns.AddProduct(smp)
+		splitIns.AddProduct(newC3)
+		c3.Vol = 100.0
+		c3 = newC3
+
+		mixInss = append(mixInss, ins)
+		splInss = append(splInss, splitIns)
+	}
+
+	ic.Child = &IChain{Parent: ic, Child: nil, Values: splInss, Depth: 1}
+	ic.Child.Child = &IChain{Parent: ic.Child, Child: nil, Values: mixInss, Depth: 2}
+
+	// try fixing the volumes
+
+	req, err := FixVolumes(req)
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// check to see if the result of the first mix is now 155.0 ul
+
+	mix1 := req.InstructionChain.Values[0]
+
+	if mix1.Results[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
 	}
 }

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -207,10 +207,13 @@ func (it *IChain) splitMixedNode() {
 		}
 	}
 
+	// it == Mix level
 	it.Values = mixValues
+	// ch == Split level
 	ch := NewIChain(it)
 	ch.Values = splitValues
 	ch.Child = it.Child
+	ch.Child.Parent = ch
 	it.Child = ch
 }
 


### PR DESCRIPTION
Main fix in this branch is improving the volume fixing logic to account for split samples, which previously were ignored, causing a test failure for one bundle using the revised SerialDilutions protocol.

The mechanism is similar to the one for prompts in that the ID change is handled when assessing the amount of component required, additionally there is logic to accumulate if the new ID is already known when planning. 

One small fix comes in with this: previously inventory components were returned with a constant ID. This has not previously been consequential but was clearly incorrect behaviour. Now this is fixed.

Also as a freebie there is an additional benchmark test added to the transferblock test set as a convenience for profiling a substantial part of the system. 