### PR TITLE
Feature/handle duplicate plate names

### DIFF
--- a/antha/anthalib/wtype/uuid.go
+++ b/antha/anthalib/wtype/uuid.go
@@ -23,7 +23,7 @@
 package wtype
 
 import (
-	//	"github.com/dustinkirkland/golang-petname"
+	//"github.com/dustinkirkland/golang-petname"
 	"github.com/twinj/uuid"
 )
 

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -181,7 +181,6 @@ func input_plate_setup(ctx context.Context, request *LHRequest) (*LHRequest, err
 					}
 					plates_in_play[platetype.Type] = p
 					curr_plate = plates_in_play[platetype.Type]
-					//platename := fmt.Sprintf("Input_plate_%d", curplaten)
 					platename := getSafeInputPlateName(request, curplaten)
 					curr_plate.PlateName = platename
 					curplaten += 1

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -25,6 +25,7 @@ package liquidhandling
 import (
 	"context"
 	"fmt"
+	"github.com/dustinkirkland/golang-petname"
 	"sort"
 	"strings"
 
@@ -180,7 +181,8 @@ func input_plate_setup(ctx context.Context, request *LHRequest) (*LHRequest, err
 					}
 					plates_in_play[platetype.Type] = p
 					curr_plate = plates_in_play[platetype.Type]
-					platename := fmt.Sprintf("Input_plate_%d", curplaten)
+					//platename := fmt.Sprintf("Input_plate_%d", curplaten)
+					platename := getSafePlateName(request, curplaten)
 					curr_plate.PlateName = platename
 					curplaten += 1
 					curr_plate.DeclareTemporary()
@@ -264,4 +266,25 @@ func isInstance(s string) bool {
 	} else {
 		return false
 	}
+}
+
+// returns a unique plate name
+func getSafePlateName(request *LHRequest, curplaten int) string {
+	trialPlateName := randomPlateName("auto_input_plate", "_", curplaten)
+
+	for {
+		if request.HasPlateNamed(trialPlateName) {
+			trialPlateName = randomPlateName("auto_input_plate", "_", curplaten)
+
+		} else {
+			break
+		}
+	}
+
+	return trialPlateName
+}
+
+func randomPlateName(prefix, sep string, order int) string {
+	tox := []string{prefix, fmt.Sprintf("%d", order), petname.Generate(1, "")}
+	return strings.Join(tox, sep)
 }

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -182,7 +182,7 @@ func input_plate_setup(ctx context.Context, request *LHRequest) (*LHRequest, err
 					plates_in_play[platetype.Type] = p
 					curr_plate = plates_in_play[platetype.Type]
 					//platename := fmt.Sprintf("Input_plate_%d", curplaten)
-					platename := getSafePlateName(request, curplaten)
+					platename := getSafeInputPlateName(request, curplaten)
 					curr_plate.PlateName = platename
 					curplaten += 1
 					curr_plate.DeclareTemporary()
@@ -269,12 +269,16 @@ func isInstance(s string) bool {
 }
 
 // returns a unique plate name
-func getSafePlateName(request *LHRequest, curplaten int) string {
-	trialPlateName := randomPlateName("auto_input_plate", "_", curplaten)
+func getSafeInputPlateName(request *LHRequest, curplaten int) string {
+	return getSafePlateName(request, "auto_input_plate", "_", curplaten)
+}
+
+func getSafePlateName(request *LHRequest, prefix, sep string, curplaten int) string {
+	trialPlateName := randomPlateName(prefix, sep, curplaten)
 
 	for {
 		if request.HasPlateNamed(trialPlateName) {
-			trialPlateName = randomPlateName("auto_input_plate", "_", curplaten)
+			trialPlateName = randomPlateName(prefix, sep, curplaten)
 
 		} else {
 			break

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -24,8 +24,6 @@
 package liquidhandling
 
 import (
-	"fmt"
-
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
@@ -223,7 +221,8 @@ func (lhr *LHRequest) AddUserPlate(p *wtype.LHPlate) {
 	// impose sanity
 
 	if p.PlateName == "" {
-		p.PlateName = fmt.Sprintf("User_plate_%d", lhr.NUserPlates+1)
+		//p.PlateName = fmt.Sprintf("User_plate_%d", lhr.NUserPlates+1)
+		p.PlateName = getSafePlateName(lhr, "user_plate", "_", lhr.NUserPlates+1)
 		lhr.NUserPlates += 1
 	}
 

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -252,18 +252,22 @@ func (mgr *LHPolicyManager) MergePolicies(protocolpolicies *wtype.LHPolicyRuleSe
 	return ret
 }
 
-/*
-func (request *LHRequest) GetPlate(id string) *wtype.LHPlate {
-	p, ok := request.Input_plates[id]
-
-	if !ok {
-		p, ok = request.Output_plates[id]
-
-		if !ok {
-			return nil
+func (request *LHRequest) HasPlateNamed(name string) bool {
+	checkForPlateNamed := func(query string, subject map[string]*wtype.LHPlate) bool {
+		for _, plate := range subject {
+			if plate.PlateName == query {
+				return true
+			}
 		}
+		return false
 	}
 
-	return p
+	if checkForPlateNamed(name, request.Input_plates) {
+		return true
+	}
+	if checkForPlateNamed(name, request.Output_plates) {
+		return true
+	}
+
+	return false
 }
-*/

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -221,7 +221,6 @@ func (lhr *LHRequest) AddUserPlate(p *wtype.LHPlate) {
 	// impose sanity
 
 	if p.PlateName == "" {
-		//p.PlateName = fmt.Sprintf("User_plate_%d", lhr.NUserPlates+1)
 		p.PlateName = getSafePlateName(lhr, "user_plate", "_", lhr.NUserPlates+1)
 		lhr.NUserPlates += 1
 	}
@@ -251,6 +250,7 @@ func (mgr *LHPolicyManager) MergePolicies(protocolpolicies *wtype.LHPolicyRuleSe
 	return ret
 }
 
+// HasPlateNamed checks if the request already contains a plate with the specified name
 func (request *LHRequest) HasPlateNamed(name string) bool {
 	checkForPlateNamed := func(query string, subject map[string]*wtype.LHPlate) bool {
 		for _, plate := range subject {

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -135,6 +135,27 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 
 	}
 
+	// sanity check
+
+	nPos := len(output_plate_order) + len(input_plate_order)
+	needsTips := false
+
+	if params.GetTipType() == liquidhandling.DisposableTips || params.GetTipType() == liquidhandling.MixedDisposableAndFixedTips {
+		// at least two positions are needed
+		nPos += 2
+		needsTips = true
+	}
+
+	if nPos > len(params.Positions) {
+		errStr := fmt.Sprintf("Protocol requires %d input plates, %d output plates", len(input_plate_order), len(output_plate_order))
+		if needsTips {
+			errStr += fmt.Sprintf(" and at least 2 spaces for tip waste and boxes")
+		}
+
+		errStr += fmt.Sprintf(": %d positions total, %d available on platform %s %s", nPos, len(params.Positions), params.Mnfr, params.Model)
+		return nil, wtype.LHError(wtype.LH_ERR_NO_DECK_SPACE, errStr)
+	}
+
 	// tips
 	tips := request.Tips
 

--- a/microArch/scheduler/liquidhandling/uniquePlateNameTest.go
+++ b/microArch/scheduler/liquidhandling/uniquePlateNameTest.go
@@ -1,0 +1,45 @@
+package liquidhandling
+
+import (
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"testing"
+)
+
+func TestUniquePlateName(t *testing.T) {
+	mswl := func(s string) map[string]*wtype.LHPlate {
+		return map[string]*wtype.LHPlate{s: &wtype.LHPlate{}}
+	}
+
+	type testData struct {
+		Name         string
+		InputPlates  map[string]*wtype.LHPlate
+		OutputPlates map[string]*wtype.LHPlate
+	}
+
+	tests := []testData{
+		{Name: "InputPlates", InputPlates: mswl("input_plate_1"), OutputPlates: mswl("")},
+		{Name: "OutputPlates", InputPlates: mswl(""), OutputPlates: mswl("output_plate_1")},
+		{Name: "Both", InputPlates: mswl("input_plate_1"), OutputPlates: mswl("output_plate_1")},
+	}
+
+	for i := range tests {
+		dat := tests[i]
+
+		doTheTest := func(t *testing.T) {
+			rq := NewLHRequest()
+			rq.Input_plates = dat.InputPlates
+			rq.Output_plates = dat.OutputPlates
+
+			for v := 0; v < 100; v++ {
+				nom := getSafePlateName(rq, 1)
+
+				if rq.HasPlateNamed(nom) {
+					t.Errorf("Plate named %s returned by getSafePlateName - already defined by request", nom)
+				}
+			}
+		}
+
+		t.Run(dat.Name, doTheTest)
+	}
+
+}

--- a/microArch/scheduler/liquidhandling/uniquePlateNameTest.go
+++ b/microArch/scheduler/liquidhandling/uniquePlateNameTest.go
@@ -31,10 +31,16 @@ func TestUniquePlateName(t *testing.T) {
 			rq.Output_plates = dat.OutputPlates
 
 			for v := 0; v < 100; v++ {
-				nom := getSafePlateName(rq, 1)
+				nom := getSafeInputPlateName(rq, 1)
 
 				if rq.HasPlateNamed(nom) {
 					t.Errorf("Plate named %s returned by getSafePlateName - already defined by request", nom)
+				}
+
+				rq.AddUserPlate(&wtype.LHPlate{PlateName: nom})
+
+				if !rq.HasPlateNamed(nom) {
+					t.Errorf("Plate named %s not recognised by request after addition", nom)
 				}
 			}
 		}


### PR DESCRIPTION
Function to check if plate name is already defined in request and ensure generated names do not collide with anything already known. Additional function to make readable random names.

Bonus feature: overlarge plate numbers in a single request are also covered.

Proposed fix for Antha-1257 (can confirm this fixes original bundle)