### PR TITLE
Prevent attempts to pipette small volumes

### DIFF
--- a/microArch/driver/liquidhandling/choosechannel_test.go
+++ b/microArch/driver/liquidhandling/choosechannel_test.go
@@ -13,7 +13,7 @@ import (
 func getVols() []wunit.Volume {
 	// a selection of volumes
 	vols := make([]wunit.Volume, 0, 1)
-	for _, v := range []float64{0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0} {
+	for _, v := range []float64{0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0} {
 		vol := wunit.NewVolume(v, "ul")
 		vols = append(vols, vol)
 	}
@@ -23,21 +23,19 @@ func getVols() []wunit.Volume {
 // answers to test
 
 func getMinvols1() []wunit.Volume {
-	v0 := wunit.NewVolume(0.0, "ul")
 	v1 := wunit.NewVolume(0.5, "ul")
 	v2 := wunit.NewVolume(10.0, "ul")
 
-	ret := []wunit.Volume{v0, v1, v1, v1, v1, v1, v1, v2, v2, v2, v2}
+	ret := []wunit.Volume{v1, v1, v1, v1, v1, v1, v2, v2, v2, v2}
 
 	return ret
 }
 
 func getMaxvols1() []wunit.Volume {
-	v0 := wunit.NewVolume(0.0, "ul")
 	v1 := wunit.NewVolume(20.0, "ul")
 	v2 := wunit.NewVolume(250.0, "ul")
 
-	ret := []wunit.Volume{v0, v1, v1, v1, v1, v1, v1, v2, v2, v2, v2}
+	ret := []wunit.Volume{v1, v1, v1, v1, v1, v1, v2, v2, v2, v2}
 
 	return ret
 }
@@ -46,7 +44,7 @@ func getMaxvols1() []wunit.Volume {
 
  */
 func getTypes1() []string {
-	ret := []string{"", "Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson200", "Gilson200", "Gilson200", "Gilson200"}
+	ret := []string{"Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson20", "Gilson200", "Gilson200", "Gilson200", "Gilson200"}
 
 	return ret
 }
@@ -59,7 +57,11 @@ func TestDefaultChooser(t *testing.T) {
 	types := getTypes1()
 
 	for i, vol := range vols {
-		prm, tip := ChooseChannel(vol, lhp)
+		prm, tip, err := ChooseChannel(vol, lhp)
+		if err != nil {
+			t.Error(err)
+		}
+
 		tiptype := ""
 
 		if tip != nil {
@@ -87,6 +89,24 @@ func TestDefaultChooser(t *testing.T) {
 		*/
 	}
 
+}
+
+func TestSmallVolumeError(t *testing.T) {
+	lhp := makeTestLH()
+
+	vol := wunit.NewVolume(0.47, "ul")
+
+	prm, tip, err := ChooseChannel(vol, lhp)
+
+	if prm != nil {
+		t.Error("channel was not nil for small volume")
+	}
+	if tip != nil {
+		t.Error("tip was not nil for small volume")
+	}
+	if err == nil {
+		t.Error("error not generated for small volume")
+	}
 }
 
 func makeTestLH() *LHProperties {

--- a/microArch/driver/liquidhandling/lhl_test.go
+++ b/microArch/driver/liquidhandling/lhl_test.go
@@ -111,7 +111,7 @@ func makeTestGilson(ctx context.Context) (*LHProperties, error) {
 
 func getTestBlowout(robot *LHProperties) RobotInstruction {
 	v := wunit.NewVolume(10.0, "ul")
-	ch, _ := ChooseChannel(v, robot)
+	ch, _, _ := ChooseChannel(v, robot)
 	bi := NewBlowInstruction()
 	bi.Multi = 1
 	bi.What = append(bi.What, "soup")

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -203,7 +203,7 @@ func TestTipOverrideNegative(t *testing.T) {
 
 	err = lh.Plan(ctx, rq)
 
-	if e, f := "No tip chosen: Volume 8 ul is too low to be accurately moved by the liquid handler (configured minimum 10 ul, tip minimum 10 ul). Low volume tips may not be available and / or the robot may need to be configured differently", err.Error(); e != f {
+	if e, f := "7 (LH_ERR_VOL) : volume error : No tip chosen: Volume 8 ul is too low to be accurately moved by the liquid handler (configured minimum 10 ul, tip minimum 10 ul). Low volume tips may not be available and / or the robot may need to be configured differently", err.Error(); e != f {
 		t.Fatalf("expecting error %q found %q", e, f)
 	}
 }


### PR DESCRIPTION
Fixes [ANTHA-1278](https://synthace.atlassian.net/browse/ANTHA-1278)

TLDR; Volume rounding was allowing channels whose minimum volume was 0.5ul to pipette less - down to 0.25ul - which ends up causing errors in trilution because the machine can't pipette less than 0.5ul

Choose channels now explicitly checks that requested volume is greater than the minimum possible, to within rounding error.