### PR TITLE
MixNamed no longer fragments plates

### DIFF
--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -179,6 +179,7 @@ func input_plate_setup(ctx context.Context, request *LHRequest) (*LHRequest, err
 					if err != nil {
 						return nil, err
 					}
+
 					plates_in_play[platetype.Type] = p
 					curr_plate = plates_in_play[platetype.Type]
 					platename := getSafeInputPlateName(request, curplaten)

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -270,3 +270,34 @@ func (request *LHRequest) HasPlateNamed(name string) bool {
 
 	return false
 }
+
+// OrderedInputPlates returns the list of input plates in order
+func (request *LHRequest) OrderedInputPlates() []*wtype.LHPlate {
+	ret := make([]*wtype.LHPlate, 0, len(request.Input_plates))
+	for _, id := range request.Input_plate_order {
+		ret = append(ret, request.Input_plates[id])
+	}
+
+	return ret
+}
+
+// OrderedOutputPlates returns the list of input plates in order
+func (request *LHRequest) OrderedOutputPlates() []*wtype.LHPlate {
+	ret := make([]*wtype.LHPlate, 0, len(request.Output_plates))
+	for _, id := range request.Output_plate_order {
+		ret = append(ret, request.Output_plates[id])
+	}
+
+	return ret
+}
+
+// AllPlates returns a list of all known plates, in the order input plates, output plates
+// ordering will be as within the stated orders of each
+func (request *LHRequest) AllPlates() []*wtype.LHPlate {
+	r := make([]*wtype.LHPlate, 0, len(request.Input_plates)+len(request.Output_plates))
+
+	r = append(r, request.OrderedInputPlates()...)
+	r = append(r, request.OrderedOutputPlates()...)
+
+	return r
+}

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -328,7 +328,7 @@ func TestBeforeVsAfter(t *testing.T) {
 		t.Fatal(fmt.Sprint("Got an error planning with no inputs: ", err))
 	}
 
-	for pos, _ := range lh.Properties.PosLookup {
+	for pos := range lh.Properties.PosLookup {
 
 		id1, ok1 := lh.Properties.PosLookup[pos]
 		id2, ok2 := lh.FinalProperties.PosLookup[pos]
@@ -536,4 +536,33 @@ func TestEP3WrongTotalVolume(t *testing.T) {
 	if err == nil {
 		t.Fatal("Negative volume did not cause a planning error")
 	}
+}
+
+func TestDistinctPlateNames(t *testing.T) {
+	rq := NewLHRequest()
+	for i := 0; i < 100; i++ {
+		p := &wtype.LHPlate{ID: fmt.Sprintf("anID-%d", i), PlateName: "aName"}
+		rq.Input_plate_order = append(rq.Input_plate_order, p.ID)
+		rq.Input_plates[p.ID] = p
+	}
+	for i := 100; i < 200; i++ {
+		p := &wtype.LHPlate{ID: fmt.Sprintf("anID-%d", i), PlateName: "aName"}
+		rq.Output_plate_order = append(rq.Output_plate_order, p.ID)
+		rq.Output_plates[p.ID] = p
+	}
+
+	rq = fixDuplicatePlateNames(rq)
+
+	found := make(map[string]int)
+
+	for _, p := range rq.AllPlates() {
+		_, ok := found[p.PlateName]
+
+		if !ok {
+			found[p.PlateName] = 1
+		} else {
+			t.Errorf("fixDuplicatePlateNames failed to prevent duplicates: found at least two of %s", p.PlateName)
+		}
+	}
+
 }

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -82,7 +82,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 		}
 
 		if len(input_plate_order) < len(input_plates) {
-			for id, _ := range input_plates {
+			for id := range input_plates {
 				if !isInStrArr(id, input_plate_order) {
 					input_plate_order = append(input_plate_order, id)
 				}


### PR DESCRIPTION
This fixes a reported issue with the unique plate naming - post the fix the system was splitting samples to multiple wells excessively. 

The fix was to add a check for an eligible plate with the same type and name. Uniqueness of plate naming assigned in this way is enforced in a later check. 

