### PR TITLE
Added LTDNACELLSMIXMULTI to func LiquidTypeName in LiquidType.go

### DIFF
--- a/antha/anthalib/wtype/LiquidType.go
+++ b/antha/anthalib/wtype/LiquidType.go
@@ -205,6 +205,8 @@ func LiquidTypeName(lt LiquidType) PolicyName {
 		return "colonymix"
 	case LTDNACELLSMIX:
 		return "dna_cells_mix"
+	case LTDNACELLSMIXMULTI:
+		return "dna_cells_mix_multi"
 	case LTMultiWater:
 		return "multiwater"
 	case LTCSrc:


### PR DESCRIPTION
This was missing, resulting in, for example, `nil` labels coming up for liquid policy on the UI.