### PR TITLE
Accept sources which are only smaller due to numerical error

### DIFF
--- a/antha/anthalib/wtype/componentvector.go
+++ b/antha/anthalib/wtype/componentvector.go
@@ -17,7 +17,7 @@ func (cv ComponentVector) String() string {
 //DeleteAllBelowVolume set all components whose volume is below vol to nil
 func (cv ComponentVector) DeleteAllBelowVolume(vol wunit.Volume) {
 	for i := 0; i < len(cv); i++ {
-		//if the i^th component's volume is less than vol, and the difference is greater than floating point error
+		//Volume.isZero() checks that volume is zero or within a small tolerace to zero
 		if v := cv[i].Volume(); v.LessThan(vol) && !wunit.SubtractVolumes(vol, v).IsZero() {
 			cv[i] = nil
 		}

--- a/antha/anthalib/wtype/componentvector.go
+++ b/antha/anthalib/wtype/componentvector.go
@@ -16,7 +16,7 @@ func (cv ComponentVector) String() string {
 
 func (cv ComponentVector) DeleteAllBelowVolume(vol wunit.Volume) {
 	for i := 0; i < len(cv); i++ {
-		if cv[i] != nil && cv[i].Volume().LessThan(vol) {
+		if v := cv[i].Volume(); v.LessThan(vol) && !wunit.SubtractVolumes(vol, v).IsZero() {
 			cv[i] = nil
 		}
 	}

--- a/antha/anthalib/wtype/componentvector.go
+++ b/antha/anthalib/wtype/componentvector.go
@@ -14,8 +14,10 @@ func (cv ComponentVector) String() string {
 	return s
 }
 
+//DeleteAllBelowVolume set all components whose volume is below vol to nil
 func (cv ComponentVector) DeleteAllBelowVolume(vol wunit.Volume) {
 	for i := 0; i < len(cv); i++ {
+		//if the i^th component's volume is less than vol, and the difference is greater than floating point error
 		if v := cv[i].Volume(); v.LessThan(vol) && !wunit.SubtractVolumes(vol, v).IsZero() {
 			cv[i] = nil
 		}

--- a/antha/anthalib/wtype/lhcomponent.go
+++ b/antha/anthalib/wtype/lhcomponent.go
@@ -466,7 +466,7 @@ func (lhc *LHComponent) SetPolicyName(policy PolicyName) error {
 
 // Volume returns the Volume of the LHComponent
 func (lhc *LHComponent) Volume() wunit.Volume {
-	if lhc.Vunit == "" && lhc.Vol == 0.0 {
+	if lhc == nil || (lhc.Vunit == "" && lhc.Vol == 0.0) {
 		return wunit.NewVolume(0.0, "ul")
 	}
 	return wunit.NewVolume(lhc.Vol, lhc.Vunit)

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -13,7 +13,7 @@ type ComponentVolumeHash map[string]wunit.Volume
 
 func (h ComponentVolumeHash) AllVolsPosOrZero() bool {
 	for _, v := range h {
-		if v.LessThan(wunit.ZeroVolume()) {
+		if v.LessThan(wunit.ZeroVolume()) && !v.IsZero() {
 			return false
 		}
 	}

--- a/microArch/scheduler/liquidhandling/fixvolumes.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes.go
@@ -149,7 +149,7 @@ func findUpdateInstructionVolumes(ch *IChain, wanted map[string]wunit.Volume, pl
 				}
 			} else if !wantInPlace(wanted, ins.Results[0].FullyQualifiedName()) {
 				wantVol.Add(plates[ins.PlateID].Rows[0][0].ResidualVolume())
-				//wantVol.Subtract(carryVol)
+				wantVol.Subtract(carryVol)
 			}
 
 			if wantVol.GreaterThan(ins.Results[0].Volume()) {


### PR DESCRIPTION
This time I definitely ran it though antha-tester and it passed.

key change is in `AllVolsPosOrZero()` in file driver/liquidhandling/getComponents.go - the issue is as we suspected, the carryVol was protecting us from numerical instabilities that we're now exposed to. I played around with matching volumes in matchComponents as well, but it added extra complexity that wasn't actually necessary