### PR TITLE
Plate cache

### DIFF
--- a/antha/anthalib/wtype/lhcomponent.go
+++ b/antha/anthalib/wtype/lhcomponent.go
@@ -740,7 +740,7 @@ func (cmp *LHComponent) Clean() {
 	cmp.Inst = ""
 	cmp.Order = 0
 	cmp.CName = ""
-	cmp.Type = LiquidType{}
+	cmp.Type = LiquidType("")
 	cmp.Vol = 0.0
 	cmp.Conc = 0.0
 	cmp.Vunit = "ul"

--- a/antha/anthalib/wtype/lhcomponent.go
+++ b/antha/anthalib/wtype/lhcomponent.go
@@ -732,6 +732,29 @@ func NewLHComponent() *LHComponent {
 	return &lhc
 }
 
+//Clean the component to its initial state
+func (cmp *LHComponent) Clean() {
+	cmp.Vunit = "ul"
+	cmp.DaughterID = ""
+	cmp.ParentID = ""
+	cmp.Inst = ""
+	cmp.Order = 0
+	cmp.CName = ""
+	cmp.Type = LiquidType{}
+	cmp.Vol = 0.0
+	cmp.Conc = 0.0
+	cmp.Vunit = "ul"
+	cmp.Cunit = ""
+	cmp.Tvol = 0.0
+	cmp.Smax = 0.0
+	cmp.Visc = 0.0
+	cmp.StockConcentration = 0.0
+	cmp.Extra = make(map[string]interface{})
+	cmp.Loc = ""
+	cmp.Destination = ""
+	cmp.Policy = make(map[string]interface{})
+}
+
 func (cmp *LHComponent) String() string {
 	id := cmp.ID
 

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -561,6 +561,15 @@ func (lhp *LHPlate) IsEmpty() bool {
 	return true
 }
 
+//Clean empty all the wells of the plate so that IsEmpty returns true
+func (lhp *LHPlate) Clean() {
+
+	for _, w := range lhp.WellCoords {
+		w.Clean()
+	}
+	lhp.Welltype.Clean()
+}
+
 func (lhp *LHPlate) NextEmptyWell(it PlateIterator) WellCoords {
 	c := 0
 	for wc := it.Curr(); it.Valid(); wc = it.Next() {

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -564,7 +564,7 @@ func (lhp *LHPlate) IsEmpty() bool {
 //Clean empty all the wells of the plate so that IsEmpty returns true
 func (lhp *LHPlate) Clean() {
 
-	for _, w := range lhp.WellCoords {
+	for _, w := range lhp.Wellcoords {
 		w.Clean()
 	}
 	lhp.Welltype.Clean()

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -438,12 +438,7 @@ const (
 	BYCOLUMN = false
 )
 
-var awpCalls = 0
-
 func (lhp *LHPlate) AllWellPositions(byrow bool) (wellpositionarray []string) {
-	fmt.Printf("lhp(%s).AllWellPositions(%t) WlsX x WlsY = %d x %x = %d. call %d\n", lhp.ID, byrow, lhp.WlsX, lhp.WlsY, lhp.WlsX*lhp.WlsY, awpCalls)
-	awpCalls += 1
-
 	wellpositionarray = make([]string, 0, lhp.WlsX*lhp.WlsY)
 
 	if byrow {

--- a/antha/anthalib/wtype/lhplate.go
+++ b/antha/anthalib/wtype/lhplate.go
@@ -438,9 +438,13 @@ const (
 	BYCOLUMN = false
 )
 
-func (lhp *LHPlate) AllWellPositions(byrow bool) (wellpositionarray []string) {
+var awpCalls = 0
 
-	wellpositionarray = make([]string, 0)
+func (lhp *LHPlate) AllWellPositions(byrow bool) (wellpositionarray []string) {
+	fmt.Printf("lhp(%s).AllWellPositions(%t) WlsX x WlsY = %d x %x = %d. call %d\n", lhp.ID, byrow, lhp.WlsX, lhp.WlsY, lhp.WlsX*lhp.WlsY, awpCalls)
+	awpCalls += 1
+
+	wellpositionarray = make([]string, 0, lhp.WlsX*lhp.WlsY)
 
 	if byrow {
 

--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -435,6 +435,13 @@ func (w *LHWell) IsEmpty() bool {
 	return w.CurrentVolume().LessThan(tolerance)
 }
 
+//Clean reset the volume in the well so that it's empty
+func (w *LHWell) Clean() {
+	w.WContents.Clean()
+	w.WContents.Loc = w.Plate.(*LHPlate).ID + ":" + w.Crds.FormatA1()
+	w.Extra = make(map[string]interface{})
+}
+
 // copy of instance
 func (lhw *LHWell) Dup() *LHWell {
 	return lhw.dup(false)

--- a/cmd/antha/cmd/run.go
+++ b/cmd/antha/cmd/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/antha-lang/antha/execute"
 	"github.com/antha-lang/antha/execute/executeutil"
 	"github.com/antha-lang/antha/inject"
+	"github.com/antha-lang/antha/inventory/cache/plateCache"
 	"github.com/antha-lang/antha/inventory/testinventory"
 	"github.com/antha-lang/antha/target"
 	"github.com/antha-lang/antha/target/auto"
@@ -123,7 +124,9 @@ func makeContext() (context.Context, error) {
 			return nil, fmt.Errorf("adding protocol %q: %s", desc.Name, err)
 		}
 	}
-	return testinventory.NewContext(ctx), nil
+	ctx = testinventory.NewContext(ctx)
+	ctx = plateCache.NewContext(ctx)
+	return ctx, nil
 }
 
 type runOpt struct {
@@ -312,6 +315,7 @@ func runWorkflow(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := testinventory.NewContext(context.Background())
+	ctx = plateCache.NewContext(ctx)
 
 	var drivers []string
 	for idx, uri := range GetStringSlice("driver") {

--- a/inventory/cache/cache.go
+++ b/inventory/cache/cache.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"github.com/antha-lang/antha/inventory"
+)
+
+const (
+	theCtxKey ctxKey = "inventoryCache"
+)
+
+type ctxKey string
+
+type Cache interface {
+	inventory.Inventory
+	ReturnObject(ctx context.Context, obj interface{}) error
+}
+
+func fromContext(ctx context.Context) Cache {
+	return ctx.Value(theCtxKey).(Cache)
+}
+
+//NewContext returns a context with the new cache
+func NewContext(ctx context.Context, pc Cache) context.Context {
+	return context.WithValue(ctx, theCtxKey, pc)
+}
+
+//GetCache returns the plate cache from the context
+func GetCache(ctx context.Context) Cache {
+	return fromContext(ctx)
+}
+
+// NewComponent returns a new component of the given type
+func NewComponent(ctx context.Context, typ string) (*wtype.LHComponent, error) {
+	return fromContext(ctx).NewComponent(ctx, typ)
+}
+
+// NewPlate returns a new plate of the given type
+func NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {
+	return fromContext(ctx).NewPlate(ctx, typ)
+}
+
+// NewTipwaste returns a new tipwaste of the given type
+func NewTipwaste(ctx context.Context, typ string) (*wtype.LHTipwaste, error) {
+	return fromContext(ctx).NewTipwaste(ctx, typ)
+}
+
+// NewTipbox returns a new tipbox of the given type
+func NewTipbox(ctx context.Context, typ string) (*wtype.LHTipbox, error) {
+	return fromContext(ctx).NewTipbox(ctx, typ)
+}
+
+// ReturnObject return an object to the cache to be cleaned
+func ReturnObject(ctx context.Context, obj interface{}) error {
+	return fromContext(ctx).ReturnObject(ctx, obj)
+}

--- a/inventory/cache/cache.go
+++ b/inventory/cache/cache.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"context"
-	"errors"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/inventory"
 )
 

--- a/inventory/cache/cache.go
+++ b/inventory/cache/cache.go
@@ -15,6 +15,7 @@ type ctxKey string
 type Cache interface {
 	inventory.Inventory
 	ReturnObject(ctx context.Context, obj interface{}) error
+	IsFromCache(ctx context.Context, obj interface{}) bool
 }
 
 func fromContext(ctx context.Context) Cache {
@@ -54,4 +55,9 @@ func NewTipbox(ctx context.Context, typ string) (*wtype.LHTipbox, error) {
 // ReturnObject return an object to the cache to be cleaned
 func ReturnObject(ctx context.Context, obj interface{}) error {
 	return fromContext(ctx).ReturnObject(ctx, obj)
+}
+
+// IsFromCache returns true if the object is from the cache
+func IsFromCache(ctx context.Context, obj interface{}) bool {
+	return fromContext(ctx).IsFromCache(ctx, obj)
 }

--- a/inventory/cache/plateCache/plateCache.go
+++ b/inventory/cache/plateCache/plateCache.go
@@ -1,6 +1,8 @@
 package plateCache
 
 import (
+	"context"
+	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/inventory"
 	"github.com/antha-lang/antha/inventory/cache"
@@ -23,10 +25,12 @@ func (p *plateCache) NewTipwaste(ctx context.Context, typ string) (*wtype.LHTipw
 }
 
 func (p *plateCache) NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {
+	fmt.Printf("plateCache: Getting Plate type \"%s\"\n", typ)
 	return inventory.NewPlate(ctx, typ)
 }
 
 func (p *plateCache) ReturnObject(ctx context.Context, obj interface{}) error {
+	fmt.Printf("plateCache: Returning %s type \"%s\"\n", wtype.ClassOf(obj), wtype.TypeOf(obj))
 	return nil
 }
 

--- a/inventory/cache/plateCache/plateCache.go
+++ b/inventory/cache/plateCache/plateCache.go
@@ -26,19 +26,19 @@ func (p *plateCache) NewTipwaste(ctx context.Context, typ string) (*wtype.LHTipw
 }
 
 func (p *plateCache) NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {
+	/*
+		plateList, ok := p.platesByType[typ]
+		if !ok {
+			plateList = make([]*wtype.LHPlate, 0)
+			p.platesByType[typ] = plateList
+		}
 
-	plateList, ok := p.platesByType[typ]
-	if !ok {
-		plateList = make([]*wtype.LHPlate, 0)
-		p.platesByType[typ] = plateList
-	}
-
-	if len(plateList) > 0 {
-		plate := plateList[0]
-		p.platesByType[typ] = plateList[1:]
-		return plate, nil
-	}
-
+		if len(plateList) > 0 {
+			plate := plateList[0]
+			p.platesByType[typ] = plateList[1:]
+			return plate, nil
+		}
+	*/
 	plate, err := inventory.NewPlate(ctx, typ)
 	if err != nil {
 		return nil, err

--- a/inventory/cache/plateCache/plateCache.go
+++ b/inventory/cache/plateCache/plateCache.go
@@ -1,0 +1,40 @@
+package plateCache
+
+import (
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/cache"
+)
+
+type plateCache struct {
+	platesByType map[string][]*wtype.LHPlate
+}
+
+func (p *plateCache) NewComponent(ctx context.Context, name string) (*wtype.LHComponent, error) {
+	return inventory.NewComponent(ctx, name)
+}
+
+func (p *plateCache) NewTipbox(ctx context.Context, typ string) (*wtype.LHTipbox, error) {
+	return inventory.NewTipbox(ctx, typ)
+}
+
+func (p *plateCache) NewTipwaste(ctx context.Context, typ string) (*wtype.LHTipwaste, error) {
+	return inventory.NewTipwaste(ctx, typ)
+}
+
+func (p *plateCache) NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {
+	return inventory.NewPlate(ctx, typ)
+}
+
+func (p *plateCache) ReturnObject(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// NewContext creates a new plateCache context
+func NewContext(ctx context.Context) context.Context {
+	pc := &plateCache{
+		platesByType: make(map[string][]*wtype.LHPlate),
+	}
+
+	return cache.NewContext(ctx, pc)
+}

--- a/inventory/cache/plateCache/plateCache.go
+++ b/inventory/cache/plateCache/plateCache.go
@@ -26,19 +26,19 @@ func (p *plateCache) NewTipwaste(ctx context.Context, typ string) (*wtype.LHTipw
 }
 
 func (p *plateCache) NewPlate(ctx context.Context, typ string) (*wtype.LHPlate, error) {
-	/*
-		plateList, ok := p.platesByType[typ]
-		if !ok {
-			plateList = make([]*wtype.LHPlate, 0)
-			p.platesByType[typ] = plateList
-		}
 
-		if len(plateList) > 0 {
-			plate := plateList[0]
-			p.platesByType[typ] = plateList[1:]
-			return plate, nil
-		}
-	*/
+	plateList, ok := p.platesByType[typ]
+	if !ok {
+		plateList = make([]*wtype.LHPlate, 0)
+		p.platesByType[typ] = plateList
+	}
+
+	if len(plateList) > 0 {
+		plate := plateList[0]
+		p.platesByType[typ] = plateList[1:]
+		return plate, nil
+	}
+
 	plate, err := inventory.NewPlate(ctx, typ)
 	if err != nil {
 		return nil, err

--- a/inventory/cache/plateCache/plateCache_test.go
+++ b/inventory/cache/plateCache/plateCache_test.go
@@ -29,7 +29,7 @@ func TestPlateReuse(t *testing.T) {
 
 	c := wtype.NewLHComponent()
 	c.Vol = 10.0
-	well := firstPlate.GetChildByAddress(wtype.WellCoords{0, 0}).(*wtype.LHWell)
+	well := firstPlate.GetChildByAddress(wtype.WellCoords{X: 0, Y: 0}).(*wtype.LHWell)
 	err = well.SetContents(c)
 	if err != nil {
 		t.Fatal(err)

--- a/inventory/cache/plateCache/plateCache_test.go
+++ b/inventory/cache/plateCache/plateCache_test.go
@@ -1,0 +1,65 @@
+package plateCache
+
+import (
+	"context"
+	"fmt"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/inventory/cache"
+	"github.com/antha-lang/antha/inventory/testinventory"
+	"testing"
+)
+
+const plateType = "pcrplate"
+
+func makeContext() context.Context {
+	ctx := NewContext(testinventory.NewContext(context.Background()))
+	return ctx
+}
+
+func TestPlateReuse(t *testing.T) {
+
+	ctx := makeContext()
+	firstPlate, err := cache.NewPlate(ctx, plateType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstID := wtype.IDOf(firstPlate)
+
+	c := wtype.NewLHComponent()
+	c.Vol = 10.0
+	well := firstPlate.GetChildByAddress(wtype.WellCoords{0, 0}).(*wtype.LHWell)
+	err = well.SetContents(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if firstPlate.IsEmpty() {
+		t.Fatal("Plate shouldn't be empty")
+	}
+
+	cache.ReturnObject(ctx, firstPlate)
+
+	secondPlate, err := cache.NewPlate(ctx, plateType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if secondPlate.ID != firstID {
+		t.Fatal(fmt.Sprintf("Second plate ID doesn't match the first: %s != %s", secondPlate.ID, firstID))
+	}
+
+	if !secondPlate.IsEmpty() {
+		t.Error("secondPlate was not clean")
+	}
+
+	thirdPlate, err := cache.NewPlate(ctx, plateType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if thirdPlate.ID == firstID {
+		t.Fatal("thirdPlate ID was the same as the second, even though the second hasn't been returned")
+	}
+
+}

--- a/inventory/cache/plateCache/plateCache_test.go
+++ b/inventory/cache/plateCache/plateCache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/inventory"
 	"github.com/antha-lang/antha/inventory/cache"
 	"github.com/antha-lang/antha/inventory/testinventory"
 	"testing"
@@ -60,6 +61,23 @@ func TestPlateReuse(t *testing.T) {
 
 	if thirdPlate.ID == firstID {
 		t.Fatal("thirdPlate ID was the same as the second, even though the second hasn't been returned")
+	}
+
+	if !cache.IsFromCache(ctx, secondPlate) {
+		t.Error("secondPlate came from cache, but cache.IsFromPlate returned false")
+	}
+
+	if !cache.IsFromCache(ctx, thirdPlate) {
+		t.Error("thirdPlate came from cache, but cache.IsFromPlate returned false")
+	}
+
+	fourthPlate, err := inventory.NewPlate(ctx, plateType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cache.IsFromCache(ctx, fourthPlate) {
+		t.Error("fourthPlate came from inventory, but cache.IsFromPlate returned true")
 	}
 
 }

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -95,15 +95,24 @@ func getPlateIterator(lhp *wtype.LHPlate, ori, multi int) wtype.VectorPlateItera
 	}
 }
 
+var gsfCalls = 0
+
 func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi int, minPossibleVolume wunit.Volume, ignoreInstances bool) []wtype.ComponentVector {
+	fmt.Printf("GSF_calls = %d\n", gsfCalls)
+	gsfCalls += 1
+
 	ret := make([]wtype.ComponentVector, 0, 1)
 
+	fmt.Printf("len(lhp.OrderedMergedPlatePrefs()) = %d\n", len(lhp.OrderedMergedPlatePrefs()))
 	for _, ipref := range lhp.OrderedMergedPlatePrefs() {
+		fmt.Printf("len(ipref) = %d\n", len(ipref))
 		p, ok := lhp.Plates[ipref]
 
 		if ok {
 			it := getPlateIterator(p, ori, multi)
+			fmt.Println("BEGIN LOOP")
 			for wv := it.Curr(); it.Valid(); wv = it.Next() {
+				fmt.Printf("  loop wv = %v\n", wv)
 				// cmps needs duping here
 				mycmps := p.GetVolumeFilteredContentVector(wv, cmps, minPossibleVolume, ignoreInstances) // dups components
 				if mycmps.Empty() {
@@ -116,6 +125,7 @@ func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi in
 
 				ret = append(ret, mycmps)
 			}
+			fmt.Println("END LOOP")
 		}
 	}
 

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -96,10 +96,11 @@ func getPlateIterator(lhp *wtype.LHPlate, ori, multi int) wtype.VectorPlateItera
 }
 
 var gsfCalls = 0
+var types = make(map[string]bool)
 
 func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi int, minPossibleVolume wunit.Volume, ignoreInstances bool) []wtype.ComponentVector {
-	fmt.Printf("GSF_calls = %d\n", gsfCalls)
 	gsfCalls += 1
+	fmt.Printf("count GSF_calls = %d\n", gsfCalls)
 
 	ret := make([]wtype.ComponentVector, 0, 1)
 
@@ -107,6 +108,8 @@ func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi in
 	for _, ipref := range lhp.OrderedMergedPlatePrefs() {
 		fmt.Printf("len(ipref) = %d\n", len(ipref))
 		p, ok := lhp.Plates[ipref]
+
+		types[wtype.TypeOf(p)] = true
 
 		if ok {
 			it := getPlateIterator(p, ori, multi)
@@ -128,6 +131,8 @@ func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi in
 			fmt.Println("END LOOP")
 		}
 	}
+
+	fmt.Printf("count : %v\n", types)
 
 	return ret
 }

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -95,27 +95,15 @@ func getPlateIterator(lhp *wtype.LHPlate, ori, multi int) wtype.VectorPlateItera
 	}
 }
 
-var gsfCalls = 0
-var types = make(map[string]bool)
-
 func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi int, minPossibleVolume wunit.Volume, ignoreInstances bool) []wtype.ComponentVector {
-	gsfCalls += 1
-	fmt.Printf("count GSF_calls = %d\n", gsfCalls)
-
 	ret := make([]wtype.ComponentVector, 0, 1)
 
-	fmt.Printf("len(lhp.OrderedMergedPlatePrefs()) = %d\n", len(lhp.OrderedMergedPlatePrefs()))
 	for _, ipref := range lhp.OrderedMergedPlatePrefs() {
-		fmt.Printf("len(ipref) = %d\n", len(ipref))
 		p, ok := lhp.Plates[ipref]
-
-		types[wtype.TypeOf(p)] = true
 
 		if ok {
 			it := getPlateIterator(p, ori, multi)
-			fmt.Println("BEGIN LOOP")
 			for wv := it.Curr(); it.Valid(); wv = it.Next() {
-				fmt.Printf("  loop wv = %v\n", wv)
 				// cmps needs duping here
 				mycmps := p.GetVolumeFilteredContentVector(wv, cmps, minPossibleVolume, ignoreInstances) // dups components
 				if mycmps.Empty() {
@@ -128,11 +116,8 @@ func (lhp *LHProperties) GetSourcesFor(cmps wtype.ComponentVector, ori, multi in
 
 				ret = append(ret, mycmps)
 			}
-			fmt.Println("END LOOP")
 		}
 	}
-
-	fmt.Printf("count : %v\n", types)
 
 	return ret
 }

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -8,8 +8,15 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/cache/plateCache"
 	"github.com/antha-lang/antha/inventory/testinventory"
 )
+
+func GetContextForTest() context.Context {
+	ctx := testinventory.NewContext(context.Background())
+	ctx = plateCache.NewContext(ctx)
+	return ctx
+}
 
 func getComponent(ctx context.Context, name string, volume float64) (*wtype.LHComponent, error) {
 	c, err := inventory.NewComponent(ctx, name)
@@ -154,7 +161,7 @@ func getTestRobot(ctx context.Context, dstp *wtype.LHPlate, platetype string) *L
 }
 
 func TestMultichannelFailPolicy(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// policy disallows
 	tb, dstp := getTransferBlock2Component(ctx)
@@ -171,7 +178,7 @@ func TestMultichannelFailPolicy(t *testing.T) {
 	testNegative(ctx, ris, pol, rbt, t)
 }
 func TestMultichannelSucceedSubset(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// can do 7
 	tb, dstp := getTransferBlock2Component(ctx)
@@ -195,7 +202,7 @@ func TestMultichannelSucceedSubset(t *testing.T) {
 }
 
 func TestMultichannelSucceedPair(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// can do 7
 	tb, dstp := getTransferBlock2Component(ctx)
@@ -227,7 +234,7 @@ func TestMultichannelSucceedPair(t *testing.T) {
 }
 
 func TestMultichannelFailDest(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	tb, dstp := getTransferBlock2Component(ctx)
 
 	/*
@@ -263,7 +270,7 @@ func TestMultichannelFailDest(t *testing.T) {
 func TestMultiChannelFailSrc(t *testing.T) {
 	// this actually works
 	t.Skip()
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// sources not aligned
 	tb, dstp := getTransferBlock2Component(ctx)
@@ -289,7 +296,7 @@ func TestMultiChannelFailSrc(t *testing.T) {
 }
 
 func TestMultiChannelFailComponent(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// components not same liquid type
 	tb, dstp := getTransferBlock2Component(ctx)
@@ -321,7 +328,7 @@ func TestMultiChannelFailComponent(t *testing.T) {
 }
 
 func TestMultichannelPositive(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock2Component(ctx)
 	rbt := getTestRobot(ctx, dstp, "pcrplate_skirted_riser40")
@@ -353,7 +360,7 @@ func TestMultichannelPositive(t *testing.T) {
 }
 
 func TestIndependentMultichannelPositive(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock2Component(ctx)
 
@@ -402,7 +409,7 @@ func TestIndependentMultichannelPositive(t *testing.T) {
 }
 
 func TestTroughMultichannelPositive(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock2Component(ctx)
 
@@ -437,7 +444,7 @@ func TestTroughMultichannelPositive(t *testing.T) {
 
 func TestBigWellMultichannelPositive(t *testing.T) {
 	t.Skip() // pending revisions
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock2Component(ctx)
 
@@ -471,7 +478,7 @@ func TestBigWellMultichannelPositive(t *testing.T) {
 }
 
 func TestInsByInsMixPositiveMultichannel(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock3Component(ctx)
 
@@ -508,7 +515,7 @@ func TestInsByInsMixPositiveMultichannel(t *testing.T) {
 }
 
 func TestInsByInsMixNegativeMultichannel(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	tb, dstp := getTransferBlock3Component(ctx)
 
@@ -700,7 +707,7 @@ func assertNumLoadUnloadInstructions(t *testing.T, instructions []RobotInstructi
 
 //TestMultiChannelTipReuseGood Move water to two columns of wells - shouldn't need to change tips in between
 func TestMultiChannelTipReuseGood(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 16, []string{inventory.WaterType}, []float64{50.0})
 	if err != nil {
@@ -716,7 +723,7 @@ func TestMultiChannelTipReuseGood(t *testing.T) {
 
 //TestMultiChannelTipReuseDisabled identical to good, except disable tip reuse
 func TestMultiChannelTipReuseDisabled(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 16, []string{inventory.WaterType}, []float64{50.0})
 	if err != nil {
@@ -741,7 +748,7 @@ func TestMultiChannelTipReuseDisabled(t *testing.T) {
 //TestSingleChannelTipReuse -- based same as above but with multichannel disabled
 //and allowing tip reuse
 func TestSingleChannelTipReuse(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 16, []string{inventory.WaterType}, []float64{50.0})
 	if err != nil {
@@ -764,7 +771,7 @@ func TestSingleChannelTipReuse(t *testing.T) {
 
 //TestSingleChannelTipReuse2 -- now we move two things
 func TestSingleChannelTipReuse2(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 16, []string{inventory.WaterType}, []float64{50.0})
 	if err != nil {
@@ -794,7 +801,7 @@ func TestSingleChannelTipReuse2(t *testing.T) {
 
 //TestMultiChannelTipReuseBad Move water and ethanol to two separate columns of wells - should change tips in between
 func TestMultiChannelTipReuseBad(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 8, []string{inventory.WaterType}, []float64{50.0})
 	if err != nil {
@@ -817,7 +824,7 @@ func TestMultiChannelTipReuseBad(t *testing.T) {
 
 //TestMultiChannelTipReuseUgly Move water and ethanol to the same columns of wells - should change tips in between
 func TestMultiChannelTipReuseUgly(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	inss, err := getMixInstructions(ctx, 8, []string{inventory.WaterType, "ethanol"}, []float64{50.0, 50.0})
 	if err != nil {
@@ -834,7 +841,7 @@ func TestMultiChannelTipReuseUgly(t *testing.T) {
 //TestMultiChannelTipReuseUgly Move water and ethanol to the same columns of wells - should change tips in between
 func BenchmarkMultiChannelTipReuseUgly(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ctx := testinventory.NewContext(context.Background())
+		ctx := GetContextForTest()
 
 		inss, err := getMixInstructions(ctx, 8, []string{inventory.WaterType, "ethanol"}, []float64{50.0, 50.0})
 		if err != nil {

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -32,8 +32,7 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
-	//"github.com/antha-lang/antha/inventory/cache"
-	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/cache"
 )
 
 type TransferInstruction struct {
@@ -285,7 +284,7 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 	}
 
 	fromPlateType := firstNonEmpty(ins.Transfers[which].FPlateType())
-	fromPlate, err := inventory.NewPlate(ctx, fromPlateType)
+	fromPlate, err := cache.NewPlate(ctx, fromPlateType)
 	if err != nil {
 		panic(err)
 	}
@@ -300,10 +299,10 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 		return false
 	}
 
-	//err = cache.ReturnObject(ctx, fromPlate)
+	err = cache.ReturnObject(ctx, fromPlate)
 
 	toPlateType := firstNonEmpty(ins.Transfers[which].TPlateType())
-	toPlate, err := inventory.NewPlate(ctx, toPlateType)
+	toPlate, err := cache.NewPlate(ctx, toPlateType)
 	if err != nil {
 		panic(err)
 	}
@@ -318,7 +317,7 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 		return false
 	}
 
-	//err = cache.ReturnObject(ctx, toPlate)
+	err = cache.ReturnObject(ctx, toPlate)
 
 	// check that we will not require different policies
 

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -32,7 +32,8 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
-	"github.com/antha-lang/antha/inventory/cache"
+	//"github.com/antha-lang/antha/inventory/cache"
+	"github.com/antha-lang/antha/inventory"
 )
 
 type TransferInstruction struct {
@@ -284,7 +285,7 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 	}
 
 	fromPlateType := firstNonEmpty(ins.Transfers[which].FPlateType())
-	fromPlate, err := cache.NewPlate(ctx, fromPlateType)
+	fromPlate, err := inventory.NewPlate(ctx, fromPlateType)
 	if err != nil {
 		panic(err)
 	}
@@ -299,10 +300,10 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 		return false
 	}
 
-	err = cache.ReturnObject(ctx, fromPlate)
+	//err = cache.ReturnObject(ctx, fromPlate)
 
 	toPlateType := firstNonEmpty(ins.Transfers[which].FPlateType())
-	toPlate, err := cache.NewPlate(ctx, toPlateType)
+	toPlate, err := inventory.NewPlate(ctx, toPlateType)
 	if err != nil {
 		panic(err)
 	}
@@ -317,7 +318,7 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 		return false
 	}
 
-	err = cache.ReturnObject(ctx, toPlate)
+	//err = cache.ReturnObject(ctx, toPlate)
 
 	// check that we will not require different policies
 

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -302,7 +302,7 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 
 	//err = cache.ReturnObject(ctx, fromPlate)
 
-	toPlateType := firstNonEmpty(ins.Transfers[which].FPlateType())
+	toPlateType := firstNonEmpty(ins.Transfers[which].TPlateType())
 	toPlate, err := inventory.NewPlate(ctx, toPlateType)
 	if err != nil {
 		panic(err)

--- a/microArch/driver/liquidhandling/transferinstruction.go
+++ b/microArch/driver/liquidhandling/transferinstruction.go
@@ -300,6 +300,9 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 	}
 
 	err = cache.ReturnObject(ctx, fromPlate)
+	if err != nil {
+		panic(err)
+	}
 
 	toPlateType := firstNonEmpty(ins.Transfers[which].TPlateType())
 	toPlate, err := cache.NewPlate(ctx, toPlateType)
@@ -318,18 +321,13 @@ func (ins *TransferInstruction) validateParallelSet(ctx context.Context, robot *
 	}
 
 	err = cache.ReturnObject(ctx, toPlate)
+	if err != nil {
+		panic(err)
+	}
 
 	// check that we will not require different policies
 
-	if !ins.CheckMultiPolicies(which) {
-		// fall back to single-channel
-		// TODO -- find a subset we CAN do
-		return false
-	}
-
-	// looks OK
-
-	return true
+	return ins.CheckMultiPolicies(which)
 }
 
 func GetMultiSet(a []string, channelmulti int, fromplatemulti int, toplatemulti int) [][]int {

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/antha/anthalib/wutil/text"
 	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/cache"
 	"github.com/antha-lang/antha/microArch/driver"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 	"github.com/antha-lang/antha/microArch/logger"
@@ -820,6 +821,18 @@ func forceSanity(request *LHRequest) {
 	}
 }
 
+//check that none of the plates we're returning came from the cache
+func assertNoTemporaryPlates(ctx context.Context, request *LHRequest) error {
+
+	for id, plate := range request.Plates {
+		if cache.IsFromCache(ctx, plate) {
+			return wtype.LHErrorf(wtype.LH_ERR_DIRE, "found a temporary plate (id=%s) being returned in the request", id)
+		}
+	}
+
+	return nil
+}
+
 func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 	// figure out the output order
 
@@ -996,7 +1009,14 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 	}
 	// ensure the after state is correct
 	this.fix_post_ids()
-	return this.fix_post_names(request)
+	err = this.fix_post_names(request)
+	if err != nil {
+		return err
+	}
+
+	err = assertNoTemporaryPlates(ctx, request)
+
+	return err
 }
 
 // resolve question of where something is requested to go

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -36,9 +36,16 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/antha/anthalib/wutil/text"
 	"github.com/antha-lang/antha/inventory"
+	"github.com/antha-lang/antha/inventory/cache/plateCache"
 	"github.com/antha-lang/antha/inventory/testinventory"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 )
+
+func GetContextForTest() context.Context {
+	ctx := testinventory.NewContext(context.Background())
+	ctx = plateCache.NewContext(ctx)
+	return ctx
+}
 
 func GetPlateForTest() *wtype.LHPlate {
 
@@ -170,7 +177,7 @@ func configureMultiChannelTestRequest(ctx context.Context, rq *LHRequest) {
 func configureTransferRequestForZTest(policyName string, transferVol wunit.Volume, numberOfTransfers int) (rq *LHRequest, err error) {
 
 	// set up ctx
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// make liquid handler
 	lh := GetLiquidHandlerForTest(ctx)
@@ -249,7 +256,7 @@ func configureSingleChannelTestRequest(ctx context.Context, rq *LHRequest) {
 func configureTransferRequestMutliSamplesTest(policyName string, samples ...*wtype.LHComponent) (rq *LHRequest, err error) {
 
 	// set up ctx
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// make liquid handler
 	lh := GetLiquidHandlerForTest(ctx)
@@ -296,7 +303,7 @@ func configureTransferRequestMutliSamplesTest(policyName string, samples ...*wty
 
 func TestToWellVolume(t *testing.T) {
 	// set up ctx
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	water := GetComponentForTest(ctx, "water", wunit.NewVolume(2000.0, "ul"))
 	mmx := GetComponentForTest(ctx, "mastermix_sapI", wunit.NewVolume(2000.0, "ul"))
 	part := GetComponentForTest(ctx, "dna", wunit.NewVolume(1000.0, "ul"))
@@ -517,7 +524,7 @@ func TestMultiZOffset2(t *testing.T) {
 
 func makeMultiTestRequest() (multiRq *LHRequest, err error) {
 	// set up ctx
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// make liquid handler
 	lh := GetLiquidHandlerForTest(ctx)
@@ -557,7 +564,7 @@ func makeMultiTestRequest() (multiRq *LHRequest, err error) {
 
 func makeSingleTestRequest() (singleRq *LHRequest, err error) {
 	// set up ctx
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	// make liquid handler
 	lh := GetLiquidHandlerForTest(ctx)
@@ -700,7 +707,7 @@ func TestMultiZOffset(t *testing.T) {
 }
 
 func TestTipOverridePositive(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	rq := GetLHRequestForTest()
@@ -725,7 +732,7 @@ func TestTipOverridePositive(t *testing.T) {
 
 }
 func TestTipOverrideNegative(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	rq := GetLHRequestForTest()
@@ -751,7 +758,7 @@ func TestTipOverrideNegative(t *testing.T) {
 }
 
 func TestPlateReuse(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	rq := GetLHRequestForTest()
@@ -854,7 +861,7 @@ func TestPlateReuse(t *testing.T) {
 }
 
 func TestBeforeVsAfter(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	rq := GetLHRequestForTest()
@@ -948,7 +955,7 @@ func TestBeforeVsAfter(t *testing.T) {
 }
 
 func TestEP3(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -967,7 +974,7 @@ func TestEP3(t *testing.T) {
 }
 
 func TestEP3TotalVolume(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -986,7 +993,7 @@ func TestEP3TotalVolume(t *testing.T) {
 }
 
 func TestEP3Overfilled(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -1004,7 +1011,7 @@ func TestEP3Overfilled(t *testing.T) {
 }
 
 func TestEP3Negative(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -1029,7 +1036,7 @@ func TestEP3Negative(t *testing.T) {
 }
 
 func TestEP3WrongResult(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -1053,7 +1060,7 @@ func TestEP3WrongResult(t *testing.T) {
 }
 
 func TestEP3WrongTotalVolume(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	lh := GetLiquidHandlerForTest(ctx)
 	lh.ExecutionPlanner = ExecutionPlanner3
@@ -1125,7 +1132,7 @@ func assertCoordsEq(lhs, rhs []wtype.Coordinates) bool {
 
 func TestAddWellTargets(t *testing.T) {
 
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	lh := GetLiquidHandlerForTest(ctx)
 
 	plate := GetPlateForTest()


### PR DESCRIPTION
add a cache of temporary plates for use during compilation to save cpu and mem by not having to make a bunch of them

Have tested this with `antha-tester`, though a few changes are required to runner, see branch `plateCache` in antha-runner