### PR TITLE
ANTHA-1829: turn things up to 37

### DIFF
--- a/antha/anthalib/wtype/aparam.go
+++ b/antha/anthalib/wtype/aparam.go
@@ -8,7 +8,18 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )
 
-const PolicyNameField string = "POLICYNAME"
+const (
+	// PolicyNameField returns the map entry of a liquid policy corresponding to the name of the policy.
+	PolicyNameField string = "POLICYNAME"
+
+	// LiquidClass is the name of the liquid type checked at instruction generation.
+	// Currently this is analagous to the POLICYNAME
+	LiquidClass string = "LIQUIDCLASS"
+
+	// DefaultPipetteSpeed is the key used to modify the default pipettte speed in a liquid policy.
+	// This value will be used for aspirating, dispensing and mixing.
+	DefaultPipetteSpeed string = "DEFAULTPIPETTESPEED"
+)
 
 func GetPolicyConsequents() AParamSet {
 	return MakePolicyItems()
@@ -27,7 +38,7 @@ func MakeInstructionParameters() AParamSet {
 	params["FROMPLATETYPE"] = AParam{Name: "FROMPLATETYPE", Type: typemap["string"]}
 	params["HEAD"] = AParam{Name: "HEAD", Type: typemap["float64"]}
 	params["INSTRUCTIONTYPE"] = AParam{Name: "INSTRUCTIONTYPE", Type: typemap["string"]}
-	params["LIQUIDCLASS"] = AParam{Name: "LIQUIDCLASS", Type: typemap["string"]}
+	params[LiquidClass] = AParam{Name: LiquidClass, Type: typemap["string"]}
 	params["LLF"] = AParam{Name: "LLF", Type: typemap["string"]} // actually bool but no checks on that yet
 	params["MULTI"] = AParam{Name: "MULTI", Type: typemap["float64"]}
 	params["NEWADAPTOR"] = AParam{Name: "NEWADAPTOR", Type: typemap["string"]}
@@ -107,7 +118,7 @@ func MakePolicyItems() AParamSet {
 	alhpis["TIP_REUSE_LIMIT"] = AParam{Name: "TIP_REUSE_LIMIT", Type: typemap["int"], Desc: "number of times tips can be reused for asp/dsp cycles"}
 	alhpis["TOUCHOFF"] = AParam{Name: "TOUCHOFF", Type: typemap["bool"], Desc: "whether to move to TOUCHOFFSET after dispense"}
 	alhpis["TOUCHOFFSET"] = AParam{Name: "TOUCHOFFSET", Type: typemap["float64"], Desc: "mm above wb to touch off at"}
-	alhpis["DEFAULTPIPETTESPEED"] = AParam{Name: "DEFAULTPIPETTESPEED", Type: typemap["float64"], Desc: "Default pipette speed in ml/min"}
+	alhpis[DefaultPipetteSpeed] = AParam{Name: DefaultPipetteSpeed, Type: typemap["float64"], Desc: "Default pipette speed in ml/min"}
 	alhpis["DEFAULTZSPEED"] = AParam{Name: "DEFAULTZSPEED", Type: typemap["float64"], Desc: "Default z movement speed in mm/s"}
 	alhpis["PTZOFFSET"] = AParam{Name: "PTZOFFSET", Type: typemap["float64"], Desc: "Z offset for pistons to zero"}
 	alhpis["PTZREFERENCE"] = AParam{Name: "PTZREFERENCE", Type: typemap["int"], Desc: "Well reference for piston to zero: 0 = well bottom, 1 = well top, 2 = liquid level"}

--- a/antha/anthalib/wtype/aparam.go
+++ b/antha/anthalib/wtype/aparam.go
@@ -13,10 +13,9 @@ const (
 	PolicyNameField string = "POLICYNAME"
 
 	// LiquidClass is the name of the liquid type checked at instruction generation.
-	// Currently this is analagous to the POLICYNAME
+	// Currently this is analogous to the POLICYNAME
 	LiquidClass string = "LIQUIDCLASS"
 
-	// DefaultPipetteSpeed is the key used to modify the default pipettte speed in a liquid policy.
 	// This value will be used for aspirating, dispensing and mixing.
 	DefaultPipetteSpeed string = "DEFAULTPIPETTESPEED"
 )

--- a/antha/anthalib/wtype/makelhpolicy.go
+++ b/antha/anthalib/wtype/makelhpolicy.go
@@ -181,8 +181,7 @@ TOUCHOFFSET,                         ,float64,          ,mm above wb to touch of
 
 func MakePEGPolicy() LHPolicy {
 	policy := make(LHPolicy, 10)
-	policy["ASPSPEED"] = 1.5
-	policy["DSPSPEED"] = 1.5
+	policy["DEFAULTPIPETTESPEED"] = 1.5
 	policy["ASP_WAIT"] = 2.0
 	policy["DSP_WAIT"] = 2.0
 	policy["ASPZOFFSET"] = 1.0
@@ -201,8 +200,7 @@ func MakePEGPolicy() LHPolicy {
 
 func MakeProtoplastPolicy() LHPolicy {
 	policy := make(LHPolicy, 8)
-	policy["ASPSPEED"] = 0.5
-	policy["DSPSPEED"] = 0.5
+	policy["DEFAULTPIPETTESPEED"] = 0.5
 	policy["ASPZOFFSET"] = 1.0
 	policy["DSPZOFFSET"] = 1.0
 	policy["BLOWOUTVOLUME"] = 100.0
@@ -218,8 +216,8 @@ func MakePaintPolicy() LHPolicy {
 	policy := make(LHPolicy, 14)
 	policy["DSPREFERENCE"] = 0
 	policy["DSPZOFFSET"] = 0.5
-	policy["ASPSPEED"] = 1.5
-	policy["DSPSPEED"] = 1.5
+	policy["POST_MIX_Z"] = 0.5
+	policy["DEFAULTPIPETTESPEED"] = 1.5
 	policy["ASP_WAIT"] = 1.0
 	policy["DSP_WAIT"] = 1.0
 	//policy["PRE_MIX"] = 3
@@ -235,8 +233,6 @@ func MakePaintPolicy() LHPolicy {
 func MakeDispenseAboveLiquidPolicy() LHPolicy {
 	policy := make(LHPolicy, 8)
 	policy["DSPREFERENCE"] = 1 // 1 indicates dispense at top of well
-	policy["ASPSPEED"] = 3.0
-	policy["DSPSPEED"] = 3.0
 	//policy["ASP_WAIT"] = 1.0
 	//policy["DSP_WAIT"] = 1.0
 	policy["BLOWOUTVOLUME"] = 50.0
@@ -249,8 +245,6 @@ func MakeDispenseAboveLiquidPolicy() LHPolicy {
 func MakeDispenseAboveLiquidMultiPolicy() LHPolicy {
 	policy := make(LHPolicy, 8)
 	policy["DSPREFERENCE"] = 1 // 1 indicates dispense at top of well
-	policy["ASPSPEED"] = 3.0
-	policy["DSPSPEED"] = 3.0
 	//policy["ASP_WAIT"] = 1.0
 	//policy["DSP_WAIT"] = 1.0
 	policy["BLOWOUTVOLUME"] = 50.0
@@ -265,8 +259,7 @@ func MakeColonyPolicy() LHPolicy {
 	policy := make(LHPolicy, 12)
 	policy["DSPREFERENCE"] = 0
 	policy["DSPZOFFSET"] = 0.0
-	policy["ASPSPEED"] = 3.0
-	policy["DSPSPEED"] = 3.0
+	policy["DEFAULTPIPETTESPEED"] = 3.0
 	policy["ASP_WAIT"] = 1.0
 	policy["POST_MIX"] = 1
 	policy["BLOWOUTVOLUME"] = 0.0
@@ -323,8 +316,7 @@ func MakeCulturePolicy() LHPolicy {
 	checkErr(culturepolicy.Set("PRE_MIX", 2))
 	checkErr(culturepolicy.Set("PRE_MIX_VOLUME", 19.0))
 	checkErr(culturepolicy.Set("PRE_MIX_RATE", 3.74))
-	checkErr(culturepolicy.Set("ASPSPEED", 2.0))
-	checkErr(culturepolicy.Set("DSPSPEED", 2.0))
+	checkErr(culturepolicy.Set("DEFAULTPIPETTESPEED", 2.0))
 	checkErr(culturepolicy.Set("CAN_MULTI", true))
 	checkErr(culturepolicy.Set("CAN_MSA", false))
 	checkErr(culturepolicy.Set("CAN_SDD", false))
@@ -344,6 +336,7 @@ func MakePlateOutPolicy() LHPolicy {
 	culturepolicy["CAN_MULTI"] = true
 	culturepolicy["ASP_WAIT"] = 1.0
 	culturepolicy["DSP_WAIT"] = 1.0
+	culturepolicy[DefaultPipetteSpeed] = 3.0
 	culturepolicy["DSPZOFFSET"] = 0.0
 	culturepolicy["TIP_REUSE_LIMIT"] = 7
 	culturepolicy["NO_AIR_DISPENSE"] = true
@@ -358,8 +351,7 @@ func MakeCultureReusePolicy() LHPolicy {
 	checkErr(culturepolicy.Set("PRE_MIX", 2))
 	checkErr(culturepolicy.Set("PRE_MIX_VOLUME", 19.0))
 	checkErr(culturepolicy.Set("PRE_MIX_RATE", 3.74))
-	checkErr(culturepolicy.Set("ASPSPEED", 2.0))
-	checkErr(culturepolicy.Set("DSPSPEED", 2.0))
+	checkErr(culturepolicy.Set("DEFAULTPIPETTESPEED", 2.0))
 	checkErr(culturepolicy.Set("CAN_MULTI", true))
 	checkErr(culturepolicy.Set("CAN_MSA", true))
 	checkErr(culturepolicy.Set("CAN_SDD", true))
@@ -375,8 +367,7 @@ func MakeCultureReusePolicy() LHPolicy {
 
 func MakeGlycerolPolicy() LHPolicy {
 	glycerolpolicy := make(LHPolicy, 9)
-	glycerolpolicy["ASPSPEED"] = 1.5
-	glycerolpolicy["DSPSPEED"] = 1.5
+	glycerolpolicy["DEFAULTPIPETTESPEED"] = 1.5
 	glycerolpolicy["ASP_WAIT"] = 1.0
 	glycerolpolicy["DSP_WAIT"] = 1.0
 	glycerolpolicy["TIP_REUSE_LIMIT"] = 0
@@ -390,8 +381,7 @@ func MakeGlycerolPolicy() LHPolicy {
 
 func MakeViscousPolicy() LHPolicy {
 	glycerolpolicy := make(LHPolicy, 7)
-	glycerolpolicy["ASPSPEED"] = 1.5
-	glycerolpolicy["DSPSPEED"] = 1.5
+	glycerolpolicy["DEFAULTPIPETTESPEED"] = 1.5
 	glycerolpolicy["ASP_WAIT"] = 1.0
 	glycerolpolicy["DSP_WAIT"] = 1.0
 	glycerolpolicy["CAN_MULTI"] = true
@@ -414,8 +404,7 @@ func MakeSolventPolicy() LHPolicy {
 
 func MakeDNAPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 12)
-	dnapolicy["ASPSPEED"] = 2.0
-	dnapolicy["DSPSPEED"] = 2.0
+	dnapolicy["DEFAULTPIPETTESPEED"] = 2.0
 	dnapolicy["CAN_MULTI"] = false
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -474,8 +463,7 @@ func MakeDNACELLSMixMultiPolicy() LHPolicy {
 func MakeDetergentPolicy() LHPolicy {
 	detergentpolicy := make(LHPolicy, 9)
 	//        detergentpolicy["POST_MIX"] = 3
-	detergentpolicy["ASPSPEED"] = 1.0
-	detergentpolicy["DSPSPEED"] = 1.0
+	detergentpolicy["DEFAULTPIPETTESPEED"] = 1.0
 	detergentpolicy["CAN_MSA"] = false
 	detergentpolicy["CAN_SDD"] = false
 	detergentpolicy["DSPREFERENCE"] = 0
@@ -489,8 +477,7 @@ func MakeProteinPolicy() LHPolicy {
 	proteinpolicy := make(LHPolicy, 12)
 	proteinpolicy["POST_MIX"] = 5
 	proteinpolicy["POST_MIX_VOLUME"] = 50.0
-	proteinpolicy["ASPSPEED"] = 2.0
-	proteinpolicy["DSPSPEED"] = 2.0
+	proteinpolicy["DEFAULTPIPETTESPEED"] = 2.0
 	proteinpolicy["CAN_MSA"] = false
 	proteinpolicy["CAN_SDD"] = false
 	proteinpolicy["DSPREFERENCE"] = 0
@@ -544,8 +531,6 @@ func MakeNeedToMixPolicy() LHPolicy {
 	dnapolicy["PRE_MIX"] = 3
 	dnapolicy["PRE_MIX_VOLUME"] = 20.0
 	dnapolicy["PRE_MIX_RATE"] = 3.74
-	dnapolicy["ASPSPEED"] = 3.74
-	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = true
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -564,9 +549,6 @@ func PreMixPolicy() LHPolicy {
 	//dnapolicy["POST_MIX_RATE"] = 3.74
 	dnapolicy["PRE_MIX"] = 3
 	dnapolicy["PRE_MIX_VOLUME"] = 19.0
-	dnapolicy["PRE_MIX_RATE"] = 3.74
-	dnapolicy["ASPSPEED"] = 3.74
-	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = true
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -586,8 +568,6 @@ func PostMixPolicy() LHPolicy {
 	//dnapolicy["PRE_MIX"] = 3
 	//dnapolicy["PRE_MIX_VOLUME"] = 10
 	//dnapolicy["PRE_MIX_RATE"] = 3.74
-	dnapolicy["ASPSPEED"] = 3.74
-	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = true
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -608,8 +588,6 @@ func SmartMixPolicy() LHPolicy {
 	policy["POST_MIX"] = 3
 	policy["POST_MIX_RATE"] = 3.74
 	policy["POST_MIX_VOLUME"] = 19.0
-	policy["ASPSPEED"] = 3.74
-	policy["DSPSPEED"] = 3.74
 	policy["CAN_MULTI"] = true
 	policy["CAN_MSA"] = false
 	policy["CAN_SDD"] = false
@@ -626,8 +604,6 @@ func MegaMixPolicy() LHPolicy {
 	dnapolicy := make(LHPolicy, 12)
 	dnapolicy["POST_MIX"] = 10
 	dnapolicy["POST_MIX_RATE"] = 3.74
-	dnapolicy["ASPSPEED"] = 3.74
-	dnapolicy["DSPSPEED"] = 3.74
 	dnapolicy["CAN_MULTI"] = true
 	dnapolicy["CAN_MSA"] = false
 	dnapolicy["CAN_SDD"] = false
@@ -661,8 +637,8 @@ func MakeDefaultPolicy() LHPolicy {
 	defaultpolicy["PTZREFERENCE"] = 1
 	defaultpolicy["PTZOFFSET"] = -0.5
 	defaultpolicy["NO_AIR_DISPENSE"] = true // SERIOUSLY??
-	defaultpolicy["DEFAULTPIPETTESPEED"] = 3.0
-	defaultpolicy["DEFAULTZSPEED"] = 120.0
+	defaultpolicy["DEFAULTPIPETTESPEED"] = 3.7
+	defaultpolicy["DEFAULTZSPEED"] = 140.0
 	defaultpolicy["MANUALPTZ"] = false
 	defaultpolicy["JUSTBLOWOUT"] = false
 	defaultpolicy["DONT_BE_DIRTY"] = true
@@ -715,10 +691,6 @@ func TurnOffBlowoutPolicy() LHPolicy {
 func MakeHVOffsetPolicy() LHPolicy {
 	lvop := make(LHPolicy, 6)
 	lvop["OFFSETZADJUST"] = 0.75
-	lvop["POST_MIX_RATE"] = 37
-	lvop["PRE_MIX_RATE"] = 37
-	lvop["ASPSPEED"] = 37
-	lvop["DSPSPEED"] = 37
 	return lvop
 }
 
@@ -749,13 +721,9 @@ func AdjustPreMixVolume(mixToVol wunit.Volume) LHPolicy {
 	return policy
 }
 
-// deprecated; see above
 func MakeHVFlowRatePolicy() LHPolicy {
-	policy := make(LHPolicy, 4)
-	policy["POST_MIX_RATE"] = 37
-	policy["PRE_MIX_RATE"] = 37
-	policy["ASPSPEED"] = 37
-	policy["DSPSPEED"] = 37
+	policy := make(LHPolicy, 1)
+	policy["DEFAULTPIPETTESPEED"] = 37.0
 	return policy
 }
 
@@ -841,8 +809,9 @@ var (
 
 // Conditions to apply to LHpolicyRules based on volume of liquid being transferred
 var (
-	LessThan20ul    = numericCondition{Class: "VOLUME", Range: conditionRange{0.0, 20.0}}
-	GreaterThan20ul = numericCondition{Class: "VOLUME", Range: conditionRange{20.1, 1000.0}}
+	LessThan20ul        = numericCondition{Class: "VOLUME", Range: conditionRange{0.0, 20.0}}
+	GreaterThan20ul     = numericCondition{Class: "VOLUME", Range: conditionRange{20.1, 1000.0}}
+	Between20ulAnd200ul = numericCondition{Class: "VOLUME", Range: conditionRange{20.01, 200.0}}
 )
 
 // Conditions to apply to LHpolicyRules based on volume of liquid in source well from which a sample is taken
@@ -868,20 +837,33 @@ func AddUniversalRules(originalRuleSet *LHPolicyRuleSet, policies map[string]LHP
 	// hack to fix plate type problems
 	// this really should be removed asap
 	rule := NewLHPolicyRule("HVOffsetFix")
-	//rule.AddNumericConditionOn("VOLUME", 20.1, 300.0) // what about higher? // set specifically for openPlant configuration
 
-	err = rule.AddCategoryConditionOn("TIPTYPE", "Gilson200")
-	if err != nil {
-		return nil, err
-	}
-	err = rule.AddCategoryConditionOn("PLATFORM", "GilsonPipetmax")
+	OnGilson := categoricCondition{"PLATFORM", "GilsonPipetmax"}
+
+	// to fix: This offset fix is not consistent with other tip types (e.g. filter tips)
+	highVolumeTips := categoricCondition{"TIPTYPE", "Gilson200"}
+
+	hvOffsetFix, err := newConditionalRule("HVOffsetFix", OnGilson, highVolumeTips)
+
 	if err != nil {
 		return nil, err
 	}
 	// don't get overridden
-	rule.Priority = 100
+	hvOffsetFix.Priority = 100
 	pol := MakeHVOffsetPolicy()
-	lhpr.AddRule(rule, pol)
+	lhpr.AddRule(hvOffsetFix, pol)
+
+	// unless a policy has a default speed explicitely set we'll increase to max for high volumes
+	for name, policy := range policies {
+		if _, found := policy[DefaultPipetteSpeed]; !found && policy.Name() != "" {
+			increaseFlowRate, err := newConditionalRule("highVolumeFlowRateFix"+"_"+name, Between20ulAnd200ul, categoricCondition{LiquidClass, name})
+			if err != nil {
+				return nil, err
+			}
+			increaseFlowRate.Priority = 100
+			lhpr.AddRule(increaseFlowRate, MakeHVFlowRatePolicy())
+		}
+	}
 
 	rule = NewLHPolicyRule("DNALV")
 	err = rule.AddNumericConditionOn("VOLUME", 0.0, 1.99)
@@ -904,12 +886,40 @@ func AddUniversalRules(originalRuleSet *LHPolicyRuleSet, policies map[string]LHP
 
 	lhpr.AddRule(turnOffPostMixIfEmpty, TurnOffPostMix())
 
-	// for Gilson, add some sensible default pipette speeds
-
 	return lhpr, nil
 }
 
-//
+// CopyRulesFromPolicy will copy all instances of rules which mention tthe liquid class policyToCopyRulesFrom into duplicate rules set on policyToCopyRulesTo.
+func CopyRulesFromPolicy(ruleSet *LHPolicyRuleSet, policyToCopyRulesFrom, policyToCopyRulesTo string) (err error) {
+
+	policyToCopyRulesFromName := policyToCopyRulesFrom
+
+	for _, rule := range ruleSet.Rules {
+		var copyThisRule bool
+		newRule := NewLHPolicyRule(rule.Name + policyToCopyRulesTo)
+
+		for _, condition := range rule.Conditions {
+			if condition.TestVariable == LiquidClass && condition.Condition.Match(policyToCopyRulesFromName) {
+				copyThisRule = true
+				lhvc := NewLHVariableCondition(LiquidClass)
+				err := lhvc.SetCategoric(policyToCopyRulesTo)
+
+				if err != nil {
+					return err
+				}
+
+				newRule.Conditions = append(newRule.Conditions, lhvc)
+
+			} else {
+				newRule.Conditions = append(newRule.Conditions, condition)
+			}
+		}
+		if copyThisRule {
+			ruleSet.AddRule(newRule, ruleSet.Policies[rule.Name])
+		}
+	}
+	return nil
+}
 
 // GetLHPolicyForTest is used to set the default System Policies.
 func GetLHPolicyForTest() (*LHPolicyRuleSet, error) {

--- a/microArch/driver/liquidhandling/compositerobotinstruction.go
+++ b/microArch/driver/liquidhandling/compositerobotinstruction.go
@@ -25,14 +25,16 @@ package liquidhandling
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
+
+	"github.com/pkg/errors"
 
 	"reflect"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
+	"github.com/antha-lang/antha/antha/anthalib/wutil/text"
 	"github.com/antha-lang/antha/inventory"
 	anthadriver "github.com/antha-lang/antha/microArch/driver"
 	"github.com/antha-lang/antha/microArch/logger"
@@ -1745,7 +1747,7 @@ func (ins *SuckInstruction) Generate(ctx context.Context, policy *wtype.LHPolicy
 	defaultpspeed, err = checkAndSaften(defaultpspeed, prms.HeadsLoaded[ins.Head].Params.Minspd.RawValue(), prms.HeadsLoaded[ins.Head].Params.Maxspd.RawValue(), allowOutOfRangePipetteSpeeds)
 
 	if err != nil {
-		return []RobotInstruction{}, errors.Wrap(err, "setting default pipette speed")
+		return []RobotInstruction{}, errors.Wrap(err, fmt.Sprintf("setting default pipette speed for policy %s", text.PrettyPrint(pol)))
 	}
 
 	// offsets
@@ -2444,7 +2446,7 @@ func (ins *BlowInstruction) Generate(ctx context.Context, policy *wtype.LHPolicy
 			if override || tb.Tiptype.Filtered {
 				mixvol = ins.Prms.Maxvol.ConvertToString("ul")
 			} else {
-				return ret, wtype.LHError(wtype.LH_ERR_POLICY, fmt.Sprintf("Setting POST_MIX_VOLME to %s cannot be achieved with current tip (type %s) volume limits %v", vmixvol.ToString(), ins.TipType, ins.Prms))
+				return ret, wtype.LHError(wtype.LH_ERR_POLICY, fmt.Sprintf("Setting POST_MIX_VOLUME to %s cannot be achieved with current tip (type %s) volume limits %v, instruction details: %s", vmixvol.ToString(), ins.TipType, ins.Prms, text.PrettyPrint(ins)))
 			}
 		}
 

--- a/microArch/driver/liquidhandling/lhpolicytestframework_test.go
+++ b/microArch/driver/liquidhandling/lhpolicytestframework_test.go
@@ -3,10 +3,11 @@ package liquidhandling
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
@@ -148,9 +149,9 @@ const (
 	HVMaxRate           = 37.5
 	LVMinRate           = 0.0225
 	LVMaxRate           = 3.75
-	defaultZSpeed       = 120.0
+	defaultZSpeed       = 140.0
 	defaultZOffset      = 0.5
-	defaultPipetteSpeed = 3.0
+	defaultPipetteSpeed = 3.7
 )
 
 func getHVConfig() *wtype.LHChannelParameter {


### PR DESCRIPTION
- This increases the default speeds of pipetting to maximum of 3.7ml/min on a low volume head and 37ml/min on the high volume head.
- Any policy without a default speed set explicitly in the policy will be increased to maximum for the appropriate head. 
- System Policies have been updated to ensure the defaults will be applied appropriately, and robust to cases where they are modified in elements.
- Z movement speed has also been increased to 140

