### PR TITLE
panic generated with invalid units should be on error type not string

### DIFF
--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -23,6 +23,7 @@
 package wunit
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -129,7 +130,7 @@ func SubtractVolumes(OriginalVol Volume, subtractvols ...Volume) (newvolume Volu
 	newvolume.Subtract(volToSubtract)
 
 	if math.IsInf(newvolume.RawValue(), 0) {
-		panic(fmt.Sprintln("Infinity value found subtracting volumes. Original: ", OriginalVol, ". Vols to subtract:", subtractvols))
+		panic(errors.New(fmt.Sprintln("Infinity value found subtracting volumes. Original: ", OriginalVol, ". Vols to subtract:", subtractvols)))
 	}
 
 	return
@@ -284,7 +285,7 @@ func NewTemperature(v float64, unit string) Temperature {
 			approved = append(approved, u)
 		}
 		sort.Strings(approved)
-		panic(fmt.Sprintf("unapproved temperature unit %q, approved units are %s", unit, approved))
+		panic(fmt.Errorf("unapproved temperature unit %q, approved units are %s", unit, approved))
 	}
 
 	return Temperature{NewMeasurement((v * details.Multiplier), details.Prefix, details.Base)}
@@ -306,7 +307,7 @@ func NewTime(v float64, unit string) (t Time) {
 			approved = append(approved, u)
 		}
 		sort.Strings(approved)
-		panic(fmt.Sprintf("unapproved time unit %q, approved units are %s", unit, approved))
+		panic(fmt.Errorf("unapproved time unit %q, approved units are %s", unit, approved))
 	}
 
 	return Time{NewMeasurement((v * details.Multiplier), details.Prefix, details.Base)}
@@ -385,7 +386,7 @@ func NewMoles(v float64, unit string) Moles {
 			approved = append(approved, u)
 		}
 		sort.Strings(approved)
-		panic(fmt.Sprintf("unapproved Amount unit %q, approved units are %s", unit, approved))
+		panic(fmt.Errorf("unapproved Amount unit %q, approved units are %s", unit, approved))
 	}
 
 	return Moles{NewMeasurement((v * details.Multiplier), details.Prefix, details.Base)}
@@ -403,7 +404,7 @@ func NewAmount(v float64, unit string) Moles {
 			approved = append(approved, u)
 		}
 		sort.Strings(approved)
-		panic(fmt.Sprintf("unapproved Amount unit %q, approved units are %s", unit, approved))
+		panic(fmt.Errorf("unapproved Amount unit %q, approved units are %s", unit, approved))
 	}
 
 	return Moles{NewMeasurement((v * details.Multiplier), details.Prefix, details.Base)}
@@ -696,7 +697,7 @@ func NewConcentration(v float64, unit string) Concentration {
 			approved = append(approved, u)
 		}
 		sort.Strings(approved)
-		panic(fmt.Sprintf("unapproved concentration unit %q, approved units are %s", unit, approved))
+		panic(fmt.Errorf("unapproved concentration unit %q, approved units are %s", unit, approved))
 	}
 
 	return Concentration{NewMeasurement((v * details.Multiplier), details.Prefix, details.Base)}


### PR DESCRIPTION
When these errors are triggered in elements the error message is currently not user friendly due to a panic within the panic.

*Previous message:*
```
panic: unapproved concentration unit "ul", approved units are [M M/L M/l Mol/L Mol/l U/L U/l U/mL U/ml X fM fM/L fM/l fM/uL fM/ul fMol/L fMol/l fMol/uL fMol/ul g/L g/l kg/L kg/l mM mM/L mM/l mMol/L mMol/l mg/L mg/l mg/mL mg/ml nM nM/L nM/l nMol/L nMol/l ng/L ng/l ng/mL ng/ml ng/uL ng/ul pM pM/L pM/l pM/uL pM/ul pMol/L pMol/l pMol/uL pMol/ul pg/L pg/l pg/mL pg/ml pg/uL pg/ul uM uM/L uM/l uMol/L uMol/l ug/L ug/l ug/mL ug/ml ug/uL ug/ul v/v w/v x] [recovered]
	panic: interface conversion: string is not error: missing method Error

goroutine 1 [running]:
encoding/json.(*decodeState).unmarshal.func1(0xc42082a208)
	/usr/local/Cellar/go/1.10/libexec/src/encoding/json/decode.go:177 +0x8f
panic(0x4d6ad60, 0xc4207539f0)
	/usr/local/Cellar/go/1.10/libexec/src/runtime/panic.go:505 +0x229
github.com/antha-lang/antha/antha/anthalib/wunit.NewConcentration(0x4014000000000000, 0xc42026aff4, 0x2, 0x4014000000000000)
	/Users/theukshowdown/go/src/github.com/antha-lang/antha/antha/anthalib/wunit/wdimension.go:699 +0x511
```
*New message:*
```
error: cannot assign parameter "RestrictionEnzymeSetPoint" of process "Construct Assembly Multi 2 1_run1" to "5ul": unapproved concentration unit "ul", approved units are [M M/L M/l Mol/L Mol/l U/L U/l U/mL U/ml X fM fM/L fM/l fM/uL fM/ul fMol/L fMol/l fMol/uL fMol/ul g/L g/l kg/L kg/l mM mM/L mM/l mMol/L mMol/l mg/L mg/l mg/mL mg/ml nM nM/L nM/l nMol/L nMol/l ng/L ng/l ng/mL ng/ml ng/uL ng/ul pM pM/L pM/l pM/uL pM/ul pMol/L pMol/l pMol/uL pMol/ul pg/L pg/l pg/mL pg/ml pg/uL pg/ul uM uM/L uM/l uMol/L uMol/l ug/L ug/l ug/mL ug/ml ug/uL ug/ul v/v w/v x]
````

Tested on the command line using  workflows with invalid units specified. 
