### PR TITLE
Don't Panic() when building the instruction graph fails, return error instead

### DIFF
--- a/microArch/scheduler/liquidhandling/executionhelpers.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers.go
@@ -362,7 +362,10 @@ func setOutputOrder(rq *LHRequest) error {
 
 	unsorted := getInstructionSet(rq)
 
-	tg := MakeTGraph(unsorted)
+	tg, err := MakeTGraph(unsorted)
+	if err != nil {
+		return err
+	}
 
 	sorted, err := graph.TopoSort(graph.TopoSortOpt{Graph: tg})
 
@@ -389,7 +392,10 @@ func setOutputOrder(rq *LHRequest) error {
 	rq = updateRequestWithNewInstructions(rq, sortedAsIns)
 
 	// sort again post aggregation
-	tg = MakeTGraph(sortedAsIns)
+	tg, err = MakeTGraph(sortedAsIns)
+	if err != nil {
+		return err
+	}
 
 	sorted, err = graph.TopoSort(graph.TopoSortOpt{Graph: tg})
 

--- a/microArch/scheduler/liquidhandling/executionhelpers_test.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers_test.go
@@ -77,14 +77,9 @@ func (self *setOutputOrderTest) Run(t *testing.T) {
 	rq.Options.OutputSort = self.OutputSort
 
 	err := setOutputOrder(rq)
-	if self.ExpectingError {
-		if err == nil {
-			t.Fatal("expecting an error but got none")
-		}
+	if encounteredError := err != nil; self.ExpectingError != encounteredError {
+		t.Fatalf("ExpectingError: %t, Encountered Error: %v", self.ExpectingError, err)
 		return
-	}
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	if e, g := self.ChainHeight, rq.InstructionChain.Height(); e != g {
@@ -138,8 +133,8 @@ func TestSetOutputOrdering_SplitUnused(t *testing.T) {
 	test := setOutputOrderTest{
 		Instructions:   []*wtype.LHInstruction{split},
 		OutputSort:     true,
-		ExpectedOrder:  []string{"theSplit"},
-		ChainHeight:    1,
+		ExpectedOrder:  []string{},
+		ChainHeight:    0,
 		ExpectingError: true,
 	}
 

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -844,7 +844,6 @@ func (this *Liquidhandler) Plan(ctx context.Context, request *LHRequest) error {
 
 	// figure out the output order
 	err := setOutputOrder(request)
-
 	if err != nil {
 		return err
 	}

--- a/microArch/scheduler/liquidhandling/tgraph_test.go
+++ b/microArch/scheduler/liquidhandling/tgraph_test.go
@@ -22,7 +22,10 @@ func TestTGraph(t *testing.T) {
 		cmpIn = cmpOut
 	}
 
-	tgraph := MakeTGraph(tIns)
+	tgraph, err := MakeTGraph(tIns)
+	if err != nil {
+		t.Error(err)
+	}
 
 	arrEq := func(ar1 []*wtype.LHInstruction, ar2 []*wtype.LHInstruction) bool {
 		if len(ar1) != len(ar2) {
@@ -94,7 +97,10 @@ func TestTGraphSplit(t *testing.T) {
 	ins.AddProduct(wtype.NewLHComponent())
 	tIns = append(tIns, ins)
 
-	tgraph := MakeTGraph(tIns)
+	tgraph, err := MakeTGraph(tIns)
+	if err != nil {
+		t.Error(err)
+	}
 
 	arrEq := func(ar1 []*wtype.LHInstruction, ar2 []*wtype.LHInstruction) bool {
 		if len(ar1) != len(ar2) {


### PR DESCRIPTION
Building the topological graph can now fail if SplitSample is used incorrectly. This change returns error instead of calling panic