### PR TITLE
Add ID and AdaptorType methods to aid adaptor identification

### DIFF
--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -426,11 +426,16 @@ func NewLHAdaptor(name, mf string, params *LHChannelParameter) *LHAdaptor {
 	lha.Manufacturer = mf
 	lha.Params = params
 	lha.Tips = make([]*LHTip, params.Multi)
+	lha.ID = GetUUID()
 	return &lha
 }
 
 func (lha *LHAdaptor) Dup() *LHAdaptor {
 	return lha.dup(false)
+}
+
+func (lha *LHAdaptor) AdaptorType() string {
+	return lha.Manufacturer + lha.Name
 }
 
 func (lha *LHAdaptor) DupKeepIDs() *LHAdaptor {
@@ -455,6 +460,10 @@ func (lha *LHAdaptor) dup(keepIDs bool) *LHAdaptor {
 				ad.AddTip(i, tip.Dup())
 			}
 		}
+	}
+
+	if keepIDs {
+		ad.ID = lha.ID
 	}
 
 	return ad

--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -464,6 +464,8 @@ func (lha *LHAdaptor) dup(keepIDs bool) *LHAdaptor {
 
 	if keepIDs {
 		ad.ID = lha.ID
+	} else {
+		ad.ID = GetUUID()
 	}
 
 	return ad


### PR DESCRIPTION
This PR adds a couple of useful things to adaptors
- the ID field is now used and maintained on duplication / reassigned depending on option
- adaptors now define a method to declare a "type" based on their manufacturer and model