### PR TITLE
Revert volume segmenting in multichannel operations

### DIFF
--- a/microArch/driver/liquidhandling/convertinstructions.go
+++ b/microArch/driver/liquidhandling/convertinstructions.go
@@ -158,11 +158,6 @@ func convertInstructions(inssIn LHIVector, robot *LHProperties, carryvol wunit.V
 		independent = channelprms.Independent
 	}
 
-	if !independent {
-		//volumes in each parallel set must be the same, so segment groups of compoents such that this is the case
-		componentsToMove, instructionsToUse = segmentAllByVolume(componentsToMove, instructionsToUse)
-	}
-
 	for i := 0; i < len(componentsToMove); i++ {
 
 		parallelTransfers, err := robot.GetComponents(
@@ -192,52 +187,6 @@ func convertInstructions(inssIn LHIVector, robot *LHProperties, carryvol wunit.V
 	}
 
 	return insOut, nil
-}
-
-func segmentAllByVolume(inComponentsByVolume [][]*wtype.Liquid, inInstructionsToUse []LHIVector) ([][]*wtype.Liquid, []LHIVector) {
-	var retComponentsToMove [][]*wtype.Liquid
-	var retInstructionsToUse []LHIVector
-
-	for i := 0; i < len(inComponentsByVolume); i++ {
-		c, ins := segmentByVolume(inComponentsByVolume[i], inInstructionsToUse[i])
-		retComponentsToMove = append(retComponentsToMove, c...)
-		retInstructionsToUse = append(retInstructionsToUse, ins...)
-	}
-
-	return retComponentsToMove, retInstructionsToUse
-}
-
-//split up the idsets such that each instruction in the set has the same volume. incoming instructions are sorted in channel order
-func segmentByVolume(components []*wtype.Liquid, instructions LHIVector) ([][]*wtype.Liquid, []LHIVector) {
-
-	var retComponents [][]*wtype.Liquid
-	var retInstructions []LHIVector
-
-	var currComponents []*wtype.Liquid
-	var currInstructions LHIVector
-
-	lastVolume := wunit.ZeroVolume()
-	for i := range components {
-		component := components[i]
-		instruction := instructions[i]
-
-		if len(currComponents) > 0 && !component.Volume().EqualTo(lastVolume) {
-			retComponents = append(retComponents, currComponents)
-			retInstructions = append(retInstructions, currInstructions)
-			currComponents = make([]*wtype.Liquid, 0)
-			currInstructions = make(LHIVector, 0)
-		}
-
-		currComponents = append(currComponents, component)
-		currInstructions = append(currInstructions, instruction)
-		lastVolume = component.Volume()
-	}
-	if len(currComponents) > 0 {
-		retComponents = append(retComponents, currComponents)
-		retInstructions = append(retInstructions, currInstructions)
-	}
-
-	return retComponents, retInstructions
 }
 
 func makeTransfers(parallelTransfer ParallelTransfer, cmps []*wtype.Liquid, robot *LHProperties, inssIn []*wtype.LHInstruction, carryvol wunit.Volume) ([]*TransferInstruction, error) {


### PR DESCRIPTION
This logic was added in to combat a particular edge case in multichannelling which resulted in strange but not logically incorrect behaviour (see ANTHA-1842, PR 798), but this fix has introduced incorrect pipetting behaviour which significantly slows down some DoE workflows.
