### PR TITLE
Add max xy bounds well coords

### DIFF
--- a/antha/anthalib/wtype/lhtipbox.go
+++ b/antha/anthalib/wtype/lhtipbox.go
@@ -419,8 +419,8 @@ func (tb *LHTipbox) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) 
 	rel := r.Subtract(tb.GetPosition())
 	tipSize := tb.Tiptype.GetSize()
 	wc := WellCoords{
-		int(math.Floor(((rel.X - tb.TipXStart + 0.5*tipSize.X) / tb.TipXOffset))),
-		int(math.Floor(((rel.Y - tb.TipYStart + 0.5*tipSize.Y) / tb.TipYOffset))),
+		X: int(math.Floor(((rel.X - tb.TipXStart + 0.5*tipSize.X) / tb.TipXOffset))),
+		Y: int(math.Floor(((rel.Y - tb.TipYStart + 0.5*tipSize.Y) / tb.TipYOffset))),
 	}
 	if wc.X < 0 {
 		wc.X = 0
@@ -682,7 +682,7 @@ func (tb *LHTipbox) GetTips(mirror bool, multi int, orient ChannelOrientation) [
 				ret = make([]string, multi)
 				for i := 0; i < multi; i++ {
 					tb.Tips[i+s][j] = nil
-					wc := WellCoords{i + s, j}
+					wc := WellCoords{X: i + s, Y: j}
 					ret[i] = wc.FormatA1()
 				}
 				break
@@ -715,7 +715,7 @@ func (tb *LHTipbox) GetTips(mirror bool, multi int, orient ChannelOrientation) [
 				n := 0
 				for j := s; j >= 0; j-- {
 					tb.Tips[i][j] = nil
-					wc := WellCoords{i, j}
+					wc := WellCoords{X: i, Y: j}
 					//fmt.Println(j, "Getting TIP from ", wc.FormatA1())
 					ret = append(ret, wc.FormatA1())
 					n += 1

--- a/antha/anthalib/wtype/lhtipwaste.go
+++ b/antha/anthalib/wtype/lhtipwaste.go
@@ -127,7 +127,7 @@ func NewLHTipwaste(capacity int, typ, mfr string, size Coordinates, w *LHWell, w
 		Z: wellzstart,
 	}
 	w.SetOffset(offset) //nolint
-	w.Crds = WellCoords{0, 0}
+	w.Crds = WellCoords{X: 0, Y: 0}
 
 	return &lht
 }
@@ -148,7 +148,7 @@ func (lht *LHTipwaste) Dispose(channels []*LHChannelParameter) ([]WellCoords, bo
 
 	//currently tipwastes only ever have one well
 	wcS := make([]WellCoords, 0, n)
-	wc := WellCoords{0, 0}
+	wc := WellCoords{X: 0, Y: 0}
 	for i := 0; i < n; i++ {
 		wcS = append(wcS, wc)
 	}
@@ -268,7 +268,7 @@ func (self *LHTipwaste) GetChildByAddress(c WellCoords) LHObject {
 }
 
 func (self *LHTipwaste) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
-	wc := WellCoords{0, 0}
+	wc := WellCoords{X: 0, Y: 0}
 
 	c, _ := self.WellCoordsToCoords(wc, TopReference)
 

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -139,8 +139,8 @@ func (lhc *Liquid) WellLocation() string {
 }
 
 // SetWellLocation sets the well location to an LHComponent in A1 format.
-func (lhc *Liquid) SetWellLocation(wellLocation string, plateType *Plate) error {
-	location := lhc.PlateLocation()
+func (lhc *Liquid) SetWellLocation(wellLocation string, plateType ...*Plate) error {
+	location := lhc.PlateLocation(plateType...)
 	lhc.Loc = location.ID + ":" + wellLocation
 	return nil
 }

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -123,8 +123,14 @@ func (lhc Liquid) GetID() string {
 	return lhc.ID
 }
 
-func (lhc *Liquid) PlateLocation() PlateLocation {
-	return PlateLocationFromString(lhc.Loc)
+func (lhc *Liquid) PlateLocation(optionalPlateType ...*Plate) PlateLocation {
+	
+	plateLoc := PlateLocationFromString(lhc.Loc)
+	
+	if len(optionalPlateType) == 1 {
+		plateLoc.Coords.MaxX, plateLoc.Coords.MaxY = optionalPlateType[0].WlsX, optionalPlateType[0].WlsY 
+	}
+	return plateLoc
 }
 
 // WellLocation returns the well location in A1 format.
@@ -133,7 +139,7 @@ func (lhc *Liquid) WellLocation() string {
 }
 
 // SetWellLocation sets the well location to an LHComponent in A1 format.
-func (lhc *Liquid) SetWellLocation(wellLocation string) error {
+func (lhc *Liquid) SetWellLocation(wellLocation string, plateType *Plate) error {
 	location := lhc.PlateLocation()
 	lhc.Loc = location.ID + ":" + wellLocation
 	return nil

--- a/antha/anthalib/wtype/plate.go
+++ b/antha/anthalib/wtype/plate.go
@@ -633,7 +633,7 @@ func NewLHPlate(platetype, mfr string, nrows, ncols int, size Coordinates, wellt
 			arr[i][j] = welltype.CDup()
 
 			//crds := wutil.NumToAlpha(i+1) + ":" + strconv.Itoa(j+1)
-			crds := WellCoords{j, i}
+			crds := WellCoords{X: j,Y: i}
 			wellcoords[crds.FormatA1()] = arr[i][j]
 			colarr[j][i] = arr[i][j]
 			rowarr[i][j] = arr[i][j]
@@ -1134,8 +1134,8 @@ func (self *Plate) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
 	rel := r.Subtract(self.GetPosition())
 	wellSize := self.Welltype.GetSize()
 	wc := WellCoords{
-		int(math.Floor((rel.X - self.WellXStart + 0.5*wellSize.X) / self.WellXOffset)),
-		int(math.Floor((rel.Y - self.WellYStart + 0.5*wellSize.Y) / self.WellYOffset)),
+		X: int(math.Floor((rel.X - self.WellXStart + 0.5*wellSize.X) / self.WellXOffset)),
+		Y: int(math.Floor((rel.Y - self.WellYStart + 0.5*wellSize.Y) / self.WellYOffset)),
 	}
 	if wc.X < 0 {
 		wc.X = 0

--- a/antha/anthalib/wtype/wellcoords.go
+++ b/antha/anthalib/wtype/wellcoords.go
@@ -1,10 +1,11 @@
 package wtype
 
 import (
-	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 func A1ArrayFromWells(wells []*LHWell) []string {
@@ -148,10 +149,12 @@ func CompareWellCoordsRow(w1, w2 WellCoords) int {
 type WellCoords struct {
 	X int
 	Y int
+	// Maximum number of wells in x and y direction based on plate type
+	MaxX, MaxY int
 }
 
 func ZeroWellCoords() WellCoords {
-	return WellCoords{-1, -1}
+	return WellCoords{X: -1, Y: -1}
 }
 func (wc WellCoords) IsZero() bool {
 	return wc.Equals(ZeroWellCoords())
@@ -175,7 +178,7 @@ func MakeWellCoords(wc string) WellCoords {
 
 	r := MakeWellCoordsA1(wc)
 
-	zero := WellCoords{-1, -1}
+	zero := WellCoords{X: -1, Y: -1}
 
 	if !r.Equals(zero) {
 		return r
@@ -198,7 +201,7 @@ func MakeWellCoordsA1(a1 string) WellCoords {
 	matches := re.FindStringSubmatch(a1)
 
 	if matches == nil {
-		return WellCoords{-1, -1}
+		return WellCoords{X: -1, Y: -1}
 	}
 	/*
 		re, _ := regexp.Compile("[A-Z]{1,}")
@@ -206,10 +209,7 @@ func MakeWellCoordsA1(a1 string) WellCoords {
 		endC := ix[1]
 	*/
 
-	X := wutil.ParseInt(matches[2]) - 1
-	Y := wutil.AlphaToNum(matches[1]) - 1
-
-	return WellCoords{X, Y}
+	return WellCoords{X: wutil.ParseInt(matches[2]) - 1, Y: wutil.AlphaToNum(matches[1]) - 1}
 }
 
 // make well coordinates in the "1A" convention
@@ -218,20 +218,18 @@ func MakeWellCoords1A(a1 string) WellCoords {
 	matches := re.FindStringSubmatch(a1)
 
 	if matches == nil {
-		return WellCoords{-1, -1}
+		return WellCoords{X: -1, Y: -1}
 	}
 
-	Y := wutil.AlphaToNum(matches[2]) - 1
-	X := wutil.ParseInt(matches[1]) - 1
-	return WellCoords{X, Y}
+	return WellCoords{X: wutil.AlphaToNum(matches[2]) - 1, Y: wutil.ParseInt(matches[1]) - 1}
 }
 
 // make well coordinates in a manner compatble with "X1,Y1" etc.
 func MakeWellCoordsXYsep(x, y string) WellCoords {
-	r := WellCoords{wutil.ParseInt(y[1:]) - 1, wutil.ParseInt(x[1:]) - 1}
+	r := WellCoords{X: wutil.ParseInt(y[1:]) - 1, Y: wutil.ParseInt(x[1:]) - 1}
 
 	if r.X < 0 || r.Y < 0 {
-		return WellCoords{-1, -1}
+		return WellCoords{X: -1, Y: -1}
 	}
 
 	return r
@@ -240,11 +238,11 @@ func MakeWellCoordsXYsep(x, y string) WellCoords {
 func MakeWellCoordsXY(xy string) WellCoords {
 	tx := strings.Split(xy, "Y")
 	if tx == nil || len(tx) != 2 || len(tx[0]) == 0 || len(tx[1]) == 0 {
-		return WellCoords{-1, -1}
+		return WellCoords{X: -1, Y: -1}
 	}
 	x := wutil.ParseInt(tx[0][1:len(tx[0])]) - 1
 	y := wutil.ParseInt(tx[1]) - 1
-	return WellCoords{x, y}
+	return WellCoords{X: x, Y: y}
 }
 
 // return well coordinates in "X1Y1" format

--- a/antha/anthalib/wtype/wtype_test.go
+++ b/antha/anthalib/wtype/wtype_test.go
@@ -261,13 +261,13 @@ func TestLHMultiConstraint(t *testing.T) {
 func TestWCSorting(t *testing.T) {
 	v := make([]WellCoords, 0, 1)
 
-	v = append(v, WellCoords{0, 2})
-	v = append(v, WellCoords{4, 2})
-	v = append(v, WellCoords{0, 1})
-	v = append(v, WellCoords{8, 9})
-	v = append(v, WellCoords{1, 3})
-	v = append(v, WellCoords{3, 6})
-	v = append(v, WellCoords{8, 0})
+	v = append(v, WellCoords{X: 0, Y: 2})
+	v = append(v, WellCoords{X: 4, Y: 2})
+	v = append(v, WellCoords{X: 0, Y: 1})
+	v = append(v, WellCoords{X: 8, Y: 9})
+	v = append(v, WellCoords{X: 1, Y: 3})
+	v = append(v, WellCoords{X: 3, Y: 6})
+	v = append(v, WellCoords{X: 8, Y: 0})
 
 	sort.Sort(WellCoordArrayRow(v))
 

--- a/execute/intrinsics.go
+++ b/execute/intrinsics.go
@@ -368,7 +368,14 @@ func genericMix(ctx context.Context, generic *wtype.LHInstruction) *wtype.Liquid
 	inst := mix(ctx, generic)
 	trace.Issue(ctx, inst)
 	if generic.Welladdress != "" {
-		err := inst.result[0].SetWellLocation(generic.Welladdress)
+		var plateType []*wtype.Plate
+
+		if generic.OutPlate != nil {
+			plateType = append(plateType, generic.OutPlate)
+		}
+
+		err := inst.result[0].SetWellLocation(generic.Welladdress, plateType...)
+
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Intended to support the idea of referencing the well coords to an actual position on a plate. However, this is currently not going to be useful until we can query a plate type (or at least carry around the properties of the well coords directly in the Liquid object)