### PR TITLE
use the gilson tip chute by default

### DIFF
--- a/inventory/testinventory/make_tip_library.go
+++ b/inventory/testinventory/make_tip_library.go
@@ -28,10 +28,12 @@ import (
 const (
 	xOffset = 14.38
 	yOffset = 11.24
+	sbsX    = 127.76
+	sbsY    = 85.48
 )
 
 func getTipboxSize() wtype.Coordinates {
-	return wtype.Coordinates{X: 127.76, Y: 85.48, Z: 60.13}
+	return wtype.Coordinates{X: sbsX, Y: sbsY, Z: 60.13}
 }
 
 func makeTipboxes() (tipboxes []*wtype.LHTipbox) {

--- a/inventory/testinventory/make_tip_waste_library.go
+++ b/inventory/testinventory/make_tip_waste_library.go
@@ -24,14 +24,22 @@ package testinventory
 import "github.com/antha-lang/antha/antha/anthalib/wtype"
 
 func makeTipwastes() (tipwastes []*wtype.LHTipwaste) {
-	tipwastes = append(tipwastes, makeGilsonTipWaste(), makeCyBioTipwaste(), makeManualTipwaste(), makeTecanTipwaste())
+	tipwastes = append(tipwastes, makeGilsonTipWaste(), makeGilsonTipChute(), makeCyBioTipwaste(), makeManualTipwaste(), makeTecanTipwaste())
 	return
 }
 
 func makeGilsonTipWaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 123.0, 80.0, 92.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 123.0, 80.0, 92.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5+xOffset, 31.5+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 92.0}, w, 49.5+xOffset, 31.5+yOffset, 0.0)
+	return lht
+}
+
+//makeGilsonTipChute this is the chute for position 1 from direct measurements
+func makeGilsonTipChute() *wtype.LHTipwaste {
+	shp := wtype.NewShape("box", "mm", 50.0, 63.8, 82.98)
+	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, wtype.FlatWellBottom, 50.0, 63.8, 82.98, 0.0, "mm")
+	lht := wtype.NewLHTipwaste(6000, "GilsonTipChute", "gilson", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 50.0}, w, sbsX/2.0, sbsY/2.0, 0.0)
 	return lht
 }
 
@@ -39,7 +47,7 @@ func makeGilsonTipWaste() *wtype.LHTipwaste {
 func makeCyBioTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(700, "CyBiotipwaste", "cybio", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(700, "CyBiotipwaste", "cybio", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }
 
@@ -47,13 +55,13 @@ func makeCyBioTipwaste() *wtype.LHTipwaste {
 func makeManualTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(1000000, "Manualtipwaste", "ACMEBagsInc", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(1000000, "Manualtipwaste", "ACMEBagsInc", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }
 
 func makeTecanTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(2000, "Tecantipwaste", "Tecan", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(2000, "Tecantipwaste", "Tecan", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -250,7 +250,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 			// representation of the liquid handler
 			switch params.Model {
 			case "Pipetmax":
-				waste, err = inventory.NewTipwaste(ctx, "Gilsontipwaste")
+				waste, err = inventory.NewTipwaste(ctx, "GilsonTipChute")
 			case "GeneTheatre":
 				fallthrough
 			case "Felix":


### PR DESCRIPTION
Previously represented this as the gilsontipwaste (i.e. the on deck box) but this is considerably taller than the chute and so several collisions are predicted with the box which do not occur when using the chute