### PR TITLE
cmd to update bundle file based on mapping details from metadata file

### DIFF
--- a/cmd/antha/cmd/convert_all_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_all_bundle_parameters.go
@@ -99,7 +99,7 @@ func convertAllBundles(cmd *cobra.Command, args []string) error {
 
 			if !c.Empty() {
 				for _, bundle := range bundles.Bundles {
-					err := convertBundleWithArgs(metadataFileName, bundle.Path, bundle.Path)
+					err := convertBundleWithArgs(metadataFileName, bundle.Path, filepath.Join(bundle.Dir, viper.GetString("addPrefix")+bundle.FileName))
 					if err != nil {
 						errs = append(errs, metadataFileName+" + "+bundle.Path+": "+err.Error())
 					}
@@ -121,4 +121,5 @@ func init() {
 
 	flags := c.Flags()
 	flags.String("rootDir", ".", "root directory to search for metadata files with new element mapping and test bundles to update")
+	flags.String("addPrefix", "", "adds a common prefix to the start of all updated bundle files")
 }

--- a/cmd/antha/cmd/convert_all_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_all_bundle_parameters.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var convertAllBundlesCmd = &cobra.Command{
+	Use:   "all-bundle-parameters",
+	Short: "update all bundle parameters according to the map of old parameter names to new found in metadata",
+	RunE:  convertAllBundles,
+}
+
+type bundle struct {
+	Dir      string
+	Path     string
+	FileName string
+}
+
+type bundles struct {
+	Bundles []*bundle
+	seen    map[string]bool
+}
+
+func newBundles() *bundles {
+	return &bundles{
+		seen: make(map[string]bool),
+	}
+}
+
+func (b *bundles) Walk(path string, fi os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if fi.IsDir() {
+		return nil
+	}
+	if !strings.HasSuffix(path, ".bundle.json") {
+		return nil
+	}
+
+	dir, fileName := filepath.Split(path)
+	if b.seen[dir] {
+		return nil
+	}
+
+	b.seen[dir] = true
+
+	b.Bundles = append(b.Bundles, &bundle{
+		Dir:      dir,
+		Path:     path,
+		FileName: fileName,
+	})
+
+	return nil
+}
+
+//
+func convertAllBundles(cmd *cobra.Command, args []string) error {
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
+		return err
+	}
+
+	// find metadata files
+	elements := newElements()
+	if err := filepath.Walk(viper.GetString("rootDir"), elements.Walk); err != nil {
+		return err
+	}
+
+	bundles := newBundles()
+	if err := filepath.Walk(viper.GetString("rootDir"), bundles.Walk); err != nil {
+		return err
+	}
+
+	for _, elem := range elements.Elements {
+		for _, bundle := range bundles.Bundles {
+			convertBundleWithArgs(filepath.Join(elem.Dir, "metadata.json"), bundle.Path, bundle.Path)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	c := convertAllBundlesCmd
+	convertCmd.AddCommand(c)
+
+	flags := c.Flags()
+	flags.String("rootDir", ".", "root directory to search for metadata files with new element mapping and test bundles to update")
+}

--- a/cmd/antha/cmd/convert_all_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_all_bundle_parameters.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
+	"strings"
+	"path/filepath"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
-	"path/filepath"
-	"strings"
+	"github.com/pkg/errors"
 )
 
 var convertAllBundlesCmd = &cobra.Command{
@@ -17,14 +17,15 @@ var convertAllBundlesCmd = &cobra.Command{
 }
 
 type bundle struct {
-	Dir      string
-	Path     string
+	Dir  string
+	Path string
 	FileName string
 }
 
+
 type bundles struct {
 	Bundles []*bundle
-	seen    map[string]bool
+	seen     map[string]bool
 }
 
 func newBundles() *bundles {
@@ -53,8 +54,8 @@ func (b *bundles) Walk(path string, fi os.FileInfo, err error) error {
 	b.seen[dir] = true
 
 	b.Bundles = append(b.Bundles, &bundle{
-		Dir:      dir,
-		Path:     path,
+		Dir:  dir,
+		Path: path,
 		FileName: fileName,
 	})
 
@@ -77,41 +78,41 @@ func convertAllBundles(cmd *cobra.Command, args []string) error {
 	if err := filepath.Walk(viper.GetString("rootDir"), bundles.Walk); err != nil {
 		return err
 	}
-
+	
 	var errs []string
 
 	for _, elem := range elements.Elements {
-
-		metadataFileName := filepath.Join(elem.Dir, "metadata.json")
-
+		
+		metadataFileName := filepath.Join(elem.Dir,"metadata.json")
+		
 		cFile, err := os.Open(metadataFileName)
 
 		if err != nil {
-			errs = append(errs, metadataFileName+": ", err.Error())
-			cFile.Close()
-		} else {
+			errs = append(errs, metadataFileName + ": ", err.Error())
+			cFile.Close() //nolint
+		} else {		
 			var c NewElementMappingDetails
 			decConv := json.NewDecoder(cFile)
 			if err := decConv.Decode(&c); err != nil {
-				errs = append(errs, "error decoding to NewElementMappingDetails for "+metadataFileName+": ", err.Error())
+				errs = append(errs, "error decoding to NewElementMappingDetails for " + metadataFileName + ": ", err.Error())
 			}
-			cFile.Close()
-
-			if !c.Empty() {
+			cFile.Close() //nolint
+			
+			if !c.Empty(){
 				for _, bundle := range bundles.Bundles {
 					err := convertBundleWithArgs(metadataFileName, bundle.Path, bundle.Path)
 					if err != nil {
-						errs = append(errs, metadataFileName+" + "+bundle.Path+": "+err.Error())
+						errs = append(errs, metadataFileName + " + " + bundle.Path + ": " + err.Error())
 					}
 				}
 			}
 		}
 	}
-
-	if len(errs) > 0 {
-		return errors.Errorf(strings.Join(errs, "\n"))
+	
+	if len(errs) > 0{
+		return errors.Errorf(strings.Join(errs,"\n"))
 	}
-
+	
 	return nil
 }
 

--- a/cmd/antha/cmd/convert_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_bundle_parameters.go
@@ -33,14 +33,14 @@ type customAnthaBundle struct {
 	CompareOutputs      bool
 	ComparisonOptions   string
 	Results             results
-	
+
 	// core bundle file fields, including a generic Config field to support both UI and command line generated bundles.
 	workflow.Desc
 	customParams
-	
+
 	// fields generated from UI
 	Properties interface{}
-	Version string `json:"version"`
+	Version    string `json:"version"`
 }
 
 type results struct {
@@ -66,7 +66,7 @@ func convertProcesses(in map[string]workflow.Process, newElementNames Conversion
 		}
 		ret[k] = workflow.Process{
 			Component: comp,
-			Metadata: v.Metadata,
+			Metadata:  v.Metadata,
 		}
 	}
 

--- a/cmd/antha/cmd/convert_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_bundle_parameters.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 	"fmt"
 	"github.com/antha-lang/antha/workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"os"
 )
 
 var convertBundleCmd = &cobra.Command{
@@ -20,11 +20,10 @@ type NewElementMappingDetails struct {
 }
 
 type ConversionDetails struct {
-	OldElementName string `json:"old-element-name"`
-	NewElementName string `json:"new-element-name"`
+	OldElementName      string            `json:"old-element-name"`
+	NewElementName      string            `json:"new-element-name"`
 	NewParameterMapping map[string]string `json:"new-parameter-mapping"`
 }
-
 
 // replaces old parameter names with new; this must be done after changing parameter names
 func convertProcesses(in map[string]workflow.Process, newElementNames ConversionDetails) map[string]workflow.Process {
@@ -32,7 +31,7 @@ func convertProcesses(in map[string]workflow.Process, newElementNames Conversion
 
 	for k, v := range in {
 		var comp string
-		
+
 		if v.Component == newElementNames.OldElementName {
 			comp = newElementNames.NewElementName
 		} else {
@@ -47,24 +46,24 @@ func convertProcesses(in map[string]workflow.Process, newElementNames Conversion
 }
 
 func convertParametersAndConnections(in anthaBundle, newElementNames ConversionDetails) (map[string]map[string]json.RawMessage, []workflow.Connection) {
-	
+
 	parameters := make(map[string]map[string]json.RawMessage)
 	connections := in.Connections
 
 	for processName, element := range in.Processes {
-		
+
 		// check if element name is to be replaced
 		if element.Component == newElementNames.OldElementName {
 			// get existing parameters
 			parametersForThisProcess, found := in.Parameters[processName]
-			if !found{
-				panic(fmt.Errorf("parameters not found for %s",processName))
+			if !found {
+				panic(fmt.Errorf("parameters not found for %s", processName))
 			}
 			newParameters := make(map[string]json.RawMessage)
 			// update values of parameters according to map
-			for parameterName, value := range parametersForThisProcess{
+			for parameterName, value := range parametersForThisProcess {
 				// check for replacement parameter names
-				if newParameterName, newParameterFound := newElementNames.NewParameterMapping[parameterName]; newParameterFound{
+				if newParameterName, newParameterFound := newElementNames.NewParameterMapping[parameterName]; newParameterFound {
 					newParameters[newParameterName] = value
 				} else {
 					newParameters[parameterName] = value
@@ -72,12 +71,12 @@ func convertParametersAndConnections(in anthaBundle, newElementNames ConversionD
 			}
 			// replace connections
 			for parameterName, newParameterName := range newElementNames.NewParameterMapping {
-				for i := range connections{
+				for i := range connections {
 					connections[i] = replaceConnection(connections[i], processName, parameterName, newParameterName)
 				}
 			}
 			parameters[processName] = newParameters
-		} else{
+		} else {
 			parameters[processName] = in.Parameters[processName]
 		}
 	}
@@ -85,21 +84,21 @@ func convertParametersAndConnections(in anthaBundle, newElementNames ConversionD
 	return parameters, connections
 }
 
-func replaceConnection(connection workflow.Connection, processToReplace, parameterToReplace, newParameterName string)workflow.Connection{
-	var newConnection workflow.Connection	
-	if connection.Src.Process == processToReplace && connection.Src.Port == parameterToReplace{
+func replaceConnection(connection workflow.Connection, processToReplace, parameterToReplace, newParameterName string) workflow.Connection {
+	var newConnection workflow.Connection
+	if connection.Src.Process == processToReplace && connection.Src.Port == parameterToReplace {
 		newConnection.Src = workflow.Port{
 			Process: connection.Src.Process,
-			Port: newParameterName,
+			Port:    newParameterName,
 		}
 	} else {
 		newConnection.Src = connection.Src
 	}
-	
-	if connection.Tgt.Process == processToReplace && connection.Tgt.Port == parameterToReplace{
+
+	if connection.Tgt.Process == processToReplace && connection.Tgt.Port == parameterToReplace {
 		newConnection.Tgt = workflow.Port{
 			Process: connection.Tgt.Process,
-			Port: newParameterName,
+			Port:    newParameterName,
 		}
 		panic(fmt.Sprintln(newConnection))
 	} else {
@@ -107,6 +106,7 @@ func replaceConnection(connection workflow.Connection, processToReplace, paramet
 	}
 	return newConnection
 }
+
 //
 func convertBundle(cmd *cobra.Command, args []string) error {
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {
@@ -124,26 +124,25 @@ func convertBundle(cmd *cobra.Command, args []string) error {
 	if err := dec.Decode(&original); err != nil {
 		return err
 	}
-		
+
 	cFile, err := os.Open(viper.GetString("conversionMap"))
-	
+
 	if err != nil {
 		return err
 	}
 	defer cFile.Close() // nolint
-	
+
 	var c NewElementMappingDetails
 	decConv := json.NewDecoder(cFile)
 	if err := decConv.Decode(&c); err != nil {
 		return err
 	}
-	
 
 	var bundle anthaBundle
 	bundle.Parameters, bundle.Connections = convertParametersAndConnections(original, c.ConversionDetails)
 	bundle.Processes = convertProcesses(original.Processes, c.ConversionDetails)
 	bundle.Config = original.Config
-	
+
 	outFile, err := os.Create(viper.GetString("output"))
 	if err != nil {
 		return err
@@ -161,6 +160,6 @@ func init() {
 
 	flags := c.Flags()
 	flags.String("bundle", "", "Input bundle")
-	flags.String("conversionMap","", "conversion map file")
+	flags.String("conversionMap", "", "conversion map file")
 	flags.String("output", "output.json", "default output bundle name in antha format")
 }

--- a/cmd/antha/cmd/convert_bundle_parameters.go
+++ b/cmd/antha/cmd/convert_bundle_parameters.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"fmt"
+	"github.com/antha-lang/antha/workflow"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var convertBundleCmd = &cobra.Command{
+	Use:   "bundle-parameters",
+	Short: "update bundle parameters according to the map of old parameter names to new",
+	RunE:  convertBundle,
+}
+
+type NewElementMappingDetails struct {
+	ConversionDetails `json:"new-element-mapping-details"`
+}
+
+type ConversionDetails struct {
+	OldElementName string `json:"old-element-name"`
+	NewElementName string `json:"new-element-name"`
+	NewParameterMapping map[string]string `json:"new-parameter-mapping"`
+}
+
+
+// replaces old parameter names with new; this must be done after changing parameter names
+func convertProcesses(in map[string]workflow.Process, newElementNames ConversionDetails) map[string]workflow.Process {
+	ret := make(map[string]workflow.Process)
+
+	for k, v := range in {
+		var comp string
+		
+		if v.Component == newElementNames.OldElementName {
+			comp = newElementNames.NewElementName
+		} else {
+			comp = v.Component
+		}
+		ret[k] = workflow.Process{
+			Component: comp,
+		}
+	}
+
+	return ret
+}
+
+func convertParametersAndConnections(in anthaBundle, newElementNames ConversionDetails) (map[string]map[string]json.RawMessage, []workflow.Connection) {
+	
+	parameters := make(map[string]map[string]json.RawMessage)
+	connections := in.Connections
+
+	for processName, element := range in.Processes {
+		
+		// check if element name is to be replaced
+		if element.Component == newElementNames.OldElementName {
+			// get existing parameters
+			parametersForThisProcess, found := in.Parameters[processName]
+			if !found{
+				panic(fmt.Errorf("parameters not found for %s",processName))
+			}
+			newParameters := make(map[string]json.RawMessage)
+			// update values of parameters according to map
+			for parameterName, value := range parametersForThisProcess{
+				// check for replacement parameter names
+				if newParameterName, newParameterFound := newElementNames.NewParameterMapping[parameterName]; newParameterFound{
+					newParameters[newParameterName] = value
+				} else {
+					newParameters[parameterName] = value
+				}
+			}
+			// replace connections
+			for parameterName, newParameterName := range newElementNames.NewParameterMapping {
+				for i := range connections{
+					connections[i] = replaceConnection(connections[i], processName, parameterName, newParameterName)
+				}
+			}
+			parameters[processName] = newParameters
+		} else{
+			parameters[processName] = in.Parameters[processName]
+		}
+	}
+
+	return parameters, connections
+}
+
+func replaceConnection(connection workflow.Connection, processToReplace, parameterToReplace, newParameterName string)workflow.Connection{
+	var newConnection workflow.Connection	
+	if connection.Src.Process == processToReplace && connection.Src.Port == parameterToReplace{
+		newConnection.Src = workflow.Port{
+			Process: connection.Src.Process,
+			Port: newParameterName,
+		}
+	} else {
+		newConnection.Src = connection.Src
+	}
+	
+	if connection.Tgt.Process == processToReplace && connection.Tgt.Port == parameterToReplace{
+		newConnection.Tgt = workflow.Port{
+			Process: connection.Tgt.Process,
+			Port: newParameterName,
+		}
+		panic(fmt.Sprintln(newConnection))
+	} else {
+		newConnection.Tgt = connection.Tgt
+	}
+	return newConnection
+}
+//
+func convertBundle(cmd *cobra.Command, args []string) error {
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
+		return err
+	}
+
+	inFile, err := os.Open(viper.GetString("bundle"))
+	if err != nil {
+		return err
+	}
+	defer inFile.Close() // nolint
+
+	var original anthaBundle
+	dec := json.NewDecoder(inFile)
+	if err := dec.Decode(&original); err != nil {
+		return err
+	}
+		
+	cFile, err := os.Open(viper.GetString("conversionMap"))
+	
+	if err != nil {
+		return err
+	}
+	defer cFile.Close() // nolint
+	
+	var c NewElementMappingDetails
+	decConv := json.NewDecoder(cFile)
+	if err := decConv.Decode(&c); err != nil {
+		return err
+	}
+	
+
+	var bundle anthaBundle
+	bundle.Parameters, bundle.Connections = convertParametersAndConnections(original, c.ConversionDetails)
+	bundle.Processes = convertProcesses(original.Processes, c.ConversionDetails)
+	bundle.Config = original.Config
+	
+	outFile, err := os.Create(viper.GetString("output"))
+	if err != nil {
+		return err
+	}
+	defer outFile.Close() // nolint
+
+	enc := json.NewEncoder(outFile)
+	enc.SetIndent("", "  ")
+	return enc.Encode(bundle)
+}
+
+func init() {
+	c := convertBundleCmd
+	convertCmd.AddCommand(c)
+
+	flags := c.Flags()
+	flags.String("bundle", "", "Input bundle")
+	flags.String("conversionMap","", "conversion map file")
+	flags.String("output", "output.json", "default output bundle name in antha format")
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -36,7 +36,13 @@ func (a Port) String() string {
 
 // A Process is an instance of a component / element execution
 type Process struct {
-	Component string `json:"component"`
+	Component string         `json:"component"`
+	Metadata  screenPosition `json:"metadata"`
+}
+
+type screenPosition struct {
+	X int `json:"x"`
+	Y int `json:"y"`
 }
 
 // A Connection connects the output of one Process to the input of another


### PR DESCRIPTION
Designed to facilitate automated upgrading of element bundles based on a defined mapping.

For example, running the command with the following metadata file against a test bundle would upgrade `Aliquot` to `Aliquot_Liquid` and  the output `Aliquots` would be updated to `NewLiquids` and the input `Solution` to `Liquid`.

```
{
  "defaults": {
    "ByRow": false,
    "NumberofAliquots": 8,
    "OutPlate": "SRWFB96_riser18",
    "Solution": "water",
    "VolumePerAliquot": "50ul"
  },
  "name": "Aliquot",
  "tags": [
    "MVL"
  ],
  "new-element-mapping-details":{
    "new-element-name": "Aliquot_Liquid",
    "new-parameter-mapping": {
      "Aliquots": "NewLiquids",
      "Solution": "Liquid"
    },
    "old-element-name": "Aliquot"
  }
}
``` 

Tested locally and working as expected. 