### PR TITLE
Generate collision descriptions at the time of the error

### DIFF
--- a/microArch/simulator/liquidhandling/errors.go
+++ b/microArch/simulator/liquidhandling/errors.go
@@ -211,8 +211,8 @@ func (self *CollisionError) CollisionDescription() string {
 	return self.collisionDescription
 }
 
-//CollisionDescription get a human readable description of the collision,
-//group objects involved in the collision as much as possible
+//setCollisionDescription store a human readable description of the collision,
+//grouping objects involved in the collision as much as possible
 func (self *CollisionError) setCollisionDescription(objectsColliding []wtype.LHObject) {
 
 	//list adaptors in order for consistent errors


### PR DESCRIPTION
Previously, CollisionError would generate a helpful string description of the error only when Error() was called. This is now invalid since the state will now change as the simulation proceeds and we try to catch as many errors as possible.
Another possible solution would have been to duplicate the entire state for the error, but this seemed unnecessary since all the required information is available at the time of the error.
Have run antha-tester with no errors