### PR TITLE
Showing tip use on the command line

### DIFF
--- a/antha/anthalib/wtype/tipestimate.go
+++ b/antha/anthalib/wtype/tipestimate.go
@@ -1,8 +1,14 @@
 package wtype
 
+import "fmt"
+
 // A Tip Estimate provides information on how many tips and tip boxes of a given type are expected to be used
 type TipEstimate struct {
 	TipType   string // identifier describing which tips are to be used
 	NTips     int    // count of tips used total
 	NTipBoxes int    // count of tip boxes to be used
+}
+
+func (self TipEstimate) String() string {
+	return fmt.Sprintf("%s: %d tips in %d boxes", self.TipType, self.NTips, self.NTipBoxes)
 }

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -161,9 +161,9 @@ func (this *Liquidhandler) MakeSolutions(ctx context.Context, request *LHRequest
 		return err
 	}
 
-	fmt.Println("Tip Usage:")
-	for _, te := range request.TipsUsed {
-		fmt.Printf("  %s\n", te)
+	fmt.Println("Tip Usage Summary:")
+	for _, tipEstimate := range request.TipsUsed {
+		fmt.Printf("  %v\n", tipEstimate)
 	}
 
 	err = this.Simulate(request)

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -161,6 +161,11 @@ func (this *Liquidhandler) MakeSolutions(ctx context.Context, request *LHRequest
 		return err
 	}
 
+	fmt.Println("Tip Usage:")
+	for _, te := range request.TipsUsed {
+		fmt.Printf("  %s\n", te)
+	}
+
 	err = this.Simulate(request)
 	if err != nil && !request.Options.IgnorePhysicalSimulation {
 		return errors.WithMessage(err, "during physical simulation")
@@ -172,11 +177,9 @@ func (this *Liquidhandler) MakeSolutions(ctx context.Context, request *LHRequest
 	}
 
 	// output some info on the final setup
-
 	OutputSetup(this.Properties)
 
 	// and after
-
 	fmt.Println("SETUP AFTER: ")
 	OutputSetup(this.FinalProperties)
 
@@ -238,7 +241,7 @@ func (this *Liquidhandler) Simulate(request *LHRequest) error {
 	}
 
 	if request.Options.PrintInstructions {
-		fmt.Println("Simulating instructions")
+		fmt.Printf("Simulating %d instructions\n", len(instructions))
 		for i, ins := range instructions {
 			if (*request).Options.PrintInstructions {
 				fmt.Printf("%d: %s\n", i, liquidhandling.InsToString(ins))

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -234,6 +234,16 @@ func (this *Liquidhandler) Simulate(request *LHRequest) error {
 			return fmt.Errorf("instruction %d not terminal", i)
 		}
 		triS = append(triS, tri)
+
+	}
+
+	if request.Options.PrintInstructions {
+		fmt.Println("Simulating instructions")
+		for i, ins := range instructions {
+			if (*request).Options.PrintInstructions {
+				fmt.Printf("%d: %s\n", i, liquidhandling.InsToString(ins))
+			}
+		}
 	}
 
 	if err := vlh.Simulate(triS); err != nil {


### PR DESCRIPTION
Showing tip usage on the command line along with deck setup info, and also print low level instructions (when --printInstructions is set) before the physical simulation so they get printed even when the physical simulation fails