### PR TITLE
Fix creation of line number map.

### DIFF
--- a/antha/compile/compile.go
+++ b/antha/compile/compile.go
@@ -274,7 +274,6 @@ func (p *compiler) writeByte(ch byte, n int) {
 		p.out.Line += n
 		p.pos.Column = 1
 		p.out.Column = 1
-		p.lineMap[p.out.Line] = p.pos.Line
 		return
 	}
 	p.pos.Column += n
@@ -303,6 +302,7 @@ func (p *compiler) writeString(pos token.Position, s string, isLit bool) {
 		// atLineBegin updates p.pos if there's indentation, but p.pos
 		// is the position of s.
 		p.pos = pos
+		p.lineMap[p.out.Line] = pos.Line
 	}
 
 	if isLit {


### PR DESCRIPTION
As reported by Xander, the line numbers were off by 1 (or 2, in some places), a feature which managed to slip through both original testing and QA.
Upon closer inspection of the transpiler, we only ever call writeString for Go/Antha, and writeByte is only called for comments and whitespace. Now as whitespace does include the initial line indentation, it was still being called for every line. However, the correct internal position token isn't updated until the token itself is printed, which is after the indentation. So when we were in writeByte, I think the internal source position was still at the previous token, rather than the next.

Anyway, moving the line number catching into writeString seems to solve this issue.

cc @x-anderson 