### PR TITLE
ANTHA-1878: ensure sub components are carried over in cases where gen…

### DIFF
--- a/antha/anthalib/mixer/mixer.go
+++ b/antha/anthalib/mixer/mixer.go
@@ -199,7 +199,6 @@ func GenericMix(opt MixOptions) *wtype.LHInstruction {
 			}
 		}
 
-		wtype.UpdateComponentDetails(r.Results[0], opt.Components...) //nolint
 		r.Results[0].SetGeneration(mx)
 	}
 

--- a/antha/anthalib/wtype/LiquidType.go
+++ b/antha/anthalib/wtype/LiquidType.go
@@ -1,10 +1,6 @@
 package wtype
 
-import (
-	"strings"
-
-	"github.com/antha-lang/antha/antha/anthalib/wunit"
-)
+import "github.com/antha-lang/antha/antha/anthalib/wunit"
 
 // PolicyName represents the name of a liquid handling policy
 // used to look up the details of that policy.
@@ -133,31 +129,6 @@ func mergeTypes(c1, c2 *Liquid) LiquidType {
 	}
 
 	return c1.Type
-}
-
-// merge two names... we have a lookup function to add here
-func mergeNames(a, b string) string {
-	tx := strings.Split(a, "+")
-	tx2 := strings.Split(b, "+")
-
-	tx3 := mergeTox(tx, tx2)
-
-	tx3 = Normalize(tx3)
-
-	return strings.Join(tx3, "+")
-}
-
-// very simple, just add elements of tx2 not already in tx
-func mergeTox(tx, tx2 []string) []string {
-	for _, v := range tx2 {
-		ix := IndexOfStringArray(v, tx)
-
-		if ix == -1 {
-			tx = append(tx, v)
-		}
-	}
-
-	return tx
 }
 
 func IndexOfStringArray(s string, a []string) int {

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -609,11 +609,8 @@ func (lhc *Liquid) Dup() *Liquid {
 		for k, v := range lhc.Extra {
 			c.Extra[k] = v
 		}
-		c.SubComponents.Components = make(map[string]wunit.Concentration, len(lhc.SubComponents.Components))
-		for k, v := range lhc.SubComponents.Components {
-			c.SubComponents.Components[k] = v
-		}
 
+		c.SubComponents = lhc.SubComponents.Dup()
 		c.Loc = lhc.Loc
 		c.Destination = lhc.Destination
 		c.ParentID = lhc.ParentID

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -609,7 +609,10 @@ func (lhc *Liquid) Dup() *Liquid {
 		for k, v := range lhc.Extra {
 			c.Extra[k] = v
 		}
-		c.SubComponents = lhc.SubComponents
+		c.SubComponents.Components = make(map[string]wunit.Concentration, len(lhc.SubComponents.Components))
+		for k, v := range lhc.SubComponents.Components {
+			c.SubComponents.Components[k] = v
+		}
 
 		c.Loc = lhc.Loc
 		c.Destination = lhc.Destination

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -609,6 +609,7 @@ func (lhc *Liquid) Dup() *Liquid {
 		for k, v := range lhc.Extra {
 			c.Extra[k] = v
 		}
+		c.SubComponents = lhc.SubComponents
 
 		c.Loc = lhc.Loc
 		c.Destination = lhc.Destination
@@ -701,12 +702,6 @@ func (cmp *Liquid) Mix(cmp2 *Liquid) {
 	cmp.Type = mergeTypes(cmp, cmp2)
 	// add cmp2 to cmp
 
-	vcmp := wunit.NewVolume(cmp.Vol, cmp.Vunit)
-	vcmp2 := wunit.NewVolume(cmp2.Vol, cmp2.Vunit)
-	vcmp.Add(vcmp2)
-	cmp.Vol = vcmp.RawValue() // same units
-	cmp.CName = mergeNames(cmp.CName, cmp2.CName)
-
 	// allow trace back
 	//logger.Track(fmt.Sprintf("MIX %s %s %s", cmp.ID, cmp2.ID, vcmp.ToString()))
 
@@ -722,14 +717,27 @@ func (cmp *Liquid) Mix(cmp2 *Liquid) {
 	cmp.ID = GetUUID()
 	cmp2.AddDaughterComponent(cmp)
 
+	if wasEmpty {
+		if !cmp.HasConcentration() {
+			cmp.SetConcentration(cmp2.Concentration())
+		}
+		if len(cmp.SubComponents.Components) == 0 && len(cmp2.SubComponents.Components) > 0 {
+			updateSubComponentsOnly(cmp, cmp2) //nolint
+		}
+		cmp.SetName(cmp2.Name())
+	} else {
+		UpdateComponentDetails(cmp, cmp, cmp2) //nolint
+	}
+
+	vcmp := wunit.NewVolume(cmp.Vol, cmp.Vunit)
+	vcmp2 := wunit.NewVolume(cmp2.Vol, cmp2.Vunit)
+	vcmp.Add(vcmp2)
+	cmp.Vol = vcmp.RawValue() // same units
+
 	// result should not be a sample
 
 	cmp.SetSample(false)
 
-	if wasEmpty {
-		cmp.SetConcentration(cmp2.Concentration())
-		cmp.SubComponents = cmp2.SubComponents
-	}
 }
 
 // @implement Liquid
@@ -820,6 +828,7 @@ func (cmp *Liquid) Clean() {
 	cmp.Smax = 0.0
 	cmp.Visc = 0.0
 	cmp.StockConcentration = 0.0
+	cmp.SubComponents = ComponentList{}
 	cmp.Extra = make(map[string]interface{})
 	cmp.Loc = ""
 	cmp.Destination = ""

--- a/antha/anthalib/wtype/liquid_test.go
+++ b/antha/anthalib/wtype/liquid_test.go
@@ -129,3 +129,40 @@ func TestComponentSerialize(t *testing.T) {
 		t.Errorf("COMPONENTS NOT EQUAL AFTER MARSHAL/UNMARSHAL")
 	}
 }
+
+func TestDeepCopySubComponents(t *testing.T) {
+	l := NewLHComponent()
+	l.CName = "water"
+	sc := NewLHComponent()
+	sc.CName = "mush"
+	l.AddSubComponent(sc, wunit.NewConcentration(50.0, "g/l"))
+
+	l2 := l.Dup()
+
+	scMapEqual := func(m1, m2 map[string]wunit.Concentration) bool {
+		if len(m1) != len(m2) {
+			return false
+		}
+
+		for k, v := range m1 {
+			v2, ok := m2[k]
+
+			if !ok || !v.EqualTo(v2) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if !scMapEqual(l.SubComponents.Components, l2.SubComponents.Components) {
+		t.Errorf("Subcomponent Maps not identical in contents after Dup")
+	}
+
+	l.SubComponents.Components["fishpaste"] = wunit.NewConcentration(100.0, "g/l")
+
+	if scMapEqual(l.SubComponents.Components, l2.SubComponents.Components) {
+		t.Errorf("Subcomponent Maps still linked after dup")
+	}
+
+}

--- a/antha/anthalib/wtype/plate.go
+++ b/antha/anthalib/wtype/plate.go
@@ -788,8 +788,8 @@ func ExportPlateCSV(outputFileName string, plate *Plate, plateName string, wells
 	}
 
 	records := make([][]string, 0)
-	headerrecord := []string{plate.Type, plateName, "LiquidType", "Vol", "Vol Unit", "Conc", "Conc Unit", "SubComponents"}
-	records = append(records, headerrecord)
+	headerrecord := []string{plate.Type, plateName, "LiquidType", "Vol", "Vol Unit", "Conc", "Conc Unit"}
+	var includeSubComponentsHeader bool
 
 	for i, well := range wells {
 		volfloat := volumes[i].RawValue()
@@ -809,8 +809,11 @@ func ExportPlateCSV(outputFileName string, plate *Plate, plateName string, wells
 				concUnit = "mg/l"
 			}
 
-			for componentName := range liquids[i].SubComponents.Components {
-				subComponents = append(subComponents, componentName)
+			if liquids[i].SubComponents.Components != nil {
+				includeSubComponentsHeader = true
+				for componentName := range liquids[i].SubComponents.Components {
+					subComponents = append(subComponents, componentName)
+				}
 			}
 
 			sort.Strings(subComponents)
@@ -824,6 +827,11 @@ func ExportPlateCSV(outputFileName string, plate *Plate, plateName string, wells
 
 		records = append(records, record)
 	}
+
+	if includeSubComponentsHeader {
+		headerrecord = append(headerrecord, SubComponentsHeader)
+	}
+	records = append([][]string{headerrecord}, records...)
 
 	return exportCSV(records, outputFileName)
 }

--- a/antha/anthalib/wtype/subcomponents.go
+++ b/antha/anthalib/wtype/subcomponents.go
@@ -232,6 +232,14 @@ type ComponentList struct {
 	Components map[string]wunit.Concentration `json:"Components"`
 }
 
+func (c ComponentList) Dup() ComponentList {
+	ret := make(map[string]wunit.Concentration, len(c.Components))
+	for k, v := range c.Components {
+		ret[k] = v.Dup()
+	}
+	return ComponentList{Components: ret}
+}
+
 // add a single entry to a component list
 func (c ComponentList) Add(component *Liquid, conc wunit.Concentration) (newlist ComponentList) {
 

--- a/antha/anthalib/wtype/subcomponents.go
+++ b/antha/anthalib/wtype/subcomponents.go
@@ -488,6 +488,32 @@ func getHistory(comp *Liquid) (compList ComponentList, err error) {
 func UpdateComponentDetails(productOfMixes *Liquid, mixes ...*Liquid) error {
 	var warnings []string
 
+	err := updateSubComponentsOnly(productOfMixes, mixes...)
+	if err != nil {
+		switch err.(type) {
+		case Warning:
+			warnings = append(warnings, err.Error())
+		default:
+			return err
+		}
+	}
+
+	err = NormaliseComponentName(productOfMixes)
+
+	if err != nil {
+		warnings = append(warnings, err.Error())
+	}
+
+	if len(warnings) > 0 {
+		return NewWarningf(strings.Join(warnings, "/n"))
+	}
+
+	return nil
+}
+
+// updateSubComponentsOnly recalculates sub component concentrations without modifying the liquid name.
+func updateSubComponentsOnly(productOfMixes *Liquid, mixes ...*Liquid) error {
+	var warnings []string
 	subComponents, _, err := SimulateMix(mixes...)
 
 	if err != nil {
@@ -501,13 +527,7 @@ func UpdateComponentDetails(productOfMixes *Liquid, mixes ...*Liquid) error {
 
 	subComponents = subComponents.RemoveConcsFromSubComponentNames()
 
-	err = AddSubComponents(productOfMixes, subComponents)
-
-	if err != nil {
-		warnings = append(warnings, err.Error())
-	}
-
-	err = NormaliseComponentName(productOfMixes)
+	err = productOfMixes.OverwriteSubComponents(subComponents)
 
 	if err != nil {
 		warnings = append(warnings, err.Error())

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -175,6 +175,10 @@ func DivideVolumes(vol1, vol2 Volume) (factor float64, err error) {
 	return factor, nil
 }
 
+func (c Concentration) Dup() Concentration {
+	return CopyConcentration(c)
+}
+
 func CopyConcentration(v Concentration) Concentration {
 	ret := NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
 	return ret

--- a/target/mixer/parse_plate_test.go
+++ b/target/mixer/parse_plate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/inventory/testinventory"
+	"github.com/pkg/errors"
 )
 
 func nonEmpty(m map[string]*wtype.LHWell) map[string]*wtype.Liquid {
@@ -91,7 +92,7 @@ func samePlate(a, b *wtype.Plate) error {
 		}
 
 		if err := wtype.EqualLists(compA.SubComponents, compB.SubComponents); err != nil {
-			return err
+			return errors.Errorf("%s: %+v != %+v", err.Error(), compA.SubComponents, compB.SubComponents)
 		}
 	}
 
@@ -255,7 +256,7 @@ A6,,,0,ul,0,g/l,
 		{
 			File: []byte(
 				`
-pcrplate_with_cooler, afternoon tea tray, LiquidType, Vol,Vol Unit,Conc,Conc Unit, , ,SubComponents
+pcrplate_with_cooler, afternoon tea tray, LiquidType, Vol,Vol Unit,Conc,Conc Unit, , ,SubComponents,
 A1,water,water,50.0,ul,0,g/l,
 A4,tea,water,50.0,ul,10.0,mM/l, some random user text, ,tea leaves: ,5g/l,sugar:,1X,
 A5,milk,water,100.0,ul,10.0,g/l,
@@ -465,13 +466,13 @@ C1,neb5compcells,culture,20.5,ul,0,ng/ul
 		},
 	}
 
-	for _, tc := range suite {
+	for i, tc := range suite {
 		p, err := ParsePlateCSV(ctx, bytes.NewBuffer(tc.File), tc.ReplacementConfig)
 		if err != nil {
 			t.Error(err)
 		}
 		if err := samePlate(tc.Expected, p.Plate); err != nil {
-			t.Error(err)
+			t.Error(fmt.Sprintf("error in test %d: %s", i, err))
 		}
 		if tc.NoWarnings && len(p.Warnings) != 0 {
 			t.Errorf("found warnings: %s", p.Warnings)


### PR DESCRIPTION
…ericMix is n… (#845)

* move UpdateComponentDetails to Mix method rather than GenericMix

* only add SubComponents column when SubComponents are present

* add more complex subcomponent test to rule out calc errors

* split UpdateComponentDetails into two funcs

* overwrite existing sub components when using UpdateComponentDetails

* update volumes after calculating subcomponents + only generate sub components if > 0

* remove unused func

* reset SubComponents when using Clean method

* add test for .Dup() copying of SubComponents