### PR TITLE
[ANTHA-1989] For a user error, no stack trace.

### DIFF
--- a/execute/error.go
+++ b/execute/error.go
@@ -3,18 +3,16 @@ package execute
 import (
 	"context"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
-// An Error reported by user code
-type Error struct {
+// An UserError reported by user code
+type UserError struct {
 	message string
 }
 
-// Error returns the error message
-func (a *Error) Error() string {
-	return a.message
+// Error satisfies the error interface
+func (err UserError) Error() string {
+	return err.message
 }
 
 // Errorf reports an execution error. Does not return
@@ -27,21 +25,5 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 		msg = "element " + elementName + ": " + userMsg
 	}
 
-	var err error = &Error{message: msg}
-	err = errors.WithStack(err)
-	panic(err)
-}
-
-// unwrapError unpacks the result of Errorf
-func unwrapError(obj interface{}) (error, bool) { // nolint
-	err, ok := obj.(error)
-	if !ok {
-		return nil, false
-	}
-
-	if _, ok := errors.Cause(err).(*Error); !ok {
-		return nil, false
-	}
-
-	return err, true
+	panic(UserError{message: msg})
 }

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -51,7 +51,15 @@ func Run(parent context.Context, opt Opt) (res *Result, err error) {
 
 	ctxTr, tr := WithTrace(ctx)
 	defer func() {
-		if res := recover(); res != nil {
+		if res := recover(); res == nil {
+			return
+		} else if uErr, ok := res.(UserError); ok {
+			// Errorf internally calls panic, which is *not* the Go
+			// way. But until we fix that, to avoid full stack traces
+			// popping out here, we catch this case, and we deliberately
+			// do not attach a stack trace to it.
+			err = uErr
+		} else {
 			err = fmt.Errorf("%s\n%s", res, inject.ElementStackTrace())
 		}
 	}()


### PR DESCRIPTION
Before:

```
> antha run --driver go://github.com/Synthace/PipetMaxDriver/server --bundle ~/Downloads/1x\ Aliquot\ \(3\).json 
0 server Listening at [::]:38945
error: element Aliquot: Aliquot volume specified (500 ul) too high for well capacity (340 ul) of current plate (SRWFB96_riser18_e553f1d-e490-416b-914a-1155390f46)
goroutine 1 [running]:
runtime/debug.Stack(0x2, 0xc400000073, 0x415618)
        /home/matthew/src/golang/go1.10.3/src/runtime/debug/stack.go:24 +0xa7
github.com/antha-lang/antha/inject.ElementStackTrace(0xc4209f7ce0, 0x12a4dc0)
        /home/matthew/src/Go_external_1.10.3/src/github.com/antha-lang/antha/inject/linemap.go:45 +0x37
github.com/antha-lang/antha/execute.Run.func1(0xc4209f8ac8)
        /home/matthew/src/Go_external_1.10.3/src/github.com/antha-lang/antha/execute/execute.go:57 +0x57
panic(0x12a4dc0, 0xc42020ded0)
        /home/matthew/src/golang/go1.10.3/src/runtime/panic.go:502 +0x229
github.com/antha-lang/antha/execute.Errorf(0x1590820, 0xc4208e5230, 0x143c0ce, 0x53, 0xc4209f7fb0, 0x3, 0x3)
        /home/matthew/src/Go_external_1.10.3/src/github.com/antha-lang/antha/execute/error.go:28 +0x15a
github.com/antha-lang/elements/vendor/repos.antha.com/elements/Aliquot/element._Steps(0x1590820, 0xc4208e5230, 0xc4206ac7e0, 0xc4206a1880)
        /home/matthew/src/Go_external_1.10.3/src/github.com/antha-lang/elements/vendor/repos.antha.com/elements/Aliquot/element/element.go:116 +0xb7e
github.com/antha-lang/elements/vendor/repos.antha.com/elements/Aliquot/element.Element.Run(0x1590820, 0xc4208e4f60, 0xc420030ae0, 0xc420030ae0, 0x0, 0x0)
        /home/matthew/src/Go_external_1.10.3/src/github.com/antha-lang/elements/vendor/repos.antha.com/elements/Aliquot/element/element.go:221 +0x19a
github.com/antha-lang/elements/vendor/repos.antha.com/elements/Aliquot/element._newRunner.func1(0x1590820, 0xc4208e4f60, 0xc42061c8a0, 0xc4209e0840, 0x0, 0x0)
```

After:
```
> antha run --driver go://github.com/Synthace/PipetMaxDriver/server --bundle ~/Downloads/1x\ Aliquot\ \(3\).json 
0 server Listening at [::]:40769
error: element Aliquot: Aliquot volume specified (500 ul) too high for well capacity (340 ul) of current plate (SRWFB96_riser18_cfd168f-535d-444c-ae1c-4d1d728dc9)
```

cc @x-anderson 