### PR TITLE
Use marshalindent

### DIFF
--- a/cmd/antha/cmd/run.go
+++ b/cmd/antha/cmd/run.go
@@ -274,7 +274,7 @@ func (a *runOpt) Run() error {
 			RawParams: *params,
 			TestOpt:   expected,
 		}
-		serializedOutputs, err := json.Marshal(bundleWithOutputs)
+		serializedOutputs, err := json.MarshalIndent(bundleWithOutputs, "", "  ")
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Small fix to prevent test annotations to bundles making them unreadable

I have tested this by making 18 bundles and running them through the CI pipeline and also by manual testing - which are both successful