### PR TITLE
include liquid name in error message

### DIFF
--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -401,7 +401,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 				addr, ok := st.GetLocationOf(v.Components[0].ID)
 
 				if !ok {
-					err := wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("MIX IN PLACE WITH NO LOCATION SET FOR %s", v.Components[0].Name())
+					err := wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("MIX IN PLACE WITH NO LOCATION SET FOR %s", v.Components[0].Name()))
 					return s, m, err
 				}
 

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -401,7 +401,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 				addr, ok := st.GetLocationOf(v.Components[0].ID)
 
 				if !ok {
-					err := wtype.LHError(wtype.LH_ERR_DIRE, "MIX IN PLACE WITH NO LOCATION SET")
+					err := wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("MIX IN PLACE WITH NO LOCATION SET FOR %s", v.Components[0].Name())
 					return s, m, err
 				}
 


### PR DESCRIPTION
make error message more actionable rather than: 

```
2018-08-07 17:05:15STEP 3/3: Failed
2018-08-07 17:05:15error planning: 8 (LH_ERR_DIRE) : an internal error : MIX IN PLACE WITH NO LOCATION SET
```