### PR TITLE
In codegen/findBestMoveDevice, minC was set to -1...

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strings"
 
@@ -237,7 +238,7 @@ func (a *ir) assignDevices(t *target.Target) error {
 			}
 			return
 		},
-		EdgeWeight: func(a, b int) int {
+		EdgeWeight: func(a, b int) int64 {
 			return devices[a].MoveCost(devices[b])
 		},
 	})
@@ -370,11 +371,11 @@ func findBestMoveDevice(t *target.Target, from, to ast.Node, fromD, toD *drun) t
 	// TODO: add movement constraints
 	var req ast.Request
 	var minD target.Device
-	minC := -1
+	minC := int64(math.MaxInt64)
 
 	for _, d := range t.CanCompile(req) {
 		c := toD.Device.MoveCost(d) + d.MoveCost(fromD.Device)
-		if minC == -1 || c < minC {
+		if c < minC {
 			minC = c
 			minD = d
 		}

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -46,7 +46,7 @@ func (a *incubator) Compile(ctx context.Context, nodes []ast.Node) ([]target.Ins
 	return []target.Inst{&incubateInst{}}, nil
 }
 
-func (a *incubator) MoveCost(from target.Device) int {
+func (a *incubator) MoveCost(from target.Device) int64 {
 	if a == from {
 		return 0
 	}

--- a/graph/dag.go
+++ b/graph/dag.go
@@ -107,7 +107,7 @@ func TransitiveReduction(graph Graph) (Graph, error) {
 			dist := ShortestPath(ShortestPathOpt{
 				Graph:   graph,
 				Sources: []Node{root},
-				Weight: func(x, y Node) int {
+				Weight: func(x, y Node) int64 {
 					return -1
 				},
 			})

--- a/graph/eliminate_test.go
+++ b/graph/eliminate_test.go
@@ -172,11 +172,11 @@ func TestHarderGraphEliminate(t *testing.T) {
 	}
 
 	root := "v0"
-	depth := 7
+	depth := int64(7)
 	dist := ShortestPath(ShortestPathOpt{
 		Graph:   tr,
 		Sources: []Node{root},
-		Weight: func(x, y Node) int {
+		Weight: func(x, y Node) int64 {
 			return 1
 		},
 	})

--- a/graph/priority.go
+++ b/graph/priority.go
@@ -6,7 +6,7 @@ import (
 
 type nodeItem struct {
 	Node     Node
-	Priority int
+	Priority int64
 	Value    interface{}
 	Index    int
 }
@@ -42,7 +42,7 @@ func (a *priorityQueue) Pop() interface{} {
 	return item
 }
 
-func (a *priorityQueue) Update(item *nodeItem, priority int) {
+func (a *priorityQueue) Update(item *nodeItem, priority int64) {
 	item.Priority = priority
 	heap.Fix(a, item.Index)
 }

--- a/graph/sssp.go
+++ b/graph/sssp.go
@@ -8,17 +8,17 @@ import (
 type ShortestPathOpt struct {
 	Graph   Graph
 	Sources []Node
-	Weight  func(x, y Node) int
+	Weight  func(x, y Node) int64
 }
 
 // ShortestPath implements Dijkstra's algorithm
-func ShortestPath(opt ShortestPathOpt) map[Node]int {
-	dist := make(map[Node]int)
+func ShortestPath(opt ShortestPathOpt) map[Node]int64 {
+	dist := make(map[Node]int64)
 	item := make(map[Node]*nodeItem)
 
 	var pq priorityQueue
 
-	enqueue := func(n Node, priority int) {
+	enqueue := func(n Node, priority int64) {
 		if ni, seen := item[n]; seen {
 			pq.Update(ni, priority)
 			return

--- a/graph/sssp_test.go
+++ b/graph/sssp_test.go
@@ -14,7 +14,7 @@ func TestShortestPaths(t *testing.T) {
 		"f": {"g"},
 	})
 	type edge struct{ A, B string }
-	weights := map[edge]int{
+	weights := map[edge]int64{
 		{A: "a", B: "b"}: 1,
 		{A: "a", B: "c"}: 10,
 		{A: "b", B: "d"}: 20,
@@ -25,7 +25,7 @@ func TestShortestPaths(t *testing.T) {
 		{A: "f", B: "g"}: 1,
 	}
 
-	edist := map[string]int{
+	edist := map[string]int64{
 		"a": 0,
 		"b": 1,
 		"c": 10,
@@ -38,7 +38,7 @@ func TestShortestPaths(t *testing.T) {
 	dist := ShortestPath(ShortestPathOpt{
 		Graph:   g,
 		Sources: []Node{"a"},
-		Weight: func(x, y Node) int {
+		Weight: func(x, y Node) int64 {
 			k := edge{A: x.(string), B: y.(string)}
 			return weights[k]
 		},

--- a/graph/tree_partition_test.go
+++ b/graph/tree_partition_test.go
@@ -41,7 +41,7 @@ func checkPartition(opt PartitionTreeOpt) (*TreePartition, error) {
 		}
 	}
 
-	sum := 0
+	sum := int64(0)
 	if err := VisitTree(VisitTreeOpt{
 		Tree: opt.Tree,
 		Root: opt.Root,
@@ -76,13 +76,13 @@ func BenchmarkMinWeightTree(b *testing.B) {
 		colors = append(colors, i+1)
 	}
 
-	weights := make(map[struct{ A, B int }]int)
+	weights := make(map[struct{ A, B int }]int64)
 	// Make weight space sparse enough for interesting patterns to occur
 	maxWeight := N.Color * N.Color * N.Color * N.Color
 	for i := 0; i < N.Color; i++ {
 		for j := 0; j < N.Color; j++ {
 			k := struct{ A, B int }{A: i + 1, B: j + 1}
-			weights[k] = rand.Intn(maxWeight) + 1
+			weights[k] = rand.Int63n(int64(maxWeight)) + 1
 		}
 	}
 
@@ -106,7 +106,7 @@ func BenchmarkMinWeightTree(b *testing.B) {
 		Colors: func(Node) []int {
 			return colors
 		},
-		EdgeWeight: func(x, y int) int {
+		EdgeWeight: func(x, y int) int64 {
 			if w, seen := weights[struct{ A, B int }{A: x, B: y}]; seen {
 				return w
 			}
@@ -148,7 +148,7 @@ func testMinWeightTree(t *testing.T, exact bool) {
 		Colors: makeTestColors(map[string][]int{
 			"root": {1},
 		}),
-		EdgeWeight: func(a, b int) int {
+		EdgeWeight: func(a, b int) int64 {
 			return 1
 		},
 	}); err != nil {
@@ -170,7 +170,7 @@ func testMinWeightTree(t *testing.T, exact bool) {
 			"b":    {1, 3},
 			"c":    {4},
 		}),
-		EdgeWeight: func(a, b int) int {
+		EdgeWeight: func(a, b int) int64 {
 			if a == b {
 				return 0
 			}
@@ -202,8 +202,8 @@ func testMinWeightTree(t *testing.T, exact bool) {
 			"e":    {1, 2, 3},
 			"f":    {1, 2, 3},
 		}),
-		EdgeWeight: func(a, b int) int {
-			return 100 - (a + b)
+		EdgeWeight: func(a, b int) int64 {
+			return 100 - int64(a+b)
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/target/datasource/datasource.go
+++ b/target/datasource/datasource.go
@@ -27,7 +27,7 @@ func (ds *DataSource) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a device
-func (ds *DataSource) MoveCost(from target.Device) int {
+func (ds *DataSource) MoveCost(from target.Device) int64 {
 	return human.HumanByXCost + 1 // same as a mixer
 }
 

--- a/target/device.go
+++ b/target/device.go
@@ -9,7 +9,7 @@ import (
 // A Device is a scheduling plugin
 type Device interface {
 	CanCompile(ast.Request) bool // Can this device compile this request
-	MoveCost(from Device) int    // A non-negative cost to move to this device
+	MoveCost(from Device) int64  // A non-negative cost to move to this device
 
 	// Compile produces a single-entry, single-exit DAG of instructions where
 	// insts[0] is the entry point and insts[len(insts)-1] is the exit point

--- a/target/handler/generic.go
+++ b/target/handler/generic.go
@@ -33,7 +33,7 @@ func (a *GenericHandler) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *GenericHandler) MoveCost(target.Device) int {
+func (a *GenericHandler) MoveCost(target.Device) int64 {
 	return 0
 }
 

--- a/target/human/human.go
+++ b/target/human/human.go
@@ -69,7 +69,7 @@ func (a *Human) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements target.device MoveCost
-func (a *Human) MoveCost(from target.Device) int {
+func (a *Human) MoveCost(from target.Device) int64 {
 	if _, ok := from.(*Human); ok {
 		return HumanByHumanCost
 	}

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -51,7 +51,7 @@ func (a *Mixer) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *Mixer) MoveCost(from target.Device) int {
+func (a *Mixer) MoveCost(from target.Device) int64 {
 	if from == a {
 		return 0
 	}

--- a/target/platereader/platereader.go
+++ b/target/platereader/platereader.go
@@ -35,7 +35,7 @@ func (a *PlateReader) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *PlateReader) MoveCost(from target.Device) int {
+func (a *PlateReader) MoveCost(from target.Device) int64 {
 	return 0
 }
 

--- a/target/qpcrdevice/qpcrdevice.go
+++ b/target/qpcrdevice/qpcrdevice.go
@@ -34,7 +34,7 @@ func (a *QPCRDevice) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *QPCRDevice) MoveCost(from target.Device) int {
+func (a *QPCRDevice) MoveCost(from target.Device) int64 {
 	return 0
 }
 


### PR DESCRIPTION
...which is potentially a bug if any of the moveCosts are < 0.

Similarly, partition_tree/runExact has the same bug.

Typically, if you are trying to find a min, you need to start your accumulator with the maximum possible value. This is what I've changed it to.
To do this required moving a bunch of vars from int to int64 so that we can use math.MaxInt64 and have certainty about the width of the var.

I did try moving to a uint64 - this would be my preference, especially on the interface containing MoveCost. In fact, in tree_partition there is even a comment that EdgeWeight cannot be < 0. However, sadly in dag, a negative weight is used in order to force calculation of the longest path, rather than the shortest path, and reworking all of that would have been painful. Hence I decided to compromise on int64.

Local antha-lang tests pass, and antha-tester tests pass as before.