### PR TITLE
Updated times based on data from trilution logs for ~450 runs

### DIFF
--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -40,21 +40,21 @@ func makeNullTimer() LHTimer {
 
 func makeGilsonPipetmaxTimer() LHTimer {
 	t := NewTimer()
-	t.Times[LDT], _ = time.ParseDuration("8s") // LDT
-	t.Times[UDT], _ = time.ParseDuration("6s") // UDT
+	t.Times[LDT], _ = time.ParseDuration("7s") // LDT
+	t.Times[UDT], _ = time.ParseDuration("7s") // UDT
 	t.Times[SUK], _ = time.ParseDuration("4s") // SUK
 	t.Times[BLW], _ = time.ParseDuration("4s") // BLW
 
 	// lower level instructions
 
-	t.Times[ASP], _ = time.ParseDuration("4s")   // ASP
-	t.Times[DSP], _ = time.ParseDuration("4s")   // DSP
-	t.Times[BLO], _ = time.ParseDuration("4s")   // BLO
-	t.Times[PTZ], _ = time.ParseDuration("0.5s") // PTZ
-	t.Times[MOV], _ = time.ParseDuration("2s")   // MOV
-	t.Times[LOD], _ = time.ParseDuration("6s")   // LOAD
-	t.Times[ULD], _ = time.ParseDuration("8s")   // UNLOAD
-	t.Times[MIX], _ = time.ParseDuration("6s")   // MIX
+	t.Times[ASP], _ = time.ParseDuration("0.7s") // ASP
+	t.Times[DSP], _ = time.ParseDuration("0.7s") // DSP
+	t.Times[BLO], _ = time.ParseDuration("0.7s") // BLO
+	t.Times[PTZ], _ = time.ParseDuration("0s")   // PTZ
+	t.Times[MOV], _ = time.ParseDuration("0.9s") // MOV
+	t.Times[LOD], _ = time.ParseDuration("5.6s") // LOAD
+	t.Times[ULD], _ = time.ParseDuration("5.4s") // UNLOAD
+	t.Times[MIX], _ = time.ParseDuration("1.5s") // MIX
 
 	return t
 }

--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -51,7 +51,7 @@ func makeGilsonPipetmaxTimer() LHTimer {
 	t.Times[DSP], _ = time.ParseDuration("0.7s") // DSP
 	t.Times[BLO], _ = time.ParseDuration("0.7s") // BLO
 	t.Times[PTZ], _ = time.ParseDuration("0s")   // PTZ
-	t.Times[MOV], _ = time.ParseDuration("0.9s") // MOV
+	t.Times[MOV], _ = time.ParseDuration("1.5s") // MOV	-- sum of horizontal (0.9) and vertical (0.6) movements
 	t.Times[LOD], _ = time.ParseDuration("5.6s") // LOAD
 	t.Times[ULD], _ = time.ParseDuration("5.4s") // UNLOAD
 	t.Times[MIX], _ = time.ParseDuration("1.5s") // MIX

--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -47,11 +47,11 @@ func makeGilsonPipetmaxTimer() LHTimer {
 
 	// lower level instructions
 
-	t.Times[ASP], _ = time.ParseDuration("0.7s") // ASP
-	t.Times[DSP], _ = time.ParseDuration("0.7s") // DSP
+	t.Times[ASP], _ = time.ParseDuration("0.8s") // ASP
+	t.Times[DSP], _ = time.ParseDuration("0.8s") // DSP
 	t.Times[BLO], _ = time.ParseDuration("0.7s") // BLO
 	t.Times[PTZ], _ = time.ParseDuration("0s")   // PTZ
-	t.Times[MOV], _ = time.ParseDuration("1.5s") // MOV	-- sum of horizontal (0.9) and vertical (0.6) movements
+	t.Times[MOV], _ = time.ParseDuration("1.6s") // MOV	-- sum of horizontal (0.94) and vertical (0.68) movements
 	t.Times[LOD], _ = time.ParseDuration("5.6s") // LOAD
 	t.Times[ULD], _ = time.ParseDuration("5.4s") // UNLOAD
 	t.Times[MIX], _ = time.ParseDuration("1.5s") // MIX


### PR DESCRIPTION
Some log parsing and filtering revised my timing estimates quite a bit. 

In general the original values were tolerably close for the large-scale actions (SUK,BLW etc.) but the others were a compromise and have mostly been decreased. The most notable change is that the MIX command has been dropped by 75%, which is a relief since this was causing the biggest changes. 