### PR TITLE
[ANTHA-2031] Improve the target.Inst interface

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -382,13 +382,6 @@ func findBestMoveDevice(t *target.Target, from, to ast.Node, fromD, toD *drun) t
 	return minD
 }
 
-func appendToDepends(inst target.Inst, insts ...target.Inst) {
-	var next []target.Inst
-	next = append(next, inst.DependsOn()...)
-	next = append(next, insts...)
-	inst.SetDependsOn(next)
-}
-
 // NB(ddn): Could blindly add edges from insts to head, but would like
 // Compile() to be able to introduce instructions that just depend on the start
 // or end (or neither) of a device run.
@@ -401,18 +394,18 @@ func appendToDepends(inst target.Inst, insts ...target.Inst) {
 //   h <- a <-... <- b <- t
 func splice(head, tail target.Inst, insts []target.Inst) {
 	if len(insts) == 0 {
-		if head != nil && tail != nil {
-			appendToDepends(tail, head)
+		if head != nil && tail != nil && head != tail {
+			tail.AppendDependsOn(head)
 		}
-		return
-	}
-	oldH := insts[0]
-	oldT := insts[len(insts)-1]
-	if head != nil {
-		appendToDepends(oldH, head)
-	}
-	if tail != nil {
-		appendToDepends(tail, oldT)
+	} else {
+		oldH := insts[0]
+		oldT := insts[len(insts)-1]
+		if head != nil {
+			oldH.AppendDependsOn(head)
+		}
+		if tail != nil {
+			tail.AppendDependsOn(oldT)
+		}
 	}
 }
 
@@ -585,14 +578,11 @@ func (a *ir) genInsts() ([]target.Inst, error) {
 
 	var insts []target.Inst
 	for _, n := range order {
-		var depends []target.Inst
-		for j, jnum := 0, sg.NumOuts(n); j < jnum; j++ {
-			depends = append(depends, sg.Out(n, j).(target.Inst))
-		}
-
 		in := n.(target.Inst)
-		in.SetDependsOn(depends)
-
+		in.SetDependsOn() // reset to empty first
+		for j, jnum := 0, sg.NumOuts(n); j < jnum; j++ {
+			in.AppendDependsOn(sg.Out(n, j).(target.Inst))
+		}
 		insts = append(insts, in)
 	}
 

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -470,8 +470,7 @@ func (a *ir) addMove(ctx context.Context, t *target.Target, dnode graph.Node, ru
 
 	head := &target.Wait{}
 	tail := &target.Wait{}
-	var insts []target.Inst
-	insts = append(insts, head, tail)
+	insts := append([]target.Inst{}, head, tail)
 
 	splice(head, tail, nil)
 	splice(tail, nil, a.output[run])

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -23,8 +23,12 @@ func (a *incubateInst) DependsOn() []target.Inst {
 	return a.Depends
 }
 
-func (a *incubateInst) SetDependsOn(xs []target.Inst) {
+func (a *incubateInst) SetDependsOn(xs ...target.Inst) {
 	a.Depends = xs
+}
+
+func (a *incubateInst) AppendDependsOn(xs ...target.Inst) {
+	a.Depends = append(a.Depends, xs...)
 }
 
 type incubator struct{}

--- a/codegen/instgraph.go
+++ b/codegen/instgraph.go
@@ -73,10 +73,10 @@ func (a *instGraph) addInitializers(insts []target.Inst) {
 		return
 	}
 
-	insts = target.SequentialOrder(insts...)
+	target.SequentialOrder(insts...)
 	last := insts[len(insts)-1]
 	for _, inst := range a.entry {
-		appendToDepends(inst, last)
+		inst.AppendDependsOn(last)
 		// Unlike other cases, inst has already been added to graph, so update
 		// data explicitly
 		a.dependsOn[inst] = append(a.dependsOn[inst], last)
@@ -89,10 +89,10 @@ func (a *instGraph) addFinalizers(insts []target.Inst) {
 		return
 	}
 
-	insts = target.SequentialOrder(insts...)
+	target.SequentialOrder(insts...)
 	first := insts[0]
 	for _, inst := range a.exit {
-		appendToDepends(first, inst)
+		first.AppendDependsOn(inst)
 	}
 	a.addInsts(insts)
 }
@@ -109,8 +109,8 @@ func (a *instGraph) addRootedInsts(root graph.Node, insts []target.Inst) {
 		first := insts[0]
 		last := insts[len(insts)-1]
 
-		appendToDepends(first, entry)
-		appendToDepends(exit, last)
+		first.AppendDependsOn(entry)
+		exit.AppendDependsOn(last)
 	}
 
 	var newInsts []target.Inst

--- a/codegen/instgraph.go
+++ b/codegen/instgraph.go
@@ -43,7 +43,7 @@ func (a *instGraph) Out(n graph.Node, i int) graph.Node {
 }
 
 // addInsts adds instructions to the graph
-func (a *instGraph) addInsts(insts []target.Inst) {
+func (a *instGraph) addInsts(insts target.Insts) {
 	// Add dependencies
 	for _, in := range insts {
 		a.dependsOn[in] = append(a.dependsOn[in], in.DependsOn()...)
@@ -68,12 +68,12 @@ func (a *instGraph) addInsts(insts []target.Inst) {
 	}
 }
 
-func (a *instGraph) addInitializers(insts []target.Inst) {
+func (a *instGraph) addInitializers(insts target.Insts) {
 	if len(insts) == 0 {
 		return
 	}
 
-	target.SequentialOrder(insts...)
+	insts.SequentialOrder()
 	last := insts[len(insts)-1]
 	for _, inst := range a.entry {
 		inst.AppendDependsOn(last)
@@ -84,12 +84,12 @@ func (a *instGraph) addInitializers(insts []target.Inst) {
 	a.addInsts(insts)
 }
 
-func (a *instGraph) addFinalizers(insts []target.Inst) {
+func (a *instGraph) addFinalizers(insts target.Insts) {
 	if len(insts) == 0 {
 		return
 	}
 
-	target.SequentialOrder(insts...)
+	insts.SequentialOrder()
 	first := insts[0]
 	for _, inst := range a.exit {
 		first.AppendDependsOn(inst)
@@ -98,7 +98,7 @@ func (a *instGraph) addFinalizers(insts []target.Inst) {
 }
 
 // addRootedInsts adds instructions that correspond to a particular graph Node
-func (a *instGraph) addRootedInsts(root graph.Node, insts []target.Inst) {
+func (a *instGraph) addRootedInsts(root graph.Node, insts target.Insts) {
 	exit := &target.Wait{}
 	entry := &target.Wait{}
 
@@ -113,8 +113,6 @@ func (a *instGraph) addRootedInsts(root graph.Node, insts []target.Inst) {
 		exit.AppendDependsOn(last)
 	}
 
-	var newInsts []target.Inst
-	newInsts = append(newInsts, entry, exit)
-	newInsts = append(newInsts, insts...)
+	newInsts := append(target.Insts{entry, exit}, insts...)
 	a.addInsts(newInsts)
 }

--- a/target/handler/generic.go
+++ b/target/handler/generic.go
@@ -99,10 +99,6 @@ func (a GenericHandler) merge(nodes []ast.Node) (*ast.Command, error) {
 
 // Compile implements a Device
 func (a *GenericHandler) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
-	addDep := func(in, dep target.Inst) {
-		in.SetDependsOn(append(in.DependsOn(), dep))
-	}
-
 	g := ast.Deps(nodes)
 
 	entry := &target.Wait{}
@@ -174,10 +170,10 @@ func (a *GenericHandler) Compile(ctx context.Context, nodes []ast.Node) ([]targe
 				continue
 			}
 
-			addDep(ins[0], kidIns[len(kidIns)-1])
+			ins[0].AppendDependsOn(kidIns[len(kidIns)-1])
 		}
-		addDep(ins[0], entry)
-		addDep(exit, ins[len(ins)-1])
+		ins[0].AppendDependsOn(entry)
+		exit.AppendDependsOn(ins[len(ins)-1])
 	}
 
 	return insts, nil

--- a/target/inst.go
+++ b/target/inst.go
@@ -220,9 +220,11 @@ type TimedWait struct {
 	Duration time.Duration
 }
 
+type Insts []Inst
+
 // SequentialOrder takes a slice of instructions and modifies them
 // in-place, resetting to sequential dependencies.
-func SequentialOrder(insts ...Inst) {
+func (insts Insts) SequentialOrder() {
 	if len(insts) > 1 {
 		prev := insts[0]
 		for _, cur := range insts[1:] {

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -243,7 +243,7 @@ func (a *Mixer) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, e
 		return nil, err
 	}
 
-	return target.SequentialOrder(mix), nil
+	return []target.Inst{mix}, nil
 }
 
 func (a *Mixer) saveFile(name string) ([]byte, error) {

--- a/target/platereader/platereader.go
+++ b/target/platereader/platereader.go
@@ -154,15 +154,16 @@ func (a *PlateReader) mergePRInsts(prInsts []*wtype.PRInstruction, wellLocs map[
 		calls = append(calls, call)
 	}
 
-	var insts []target.Inst
-	insts = append(insts, &target.Prompt{
-		Message: "Please put plate(s) into plate reader and click ok to start plate reader",
-	})
-	insts = append(insts, &target.Run{
-		Dev:   a,
-		Label: "use plate reader",
-		Calls: calls,
-	})
-	target.SequentialOrder(insts...)
+	insts := target.Insts{
+		&target.Prompt{
+			Message: "Please put plate(s) into plate reader and click ok to start plate reader",
+		},
+		&target.Run{
+			Dev:   a,
+			Label: "use plate reader",
+			Calls: calls,
+		},
+	}
+	insts.SequentialOrder()
 	return insts, nil
 }

--- a/target/platereader/platereader.go
+++ b/target/platereader/platereader.go
@@ -163,5 +163,6 @@ func (a *PlateReader) mergePRInsts(prInsts []*wtype.PRInstruction, wellLocs map[
 		Label: "use plate reader",
 		Calls: calls,
 	})
-	return target.SequentialOrder(insts...), nil
+	target.SequentialOrder(insts...)
+	return insts, nil
 }

--- a/target/qpcrdevice/qpcrdevice.go
+++ b/target/qpcrdevice/qpcrdevice.go
@@ -138,20 +138,21 @@ func callsForInstructions(qpcrInsts []*ast.QPCRInstruction) ([]qpcrCall, error) 
 }
 
 // interpolatePrompts inserts a prompt before each qPCR run.
-func interpolatePrompts(calls []qpcrCall, device target.Device) []target.Inst {
+func interpolatePrompts(calls []qpcrCall, device target.Device) target.Insts {
 
 	// Interpolate a prompt before each qPCR call.
-	var insts []target.Inst
+	var insts target.Insts
 	for _, call := range calls {
-
-		insts = append(insts, &target.Prompt{
-			Message: "Ensure that the experiment file " + call.ExperimentFile + " is configured, then put the plate (" + call.Barcode + ") into qPCR device. Check that the driver software is running. Once ready, accept to start the qPCR analysis.",
-		})
-		insts = append(insts, &target.Run{
-			Dev:   device,
-			Label: "Perform qPCR Analysis",
-			Calls: call.Calls,
-		})
+		insts = append(insts,
+			&target.Prompt{
+				Message: "Ensure that the experiment file " + call.ExperimentFile + " is configured, then put the plate (" + call.Barcode + ") into qPCR device. Check that the driver software is running. Once ready, accept to start the qPCR analysis.",
+			},
+			&target.Run{
+				Dev:   device,
+				Label: "Perform qPCR Analysis",
+				Calls: call.Calls,
+			},
+		)
 	}
 
 	return insts
@@ -174,6 +175,6 @@ func (a *QPCRDevice) Compile(ctx context.Context, nodes []ast.Node) ([]target.In
 
 	// Interpolate a prompt before each qPCR call.
 	promptedInstructions := interpolatePrompts(calls, a)
-	target.SequentialOrder(promptedInstructions...)
+	promptedInstructions.SequentialOrder()
 	return promptedInstructions, nil
 }

--- a/target/qpcrdevice/qpcrdevice.go
+++ b/target/qpcrdevice/qpcrdevice.go
@@ -174,5 +174,6 @@ func (a *QPCRDevice) Compile(ctx context.Context, nodes []ast.Node) ([]target.In
 
 	// Interpolate a prompt before each qPCR call.
 	promptedInstructions := interpolatePrompts(calls, a)
-	return target.SequentialOrder(promptedInstructions...), nil
+	target.SequentialOrder(promptedInstructions...)
+	return promptedInstructions, nil
 }

--- a/target/shakerincubator/shakerincubator.go
+++ b/target/shakerincubator/shakerincubator.go
@@ -166,5 +166,6 @@ func (a *ShakerIncubator) generate(cmd interface{}) ([]target.Inst, error) {
 		})
 	}
 
-	return target.SequentialOrder(insts...), nil
+	target.SequentialOrder(insts...)
+	return insts, nil
 }

--- a/target/shakerincubator/shakerincubator.go
+++ b/target/shakerincubator/shakerincubator.go
@@ -97,7 +97,7 @@ func (a *ShakerIncubator) generate(cmd interface{}) ([]target.Inst, error) {
 
 	var initializers []target.Inst
 	var finalizers []target.Inst
-	var insts []target.Inst
+	var insts target.Insts
 
 	initializers = append(initializers, &target.Run{
 		Dev:   a,
@@ -166,6 +166,6 @@ func (a *ShakerIncubator) generate(cmd interface{}) ([]target.Inst, error) {
 		})
 	}
 
-	target.SequentialOrder(insts...)
+	insts.SequentialOrder()
 	return insts, nil
 }


### PR DESCRIPTION
Introduce an AppendDependsOn method to simplify a number of uses of the current SetDependsOn.

Local tests and antha-runner tests pass as before.