### PR TITLE
round to nearest second

### DIFF
--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -345,7 +345,7 @@ func (this *Liquidhandler) Execute(request *LHRequest) error {
 	}
 
 	logger.Debug(fmt.Sprintf("Total time estimate: %s", d.String()))
-	request.TimeEstimate = d.Seconds()
+	request.TimeEstimate = d.Round(time.Second).Seconds()
 
 	return nil
 }


### PR DESCRIPTION
Time estimates are currently subject to the same floating point overprecision in the front-end as volumes. This is since the move to more accurate estimates, which include fractions of seconds.

Previously we didn't see this so I hope that rounding to the nearest second as here will solve the problem.

I've tested this on the command-line, although without the front-end it's impossible to see if it really fixes the problem 