### PR TITLE
Fix/revised pipetmax times

### DIFF
--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -51,7 +51,7 @@ func makeGilsonPipetmaxTimer() LHTimer {
 	t.Times[DSP], _ = time.ParseDuration("0.8s") // DSP
 	t.Times[BLO], _ = time.ParseDuration("0.7s") // BLO
 	t.Times[PTZ], _ = time.ParseDuration("0s")   // PTZ
-	t.Times[MOV], _ = time.ParseDuration("3.1s") // MOV	-- using median figures for horizontal (1.1) and 2x vertical (1.0)
+	t.Times[MOV], _ = time.ParseDuration("2.3s") // MOV	-- using mean figures for horizontal (0.94) and 2x vertical (1.36)
 	t.Times[LOD], _ = time.ParseDuration("5.6s") // LOAD
 	t.Times[ULD], _ = time.ParseDuration("5.4s") // UNLOAD
 	t.Times[MIX], _ = time.ParseDuration("1.5s") // MIX

--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -40,6 +40,7 @@ func makeNullTimer() LHTimer {
 
 func makeGilsonPipetmaxTimer() LHTimer {
 	t := NewTimer()
+	t.Times[INI], _ = time.ParseDuration("5s") // INI
 	t.Times[LDT], _ = time.ParseDuration("7s") // LDT
 	t.Times[UDT], _ = time.ParseDuration("7s") // UDT
 	t.Times[SUK], _ = time.ParseDuration("4s") // SUK

--- a/microArch/driver/liquidhandling/timerfactory.go
+++ b/microArch/driver/liquidhandling/timerfactory.go
@@ -51,7 +51,7 @@ func makeGilsonPipetmaxTimer() LHTimer {
 	t.Times[DSP], _ = time.ParseDuration("0.8s") // DSP
 	t.Times[BLO], _ = time.ParseDuration("0.7s") // BLO
 	t.Times[PTZ], _ = time.ParseDuration("0s")   // PTZ
-	t.Times[MOV], _ = time.ParseDuration("1.6s") // MOV	-- sum of horizontal (0.94) and vertical (0.68) movements
+	t.Times[MOV], _ = time.ParseDuration("3.1s") // MOV	-- using median figures for horizontal (1.1) and 2x vertical (1.0)
 	t.Times[LOD], _ = time.ParseDuration("5.6s") // LOAD
 	t.Times[ULD], _ = time.ParseDuration("5.4s") // UNLOAD
 	t.Times[MIX], _ = time.ParseDuration("1.5s") // MIX


### PR DESCRIPTION
The main change here is to account for both upwards and downwards Z movements when moving.

Based on a limited number of tests this seems to improve time estimates but we'll need to look at some longer runs to see how well it works