### PR TITLE
Add copy constructors for concrete measurement types in wunit

### DIFF
--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -58,6 +58,14 @@ func NewLength(v float64, unit string) Length {
 	return Length{NewTypedMeasurement("Length", v, unit)}
 }
 
+// CopyLength duplicate the Length
+func CopyLength(v Length) Length {
+	if isNil(v.ConcreteMeasurement) {
+		return Length{}
+	}
+	return NewLength(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // area
 type Area struct {
 	*ConcreteMeasurement
@@ -66,6 +74,14 @@ type Area struct {
 // make an area unit
 func NewArea(v float64, unit string) Area {
 	return Area{NewTypedMeasurement("Area", v, unit)}
+}
+
+// CopyArea duplicate the Area
+func CopyArea(v Area) Area {
+	if isNil(v.ConcreteMeasurement) {
+		return Area{}
+	}
+	return NewArea(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func ZeroArea() Area {
@@ -86,8 +102,7 @@ func CopyVolume(v Volume) Volume {
 	if isNil(v.ConcreteMeasurement) {
 		return Volume{}
 	}
-	ret := NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
-	return ret
+	return NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // AddVolumes adds a set of volumes.
@@ -157,8 +172,10 @@ func (c Concentration) Dup() Concentration {
 }
 
 func CopyConcentration(v Concentration) Concentration {
-	ret := NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
-	return ret
+	if isNil(v.ConcreteMeasurement) {
+		return Concentration{}
+	}
+	return NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // MultiplyConcentration multiplies a concentration by a factor.
@@ -246,6 +263,14 @@ func NewTemperature(v float64, unit string) Temperature {
 	return Temperature{NewTypedMeasurement("Temperature", v, unit)}
 }
 
+// CopyTemperature duplicate the Temperature
+func CopyTemperature(v Temperature) Temperature {
+	if isNil(v.ConcreteMeasurement) {
+		return Temperature{}
+	}
+	return NewTemperature(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // time
 type Time struct {
 	*ConcreteMeasurement
@@ -254,7 +279,14 @@ type Time struct {
 // NewTime creates a time unit.
 func NewTime(v float64, unit string) (t Time) {
 	return Time{NewTypedMeasurement("Time", v, unit)}
+}
 
+// CopyTime duplicate the Time
+func CopyTime(v Time) Time {
+	if isNil(v.ConcreteMeasurement) {
+		return Time{}
+	}
+	return NewTime(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func (t Time) Seconds() float64 {
@@ -285,6 +317,14 @@ func NewMass(v float64, unit string) Mass {
 	return Mass{NewTypedMeasurement("Mass", v, unit)}
 }
 
+// CopyMass duplicate the Mass
+func CopyMass(v Mass) Mass {
+	if isNil(v.ConcreteMeasurement) {
+		return Mass{}
+	}
+	return NewMass(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // defines mass to be a SubstanceQuantity
 func (m *Mass) Quantity() Measurement {
 	return m
@@ -300,9 +340,25 @@ func NewMoles(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
 }
 
+// CopyMoles duplicate the Moles
+func CopyMoles(v Moles) Moles {
+	if isNil(v.ConcreteMeasurement) {
+		return Moles{}
+	}
+	return NewMoles(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // generate a new Amount in moles
 func NewAmount(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
+}
+
+// CopyAmount duplicate the Moles
+func CopyAmount(v Moles) Moles {
+	if isNil(v.ConcreteMeasurement) {
+		return Moles{}
+	}
+	return NewAmount(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines Moles to be a SubstanceQuantity
@@ -320,6 +376,14 @@ func NewAngle(v float64, unit string) Angle {
 	return Angle{NewTypedMeasurement("Angle", v, unit)}
 }
 
+// CopyAngle duplicate the Angle
+func CopyAngle(v Angle) Angle {
+	if isNil(v.ConcreteMeasurement) {
+		return Angle{}
+	}
+	return NewAngle(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // angular velocity (one way or another)
 
 type AngularVelocity struct {
@@ -328,6 +392,14 @@ type AngularVelocity struct {
 
 func NewAngularVelocity(v float64, unit string) AngularVelocity {
 	return AngularVelocity{NewTypedMeasurement("AngularVelocity", v, unit)}
+}
+
+// CopyAngularVelocity duplicate the AngularVelocity
+func CopyAngularVelocity(v AngularVelocity) AngularVelocity {
+	if isNil(v.ConcreteMeasurement) {
+		return AngularVelocity{}
+	}
+	return NewAngularVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // this is really Mass Length/Time^2
@@ -340,6 +412,14 @@ func NewEnergy(v float64, unit string) Energy {
 	return Energy{NewTypedMeasurement("Energy", v, unit)}
 }
 
+// CopyEnergy duplicate the Energy
+func CopyEnergy(v Energy) Energy {
+	if isNil(v.ConcreteMeasurement) {
+		return Energy{}
+	}
+	return NewEnergy(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a Force
 type Force struct {
 	*ConcreteMeasurement
@@ -350,6 +430,14 @@ func NewForce(v float64, unit string) Force {
 	return Force{NewTypedMeasurement("Force", v, unit)}
 }
 
+// CopyForce duplicate the Force
+func CopyForce(v Force) Force {
+	if isNil(v.ConcreteMeasurement) {
+		return Force{}
+	}
+	return NewForce(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a Pressure structure
 type Pressure struct {
 	*ConcreteMeasurement
@@ -358,6 +446,14 @@ type Pressure struct {
 // make a new pressure in Pascals
 func NewPressure(v float64, unit string) Pressure {
 	return Pressure{NewTypedMeasurement("Pressure", v, unit)}
+}
+
+// CopyPressure duplicate the Pressure
+func CopyPressure(v Pressure) Pressure {
+	if isNil(v.ConcreteMeasurement) {
+		return Pressure{}
+	}
+	return NewPressure(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines a concentration unit
@@ -432,6 +528,14 @@ func NewSpecificHeatCapacity(v float64, unit string) SpecificHeatCapacity {
 	return SpecificHeatCapacity{NewTypedMeasurement("SpecificHeatCapacity", v, unit)}
 }
 
+// CopySpecificHeatCapacity duplicate the SpecificHeatCapacity
+func CopySpecificHeatCapacity(v SpecificHeatCapacity) SpecificHeatCapacity {
+	if isNil(v.ConcreteMeasurement) {
+		return SpecificHeatCapacity{}
+	}
+	return NewSpecificHeatCapacity(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a structure which defines a density
 type Density struct {
 	*ConcreteMeasurement
@@ -440,6 +544,14 @@ type Density struct {
 // make a new density structure in SI units
 func NewDensity(v float64, unit string) Density {
 	return Density{NewTypedMeasurement("Density", v, unit)}
+}
+
+// CopyDensity duplicate the Density
+func CopyDensity(v Density) Density {
+	if isNil(v.ConcreteMeasurement) {
+		return Density{}
+	}
+	return NewDensity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 type FlowRate struct {
@@ -452,6 +564,14 @@ func NewFlowRate(v float64, unit string) FlowRate {
 	return FlowRate{NewTypedMeasurement("FlowRate", v, unit)}
 }
 
+// CopyFlowRate duplicate the FlowRate
+func CopyFlowRate(v FlowRate) FlowRate {
+	if isNil(v.ConcreteMeasurement) {
+		return FlowRate{}
+	}
+	return NewFlowRate(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 type Velocity struct {
 	*ConcreteMeasurement
 }
@@ -462,6 +582,32 @@ func NewVelocity(v float64, unit string) Velocity {
 	return Velocity{NewTypedMeasurement("Velocity", v, unit)}
 }
 
+// CopyVelocity duplicate the Velocity
+func CopyVelocity(v Velocity) Velocity {
+	if isNil(v.ConcreteMeasurement) {
+		return Velocity{}
+	}
+	return NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
+type Acceleration struct {
+	*ConcreteMeasurement
+}
+
+// NewAcceleration create a new acceleration with the given units which will
+// be looked up in the global unit registry
+func NewAcceleration(v float64, unit string) Acceleration {
+	return Acceleration{NewTypedMeasurement("Acceleration", v, unit)}
+}
+
+// CopyAcceleration duplicate the Acceleration
+func CopyAcceleration(v Acceleration) Acceleration {
+	if isNil(v.ConcreteMeasurement) {
+		return Acceleration{}
+	}
+	return NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 type Rate struct {
 	*ConcreteMeasurement
 }
@@ -470,10 +616,34 @@ func NewRate(v float64, unit string) (r Rate, err error) {
 	return Rate{NewTypedMeasurement("Rate", v, unit)}, nil
 }
 
+// CopyRate duplicate the Rate
+func CopyRate(v Rate) Rate {
+	if isNil(v.ConcreteMeasurement) {
+		return Rate{}
+	}
+	if r, err := NewRate(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
+		panic(err)
+	} else {
+		return r
+	}
+}
+
 type Voltage struct {
 	*ConcreteMeasurement
 }
 
 func NewVoltage(value float64, unit string) (Voltage, error) {
 	return Voltage{NewTypedMeasurement("Voltage", value, unit)}, nil
+}
+
+// CopyVoltage duplicate the Voltage
+func CopyVoltage(v Voltage) Voltage {
+	if isNil(v.ConcreteMeasurement) {
+		return Voltage{}
+	}
+	if v, err := NewVoltage(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
 }

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -590,24 +590,6 @@ func CopyVelocity(v Velocity) Velocity {
 	return NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
-type Acceleration struct {
-	*ConcreteMeasurement
-}
-
-// NewAcceleration create a new acceleration with the given units which will
-// be looked up in the global unit registry
-func NewAcceleration(v float64, unit string) Acceleration {
-	return Acceleration{NewTypedMeasurement("Acceleration", v, unit)}
-}
-
-// CopyAcceleration duplicate the Acceleration
-func CopyAcceleration(v Acceleration) Acceleration {
-	if isNil(v.ConcreteMeasurement) {
-		return Acceleration{}
-	}
-	return NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 type Rate struct {
 	*ConcreteMeasurement
 }

--- a/antha/anthalib/wunit/wdimension_test.go
+++ b/antha/anthalib/wunit/wdimension_test.go
@@ -601,27 +601,6 @@ func TestNewVelocity(t *testing.T) {
 	})
 }
 
-func TestNewAcceleration(t *testing.T) {
-	NewMeasurementTests{
-		{
-			Value:            1.0,
-			Unit:             "mm/s^2",
-			ExpectedSIValue:  1.0e-3,
-			ExpectedBaseUnit: "m/s^2",
-			ExpectedPrefix:   "m",
-		},
-		{
-			Value:       1.0,
-			Unit:        "shane williams",
-			ShouldPanic: true,
-		},
-	}.Run(t, func(v float64, u string) Measurement {
-		return NewAcceleration(v, u)
-	}, func(m Measurement) Measurement {
-		return CopyAcceleration(m.(Acceleration))
-	})
-}
-
 func TestNewRate(t *testing.T) {
 	NewMeasurementTests{
 		{

--- a/antha/anthalib/wunit/wdimension_test.go
+++ b/antha/anthalib/wunit/wdimension_test.go
@@ -2,11 +2,14 @@ package wunit
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"math"
 	"testing"
 )
 
 type MeasurementConstructor func(float64, string) Measurement
+
+type MeasurementCopier func(Measurement) Measurement
 
 type TestFn func(*testing.T, Measurement)
 
@@ -20,7 +23,32 @@ type NewMeasurementTest struct {
 	ConvertToString  map[string]float64
 }
 
-func (self *NewMeasurementTest) Run(t *testing.T, constructor MeasurementConstructor) {
+func (self *NewMeasurementTest) assertMatching(m Measurement) error {
+	if math.Abs(m.SIValue()-self.ExpectedSIValue) > 1.0e-9 {
+		return errors.Errorf("wrong SIValue: expected %e, got %e", self.ExpectedSIValue, m.SIValue())
+	}
+
+	if e, g := self.ExpectedBaseUnit, m.Unit().BaseSISymbol(); e != g {
+		return errors.Errorf("wrong base unit: expected \"%s\", got \"%s\"", e, g)
+	}
+
+	if e, g := self.ExpectedPrefix, m.Unit().Prefix().Symbol; e != g {
+		return errors.Errorf("wrong base prefix: expected \"%s\", got \"%s\"", e, g)
+	}
+
+	if e, g := self.Value, m.ConvertToString(self.Unit); math.Abs(e-g) > 1.0e-9 {
+		return errors.Errorf("(\"%s\" [%T]).ConvertToString(\"%s\") = %f, expected %f", m, m, self.Unit, g, e)
+	}
+
+	for unit, e := range self.ConvertToString {
+		if g := m.ConvertToString(unit); math.Abs(e-g) > 1.0e-9 {
+			return errors.Errorf("(\"%s\" [%T]).ConvertToString(\"%s\") = %f, expected %f", m, m, self.Unit, g, e)
+		}
+	}
+	return nil
+}
+
+func (self *NewMeasurementTest) Run(t *testing.T, constructor MeasurementConstructor, copier MeasurementCopier) {
 
 	t.Run(fmt.Sprintf("%f_%s", self.Value, self.Unit), func(t *testing.T) {
 		defer func() {
@@ -31,29 +59,19 @@ func (self *NewMeasurementTest) Run(t *testing.T, constructor MeasurementConstru
 
 		m := constructor(self.Value, self.Unit)
 
-		if !self.ShouldPanic { //don't check these if we were expecting error, the defer statement will add one
-			if math.Abs(m.SIValue()-self.ExpectedSIValue) > 1.0e-9 {
-				t.Errorf("wrong SIValue: expected %e, got %e", self.ExpectedSIValue, m.SIValue())
-			}
+		if self.ShouldPanic { //don't check these if we were expecting error, the defer statement will add one
+			return
+		}
 
-			if e, g := self.ExpectedBaseUnit, m.Unit().BaseSISymbol(); e != g {
-				t.Errorf("wrong base unit: expected \"%s\", got \"%s\"", e, g)
-			}
+		copy := copier(m)
 
-			if e, g := self.ExpectedPrefix, m.Unit().Prefix().Symbol; e != g {
-				t.Errorf("wrong base prefix: expected \"%s\", got \"%s\"", e, g)
+		if err := self.assertMatching(m); err != nil {
+			t.Error(errors.WithMessage(err, "while testing original"))
+		} else {
+			m.IncrBy(copy) // change the original to test that it has no effect on the copy
+			if err := self.assertMatching(copy); err != nil {
+				t.Error(errors.WithMessage(err, "while testing copy"))
 			}
-
-			if e, g := self.Value, m.ConvertToString(self.Unit); math.Abs(e-g) > 1.0e-9 {
-				t.Errorf("(\"%s\" [%T]).ConvertToString(\"%s\") = %f, expected %f", m, m, self.Unit, g, e)
-			}
-
-			for unit, e := range self.ConvertToString {
-				if g := m.ConvertToString(unit); math.Abs(e-g) > 1.0e-9 {
-					t.Errorf("(\"%s\" [%T]).ConvertToString(\"%s\") = %f, expected %f", m, m, self.Unit, g, e)
-				}
-			}
-
 		}
 
 	})
@@ -61,9 +79,9 @@ func (self *NewMeasurementTest) Run(t *testing.T, constructor MeasurementConstru
 
 type NewMeasurementTests []*NewMeasurementTest
 
-func (self NewMeasurementTests) Run(t *testing.T, constructor MeasurementConstructor) {
+func (self NewMeasurementTests) Run(t *testing.T, constructor MeasurementConstructor, copier MeasurementCopier) {
 	for _, test := range self {
-		test.Run(t, constructor)
+		test.Run(t, constructor, copier)
 	}
 }
 
@@ -97,6 +115,8 @@ func TestNewLength(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewLength(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyLength(m.(Length))
 	})
 }
 
@@ -123,6 +143,8 @@ func TestNewArea(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewArea(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyArea(m.(Area))
 	})
 }
 
@@ -156,6 +178,8 @@ func TestNewVolume(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewVolume(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyVolume(m.(Volume))
 	})
 }
 
@@ -196,6 +220,8 @@ func TestNewTemperature(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewTemperature(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyTemperature(m.(Temperature))
 	})
 }
 
@@ -236,6 +262,8 @@ func TestNewTime(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewTime(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyTime(m.(Time))
 	})
 }
 
@@ -265,6 +293,8 @@ func TestNewMass(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewMass(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyMass(m.(Mass))
 	})
 }
 
@@ -291,6 +321,8 @@ func TestNewMoles(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewMoles(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyMoles(m.(Moles))
 	})
 }
 
@@ -317,6 +349,8 @@ func TestNewAmount(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewAmount(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyAmount(m.(Moles))
 	})
 }
 
@@ -346,6 +380,8 @@ func TestNewAngle(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewAngle(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyAngle(m.(Angle))
 	})
 }
 
@@ -368,6 +404,8 @@ func TestNewAnglularVelocity(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewAngularVelocity(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyAngularVelocity(m.(AngularVelocity))
 	})
 }
 
@@ -387,6 +425,8 @@ func TestNewEnergy(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewEnergy(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyEnergy(m.(Energy))
 	})
 }
 
@@ -406,6 +446,8 @@ func TestNewForce(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewForce(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyForce(m.(Force))
 	})
 }
 
@@ -435,6 +477,8 @@ func TestNewPressure(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewPressure(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyPressure(m.(Pressure))
 	})
 }
 
@@ -468,6 +512,8 @@ func TestNewConcentration(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewConcentration(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyConcentration(m.(Concentration))
 	})
 }
 
@@ -487,6 +533,8 @@ func TestNewSpecificHeatCapacity(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewSpecificHeatCapacity(v, u)
+	}, func(m Measurement) Measurement {
+		return CopySpecificHeatCapacity(m.(SpecificHeatCapacity))
 	})
 }
 
@@ -506,6 +554,8 @@ func TestNewDensity(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewDensity(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyDensity(m.(Density))
 	})
 }
 
@@ -525,6 +575,8 @@ func TestNewFlowRate(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewFlowRate(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyFlowRate(m.(FlowRate))
 	})
 }
 
@@ -544,6 +596,29 @@ func TestNewVelocity(t *testing.T) {
 		},
 	}.Run(t, func(v float64, u string) Measurement {
 		return NewVelocity(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyVelocity(m.(Velocity))
+	})
+}
+
+func TestNewAcceleration(t *testing.T) {
+	NewMeasurementTests{
+		{
+			Value:            1.0,
+			Unit:             "mm/s^2",
+			ExpectedSIValue:  1.0e-3,
+			ExpectedBaseUnit: "m/s^2",
+			ExpectedPrefix:   "m",
+		},
+		{
+			Value:       1.0,
+			Unit:        "shane williams",
+			ShouldPanic: true,
+		},
+	}.Run(t, func(v float64, u string) Measurement {
+		return NewAcceleration(v, u)
+	}, func(m Measurement) Measurement {
+		return CopyAcceleration(m.(Acceleration))
 	})
 }
 
@@ -581,6 +656,8 @@ func TestNewRate(t *testing.T) {
 		} else {
 			return r
 		}
+	}, func(m Measurement) Measurement {
+		return CopyRate(m.(Rate))
 	})
 }
 
@@ -604,6 +681,8 @@ func TestNewVoltage(t *testing.T) {
 		} else {
 			return r
 		}
+	}, func(m Measurement) Measurement {
+		return CopyVoltage(m.(Voltage))
 	})
 }
 


### PR DESCRIPTION
Copy constructors are required until each type embeds ConcreteUnit by value rather than pointer, but they weren't implemented for each type.

These are implemented on the package to match with `AddVolumes` etc and existing functions.

Tests have also been updated to call copy constructors during TestNew<X>