### PR TITLE
[Antha-1978] Add structs to allow reporting of head movement behaviour

### DIFF
--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -36,6 +36,20 @@ const (
 	ZDim
 )
 
+var Dimensions = []Dimension{XDim, YDim, ZDim}
+
+func (d Dimension) String() string {
+	switch d {
+	case XDim:
+		return "X"
+	case YDim:
+		return "Y"
+	case ZDim:
+		return "Z"
+	}
+	return "" //unreachable, needed to keep compiler happy
+}
+
 type Coordinates struct {
 	X float64
 	Y float64

--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -83,6 +83,11 @@ func (a Coordinates) Dim(x Dimension) float64 {
 	}
 }
 
+// AsLength return the given dimension as a Length with units
+func (self Coordinates) AsLength(dim Dimension) wunit.Length {
+	return wunit.NewLength(self.Dim(dim), "mm")
+}
+
 //Add Addition returns a new wtype.Coordinates
 func (self Coordinates) Add(rhs Coordinates) Coordinates {
 	return Coordinates{self.X + rhs.X,

--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -28,6 +28,14 @@ import (
 	"math"
 )
 
+type Dimension int
+
+const (
+	XDim Dimension = iota
+	YDim
+	ZDim
+)
+
 type Coordinates struct {
 	X float64
 	Y float64
@@ -48,13 +56,13 @@ func (self Coordinates) StringXY() string {
 }
 
 //Dim Value for dimension
-func (a Coordinates) Dim(x int) float64 {
+func (a Coordinates) Dim(x Dimension) float64 {
 	switch x {
-	case 0:
+	case XDim:
 		return a.X
-	case 1:
+	case YDim:
 		return a.Y
-	case 2:
+	case ZDim:
 		return a.Z
 	default:
 		return 0.0

--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -424,6 +424,7 @@ type LHHeadAssemblyPosition struct {
 type LHHeadAssembly struct {
 	Positions    []*LHHeadAssemblyPosition
 	MotionLimits *BBox
+	Behaviour    *MovementBehaviour
 }
 
 //NewLHHeadAssembly build a new head assembly

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -1,18 +1,61 @@
 package wtype
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"math"
+	"strings"
 
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )
 
 // MovementBehaviour describe movement behaviour in three dimensions
 type MovementBehaviour struct {
-	Profiles   map[Dimension]LinearMovementProfile
+	Profiles   []LinearMovementProfile
 	Order      [][]Dimension //Order in which movement is carried out - dimensions in the same list are carried out simultaneously
 	BeforeMove []MovementAction
 	AfterMove  []MovementAction
+}
+
+// NewMovementBehaviour builds a new movement behaviour
+func NewMovementBehaviour(xProfile, yProfile, zProfile LinearMovementProfile, order [][]Dimension, beforeActions, afterActions []MovementAction) (*MovementBehaviour, error) {
+	if xProfile == nil || yProfile == nil || zProfile == nil {
+		return nil, errors.New("cannot use nil movement profile")
+	} else if err := assertOrderValid(order); err != nil {
+		return nil, err
+	} else {
+		return &MovementBehaviour{
+			Profiles:   []LinearMovementProfile{xProfile, yProfile, zProfile},
+			Order:      order,
+			BeforeMove: beforeActions,
+			AfterMove:  afterActions,
+		}, nil
+	}
+}
+
+// assertOrderValid each dimension should feature exactly once
+func assertOrderValid(order [][]Dimension) error {
+	errs := []string{}
+	seen := map[Dimension]int{}
+	for _, group := range order {
+		for _, dim := range group {
+			seen[dim] = seen[dim] + 1
+		}
+	}
+
+	for _, dim := range Dimensions {
+		if count := seen[dim]; count < 1 {
+			errs = append(errs, fmt.Sprintf("dimension %v not specified", dim))
+		} else if count > 1 {
+			errs = append(errs, fmt.Sprintf("dimension %v specified more than once", dim))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Errorf("invalid dimension ordering: %s", strings.Join(errs, " and "))
+	} else {
+		return nil
+	}
 }
 
 // Duration calculate the time taken for the entire move
@@ -56,17 +99,36 @@ type MovementAction interface {
 // GenericAction an action which happens in constant time at the begining or end of a move
 // for example locking or unlocking a head
 type GenericAction struct {
-	Time wunit.Time
+	TimeTaken wunit.Time
+}
+
+// NewGenericAction create a new generic action, asserting that the time taken is positive
+func NewGenericAction(time wunit.Time) (*GenericAction, error) {
+	if !(time.IsZero() || time.IsPositive()) {
+		return nil, errors.New("time taken must be non-negative")
+	}
+	return &GenericAction{
+		TimeTaken: wunit.CopyTime(time),
+	}, nil
 }
 
 // Duration return the time taken by the action and the final position of the head assembly
 func (self *GenericAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
-	return wunit.NewTime(self.Time.RawValue(), self.Time.Unit().PrefixedSymbol()), location
+	return wunit.CopyTime(self.TimeTaken), location
 }
 
 // MoveToSafetyHeightAction move in the Z-Direction to a machine specific safety height to avoid in-transit collisions
 type MoveToSafetyHeightAction struct {
 	SafetyHeight wunit.Length
+}
+
+// NewMoveToSafetyHeightAction returns a new move to safety height
+func NewMoveToSafetyHeightAction(safetyHeight wunit.Length) (*MoveToSafetyHeightAction, error) {
+	// since it's possible the robot has a wierd coordinate system, safety height
+	// might be negative
+	return &MoveToSafetyHeightAction{
+		SafetyHeight: wunit.CopyLength(safetyHeight),
+	}, nil
 }
 
 // Duration return the time taken by the action and the final position of the head assembly
@@ -101,21 +163,42 @@ type LinearAcceleration struct {
 	Acceleration    wunit.Acceleration
 }
 
+func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, accel, maxAccel wunit.Acceleration) (*LinearAcceleration, error) {
+	if minSpeed.GreaterThan(maxSpeed) {
+		return nil, errors.Errorf("minimum speed (%v) cannot be greater than maximum speed (%v)", minSpeed, maxSpeed)
+	} else if speed.GreaterThan(maxSpeed) || speed.LessThan(minSpeed) {
+		return nil, errors.Errorf("speed (%v) must be within allowable range [%v - %v]", speed, minSpeed, maxSpeed)
+	} else if minAccel.GreaterThan(maxAccel) {
+		return nil, errors.Errorf("minimum acceleration (%v) cannot be greater than maximum acceleration (%v)", minAccel, maxAccel)
+	} else if accel.GreaterThan(maxAccel) || speed.LessThan(minAccel) {
+		return nil, errors.Errorf("acceleration (%v) must be within allowable range [%v - %v]", accel, minAccel, maxAccel)
+	} else {
+		return &LinearAcceleration{
+			MinSpeed:        wunit.CopyVelocity(minSpeed),
+			Speed:           wunit.CopyVelocity(speed),
+			MaxSpeed:        wunit.CopyVelocity(maxSpeed),
+			MinAcceleration: wunit.CopyAcceleration(minAccel),
+			Acceleration:    wunit.CopyAcceleration(accel),
+			MaxAcceleration: wunit.CopyAcceleration(maxAccel),
+		}, nil
+	}
+}
+
 // SetVelocity set the velocity
 func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
 	if v.LessThan(self.MinSpeed) || v.GreaterThan(self.MaxSpeed) {
 		return errors.Errorf("cannot set velocity: %v is outside allowable rage [%v - %v]", v, self.MinSpeed, self.MaxSpeed)
 	}
-	self.Speed = wunit.NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
+	self.Speed = wunit.CopyVelocity(v)
 	return nil
 }
 
 // SetAcceleration set the acceleration
 func (self *LinearAcceleration) SetAcceleration(v wunit.Acceleration) error {
 	if v.LessThan(self.MinAcceleration) || v.GreaterThan(self.MaxAcceleration) {
-		return errors.Errorf("cannot set velocity: %v is outside allowable rage [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
+		return errors.Errorf("cannot set acceleration: %v is outside allowable rage [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
 	}
-	self.Acceleration = wunit.NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
+	self.Acceleration = wunit.CopyAcceleration(v)
 	return nil
 }
 

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -10,12 +10,12 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )
 
-// MovementBehaviour describe movement behaviour in three dimensions
+// MovementBehaviour describe movement behaviour of the head assembly in three dimensions
 type MovementBehaviour struct {
-	Profiles   MovementProfile
-	Order      [][]Dimension //Order in which movement is carried out - dimensions in the same list are carried out simultaneously
-	BeforeMove MovementActions
-	AfterMove  MovementActions
+	Profiles   MovementProfile // how does the head assembly move in each timension
+	Order      [][]Dimension   // Order in which movement is carried out - dimensions in the same list are carried out simultaneously
+	BeforeMove MovementActions // actions which are carried out before each move
+	AfterMove  MovementActions // actions which are carried out after each move
 }
 
 // NewMovementBehaviour builds a new movement behaviour
@@ -34,7 +34,7 @@ func NewMovementBehaviour(xProfile, yProfile, zProfile LinearMovementProfile, or
 	}
 }
 
-// assertOrderValid each dimension should feature exactly once
+// assertOrderValid each dimension must feature exactly once
 func assertOrderValid(order [][]Dimension) error {
 	errs := []string{}
 	seen := map[Dimension]int{}
@@ -97,6 +97,7 @@ type MovementAction interface {
 	Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates)
 }
 
+// MovementActions a slice of actions that are carried out in series
 type MovementActions []MovementAction
 
 type movementActionType string
@@ -221,7 +222,7 @@ func (self *MoveToSafetyHeightAction) Duration(location Coordinates, behaviour *
 	return duration, Coordinates{X: location.X, Y: location.Y, Z: safetyHeightMm}
 }
 
-// LinearMovementProfile movement behaviour is one direction only
+// LinearMovementProfile describe the movement behaviour in one direction only
 type LinearMovementProfile interface {
 	// GetTimeToTravel calculate the time required to travel the given distance
 	// starting and ending at a complete stop
@@ -243,7 +244,7 @@ const (
 // MovementProfile combines three LinearMovementProfiles to represent behaviour in each dimension
 type MovementProfile [3]LinearMovementProfile
 
-// UnmarshalJSON unmarshal each LinearMovementProfile into the relevant struct
+// UnmarshalJSON unmarshal each LinearMovementProfile, peserving
 func (self *MovementProfile) UnmarshalJSON(b []byte) error {
 	var profiles []*json.RawMessage
 	if err := json.Unmarshal(b, &profiles); err != nil {
@@ -288,6 +289,7 @@ type LinearAcceleration struct {
 	Acceleration    wunit.Acceleration
 }
 
+// NewLinearAcceleration builds a new LinearAcceleration, checking that the passed parameters are valid, returning an error if not
 func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, accel, maxAccel wunit.Acceleration) (*LinearAcceleration, error) {
 	if !(minSpeed.IsZero() || minSpeed.IsPositive()) {
 		return nil, errors.New("minimum speed must be non-negative")
@@ -315,7 +317,7 @@ func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, a
 	return ret, nil
 }
 
-// String a string representation
+// String a string representation useful for debugging
 func (self *LinearAcceleration) String() string {
 	return fmt.Sprintf("LinearAcceleration(V=%v[%v-%v],A=%v[%v-%v])", self.Speed, self.MinSpeed, self.MaxSpeed, self.Acceleration, self.MinAcceleration, self.MaxAcceleration)
 }

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -159,7 +159,7 @@ func NewGenericAction(time wunit.Time) (*GenericAction, error) {
 		return nil, errors.New("time taken must be non-negative")
 	}
 	return &GenericAction{
-		TimeTaken: wunit.CopyTime(time),
+		TimeTaken: wunit.NewTime(time.RawValue(), time.Unit().PrefixedSymbol()),
 	}, nil
 }
 
@@ -181,7 +181,7 @@ func (self *GenericAction) MarshalJSON() ([]byte, error) {
 
 // Duration return the time taken by the action and the final position of the head assembly
 func (self *GenericAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
-	return wunit.CopyTime(self.TimeTaken), location
+	return wunit.NewTime(self.TimeTaken.RawValue(), self.TimeTaken.Unit().PrefixedSymbol()), location
 }
 
 // MoveToSafetyHeightAction move in the Z-Direction to a machine specific safety height to avoid in-transit collisions
@@ -194,7 +194,7 @@ func NewMoveToSafetyHeightAction(safetyHeight wunit.Length) (*MoveToSafetyHeight
 	// since it's possible the robot has a wierd coordinate system, safety height
 	// might be negative
 	return &MoveToSafetyHeightAction{
-		SafetyHeight: wunit.CopyLength(safetyHeight),
+		SafetyHeight: wunit.NewLength(safetyHeight.RawValue(), safetyHeight.Unit().PrefixedSymbol()),
 	}, nil
 }
 
@@ -301,12 +301,12 @@ func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, a
 	}
 
 	ret := &LinearAcceleration{
-		MinSpeed:        wunit.CopyVelocity(minSpeed),
-		Speed:           wunit.CopyVelocity(speed),
-		MaxSpeed:        wunit.CopyVelocity(maxSpeed),
-		MinAcceleration: wunit.CopyAcceleration(minAccel),
-		Acceleration:    wunit.CopyAcceleration(accel),
-		MaxAcceleration: wunit.CopyAcceleration(maxAccel),
+		MinSpeed:        wunit.NewVelocity(minSpeed.RawValue(), minSpeed.Unit().PrefixedSymbol()),
+		Speed:           wunit.NewVelocity(speed.RawValue(), speed.Unit().PrefixedSymbol()),
+		MaxSpeed:        wunit.NewVelocity(maxSpeed.RawValue(), maxSpeed.Unit().PrefixedSymbol()),
+		MinAcceleration: wunit.NewAcceleration(minAccel.RawValue(), minAccel.Unit().PrefixedSymbol()),
+		Acceleration:    wunit.NewAcceleration(accel.RawValue(), accel.Unit().PrefixedSymbol()),
+		MaxAcceleration: wunit.NewAcceleration(maxAccel.RawValue(), maxAccel.Unit().PrefixedSymbol()),
 	}
 	if err := ret.SetVelocity(speed); err != nil {
 		return nil, err
@@ -337,7 +337,7 @@ func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
 	if v.LessThan(self.MinSpeed) || v.GreaterThan(self.MaxSpeed) || !v.IsPositive() {
 		return errors.Errorf("cannot set velocity to %v: must be positive and within allowable range [%v - %v]", v, self.MinSpeed, self.MaxSpeed)
 	}
-	self.Speed = wunit.CopyVelocity(v)
+	self.Speed = wunit.NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 	return nil
 }
 
@@ -346,7 +346,7 @@ func (self *LinearAcceleration) SetAcceleration(v wunit.Acceleration) error {
 	if v.LessThan(self.MinAcceleration) || v.GreaterThan(self.MaxAcceleration) || !v.IsPositive() {
 		return errors.Errorf("cannot set acceleration to %v: must be positive and within allowable range [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
 	}
-	self.Acceleration = wunit.CopyAcceleration(v)
+	self.Acceleration = wunit.NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
 	return nil
 }
 

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -1,0 +1,148 @@
+package wtype
+
+import (
+	"github.com/pkg/errors"
+	"math"
+
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+)
+
+// MovementBehaviour describe movement behaviour in three dimensions
+type MovementBehaviour struct {
+	Profiles   map[Dimension]LinearMovementProfile
+	Order      [][]Dimension //Order in which movement is carried out - dimensions in the same list are carried out simultaneously
+	BeforeMove []MovementAction
+	AfterMove  []MovementAction
+}
+
+// Duration calculate the time taken for the entire move
+func (self *MovementBehaviour) DurationToMoveBetween(startPosition, endPosition Coordinates) wunit.Time {
+	ret := wunit.NewTime(0.0, "s")
+
+	for _, action := range self.BeforeMove {
+		time, pos := action.Duration(startPosition, self)
+		ret.IncrBy(time) //nolint
+		startPosition = pos
+	}
+
+	for _, movementGroup := range self.Order {
+		longest := wunit.NewTime(0.0, "s")
+		for _, dim := range movementGroup {
+			dist := wunit.NewLength(math.Abs(endPosition.Dim(dim)-startPosition.Dim(dim)), "mm")
+			time := self.Profiles[dim].GetTimeToTravel(dist)
+			if time.GreaterThan(longest) {
+				longest = time
+			}
+		}
+		ret.IncrBy(longest) // nolint
+	}
+
+	for _, action := range self.AfterMove {
+		time, pos := action.Duration(startPosition, self)
+		ret.IncrBy(time) // nolint
+		startPosition = pos
+	}
+
+	return ret
+}
+
+// MovementAction an action that is carried out before or after a move operation
+type MovementAction interface {
+	// Duration calculate the time taken by the action and the final position of the head assembly,
+	// given the current location of the head assembly and movement behaviour
+	Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates)
+}
+
+// GenericAction an action which happens in constant time at the begining or end of a move
+// for example locking or unlocking a head
+type GenericAction struct {
+	Time wunit.Time
+}
+
+// Duration return the time taken by the action and the final position of the head assembly
+func (self *GenericAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
+	return wunit.NewTime(self.Time.RawValue(), self.Time.Unit().PrefixedSymbol()), location
+}
+
+// MoveToSafetyHeightAction move in the Z-Direction to a machine specific safety height to avoid in-transit collisions
+type MoveToSafetyHeightAction struct {
+	SafetyHeight wunit.Length
+}
+
+// Duration return the time taken by the action and the final position of the head assembly
+func (self *MoveToSafetyHeightAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
+	safetyHeightMm := self.SafetyHeight.MustInStringUnit("mm").RawValue()
+	location.Z = safetyHeightMm
+	return behaviour.Profiles[ZDim].GetTimeToTravel(wunit.NewLength(safetyHeightMm-location.Z, "mm")), location
+}
+
+// LinearMovementProfile movement behaviour is one direction only
+type LinearMovementProfile interface {
+	// GetTimeToTravel calculate the time required to travel the given distance
+	// starting and ending at a complete stop
+	GetTimeToTravel(wunit.Length) wunit.Time
+
+	// SetVelocity set the maximum velocity for the movement
+	SetVelocity(wunit.Velocity) error
+
+	// SetAcceleration set the maximum acceleration for the movement
+	SetAcceleration(wunit.Acceleration) error
+}
+
+// LinearAcceleration accelerates at constant acceleration at maximum acceleration
+// until reaching maximum velocity, continues at maximum velocity, then decelerates
+// continuously at maximum acceleration to a stop
+type LinearAcceleration struct {
+	MinSpeed        wunit.Velocity
+	MaxSpeed        wunit.Velocity
+	Speed           wunit.Velocity
+	MinAcceleration wunit.Acceleration
+	MaxAcceleration wunit.Acceleration
+	Acceleration    wunit.Acceleration
+}
+
+// SetVelocity set the velocity
+func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
+	if v.LessThan(self.MinSpeed) || v.GreaterThan(self.MaxSpeed) {
+		return errors.Errorf("cannot set velocity: %v is outside allowable rage [%v - %v]", v, self.MinSpeed, self.MaxSpeed)
+	}
+	self.Speed = wunit.NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
+	return nil
+}
+
+// SetAcceleration set the acceleration
+func (self *LinearAcceleration) SetAcceleration(v wunit.Acceleration) error {
+	if v.LessThan(self.MinAcceleration) || v.GreaterThan(self.MaxAcceleration) {
+		return errors.Errorf("cannot set velocity: %v is outside allowable rage [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
+	}
+	self.Acceleration = wunit.NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
+	return nil
+}
+
+// GetTimeToTravel calculate the time required to travel the given distance
+func (self *LinearAcceleration) GetTimeToTravel(distance wunit.Length) wunit.Time {
+	//convert everything into SI units
+	vMax := self.Speed.MustInStringUnit("m/s").RawValue()
+	aMax := self.Acceleration.MustInStringUnit("m/s^2").RawValue()
+	distanceM := distance.MustInStringUnit("m").RawValue()
+
+	// for constant acceleration:
+	//   \ddot{x} = aMax            (1)
+	//    \dot{x} = aMax * t        (2)
+	//         x  = aMax * t / 2    (3)
+	// let t_1 = time at which \dot{x} = vMax and x = x_1; from (2)
+	//   t_1 = vMax / aMax
+	// sub t_1 into (3)
+	//   x_1 = vMax^2 / (2 * aMax)
+	distanceToMaxVelocity := vMax * vMax / (2.0 * aMax)
+
+	//distance is long enough that there's a period of constant velocity in the middle
+	if distanceAtConstantVelocity := (distanceM - 2.0*distanceToMaxVelocity); distanceAtConstantVelocity > 0.0 {
+		timeForMaxVelocity := vMax / aMax
+		timeAtConstantVelocity := distanceAtConstantVelocity / vMax
+		return wunit.NewTime(2.0*timeForMaxVelocity+timeAtConstantVelocity, "s")
+	} else {
+		// from (3) and by symmetry
+		return wunit.NewTime(math.Sqrt(2.0*distanceM/aMax), "s")
+	}
+}

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -112,6 +112,11 @@ func NewGenericAction(time wunit.Time) (*GenericAction, error) {
 	}, nil
 }
 
+// String return a string representation
+func (self *GenericAction) String() string {
+	return fmt.Sprintf("GenericAction(%v)", self.TimeTaken)
+}
+
 // Duration return the time taken by the action and the final position of the head assembly
 func (self *GenericAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
 	return wunit.CopyTime(self.TimeTaken), location
@@ -131,11 +136,16 @@ func NewMoveToSafetyHeightAction(safetyHeight wunit.Length) (*MoveToSafetyHeight
 	}, nil
 }
 
+// String return a string representation
+func (self *MoveToSafetyHeightAction) String() string {
+	return fmt.Sprintf("MoveToSafetyHeight(%v)", self.SafetyHeight)
+}
+
 // Duration return the time taken by the action and the final position of the head assembly
 func (self *MoveToSafetyHeightAction) Duration(location Coordinates, behaviour *MovementBehaviour) (wunit.Time, Coordinates) {
 	safetyHeightMm := self.SafetyHeight.MustInStringUnit("mm").RawValue()
-	location.Z = safetyHeightMm
-	return behaviour.Profiles[ZDim].GetTimeToTravel(wunit.NewLength(safetyHeightMm-location.Z, "mm")), location
+	duration := behaviour.Profiles[ZDim].GetTimeToTravel(wunit.NewLength(safetyHeightMm-location.Z, "mm"))
+	return duration, Coordinates{X: location.X, Y: location.Y, Z: safetyHeightMm}
 }
 
 // LinearMovementProfile movement behaviour is one direction only
@@ -184,6 +194,10 @@ func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, a
 	}
 }
 
+func (self *LinearAcceleration) String() string {
+	return fmt.Sprintf("LinearAcceleration(V=%v[%v-%v],A=%v[%v-%v])", self.Speed, self.MinSpeed, self.MaxSpeed, self.Acceleration, self.MinAcceleration, self.MaxAcceleration)
+}
+
 // SetVelocity set the velocity
 func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
 	if v.LessThan(self.MinSpeed) || v.GreaterThan(self.MaxSpeed) {
@@ -223,8 +237,6 @@ func (self *LinearAcceleration) GetTimeToTravel(distance wunit.Length) wunit.Tim
 	if distanceAtConstantVelocity := (distanceM - 2.0*distanceToMaxVelocity); distanceAtConstantVelocity > 0.0 {
 		timeForMaxVelocity := vMax / aMax
 		timeAtConstantVelocity := distanceAtConstantVelocity / vMax
-		fmt.Printf("timeForMaxVelocity: %f\n", timeForMaxVelocity)
-		fmt.Printf("distanceToMaxVelocity: %f\n", distanceToMaxVelocity)
 		return wunit.NewTime(2.0*timeForMaxVelocity+timeAtConstantVelocity, "s")
 	} else {
 		// from (3) and by symmetry

--- a/antha/anthalib/wtype/movementprofile.go
+++ b/antha/anthalib/wtype/movementprofile.go
@@ -170,7 +170,7 @@ func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, a
 		return nil, errors.Errorf("speed (%v) must be within allowable range [%v - %v]", speed, minSpeed, maxSpeed)
 	} else if minAccel.GreaterThan(maxAccel) {
 		return nil, errors.Errorf("minimum acceleration (%v) cannot be greater than maximum acceleration (%v)", minAccel, maxAccel)
-	} else if accel.GreaterThan(maxAccel) || speed.LessThan(minAccel) {
+	} else if accel.GreaterThan(maxAccel) || accel.LessThan(minAccel) {
 		return nil, errors.Errorf("acceleration (%v) must be within allowable range [%v - %v]", accel, minAccel, maxAccel)
 	} else {
 		return &LinearAcceleration{
@@ -187,7 +187,7 @@ func NewLinearAcceleration(minSpeed, speed, maxSpeed wunit.Velocity, minAccel, a
 // SetVelocity set the velocity
 func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
 	if v.LessThan(self.MinSpeed) || v.GreaterThan(self.MaxSpeed) {
-		return errors.Errorf("cannot set velocity: %v is outside allowable rage [%v - %v]", v, self.MinSpeed, self.MaxSpeed)
+		return errors.Errorf("cannot set velocity: %v is outside allowable range [%v - %v]", v, self.MinSpeed, self.MaxSpeed)
 	}
 	self.Speed = wunit.CopyVelocity(v)
 	return nil
@@ -196,7 +196,7 @@ func (self *LinearAcceleration) SetVelocity(v wunit.Velocity) error {
 // SetAcceleration set the acceleration
 func (self *LinearAcceleration) SetAcceleration(v wunit.Acceleration) error {
 	if v.LessThan(self.MinAcceleration) || v.GreaterThan(self.MaxAcceleration) {
-		return errors.Errorf("cannot set acceleration: %v is outside allowable rage [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
+		return errors.Errorf("cannot set acceleration: %v is outside allowable range [%v - %v]", v, self.MinAcceleration, self.MaxAcceleration)
 	}
 	self.Acceleration = wunit.CopyAcceleration(v)
 	return nil
@@ -223,9 +223,11 @@ func (self *LinearAcceleration) GetTimeToTravel(distance wunit.Length) wunit.Tim
 	if distanceAtConstantVelocity := (distanceM - 2.0*distanceToMaxVelocity); distanceAtConstantVelocity > 0.0 {
 		timeForMaxVelocity := vMax / aMax
 		timeAtConstantVelocity := distanceAtConstantVelocity / vMax
+		fmt.Printf("timeForMaxVelocity: %f\n", timeForMaxVelocity)
+		fmt.Printf("distanceToMaxVelocity: %f\n", distanceToMaxVelocity)
 		return wunit.NewTime(2.0*timeForMaxVelocity+timeAtConstantVelocity, "s")
 	} else {
 		// from (3) and by symmetry
-		return wunit.NewTime(math.Sqrt(2.0*distanceM/aMax), "s")
+		return wunit.NewTime(2.0*math.Sqrt(distanceM/aMax), "s")
 	}
 }

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -141,7 +141,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "missing Y profile",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, nil, profile},
+				Profiles: MovementProfile{profile, nil, profile},
 				Order:    [][]Dimension{{XDim}, {YDim}, {ZDim}},
 			},
 			ShouldError: true,
@@ -149,7 +149,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "missing XDim",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, profile, profile},
+				Profiles: MovementProfile{profile, profile, profile},
 				Order:    [][]Dimension{{YDim}, {ZDim}},
 			},
 			ShouldError: true,
@@ -157,7 +157,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "repeated ZDim",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, profile, profile},
+				Profiles: MovementProfile{profile, profile, profile},
 				Order:    [][]Dimension{{XDim, ZDim}, {YDim}, {ZDim}},
 			},
 			ShouldError: true,
@@ -165,7 +165,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "several ordering errors",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, profile, profile},
+				Profiles: MovementProfile{profile, profile, profile},
 				Order:    [][]Dimension{{XDim, ZDim}, {ZDim}},
 			},
 			ShouldError: true,
@@ -173,7 +173,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "OK simple",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, profile, profile},
+				Profiles: MovementProfile{profile, profile, profile},
 				Order:    [][]Dimension{{XDim}, {YDim}, {ZDim}},
 			},
 			Tests: DurationToMoveBetweenTests{
@@ -200,7 +200,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "OK XY Simultaneous",
 			Input: &MovementBehaviour{
-				Profiles: []LinearMovementProfile{profile, profile, profile},
+				Profiles: MovementProfile{profile, profile, profile},
 				Order:    [][]Dimension{{XDim, YDim}, {ZDim}},
 			},
 			Tests: DurationToMoveBetweenTests{
@@ -227,7 +227,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "OK with Generic",
 			Input: &MovementBehaviour{
-				Profiles:   []LinearMovementProfile{profile, profile, profile},
+				Profiles:   MovementProfile{profile, profile, profile},
 				Order:      [][]Dimension{{XDim, YDim}, {ZDim}},
 				BeforeMove: []MovementAction{waitOneSec},
 				AfterMove:  []MovementAction{waitTwoSec},
@@ -250,7 +250,7 @@ func TestMovementBehaviour(t *testing.T) {
 		{
 			Name: "OK with SafetyHeight",
 			Input: &MovementBehaviour{
-				Profiles:   []LinearMovementProfile{profile, profile, profile},
+				Profiles:   MovementProfile{profile, profile, profile},
 				Order:      [][]Dimension{{XDim, YDim}, {ZDim}},
 				BeforeMove: []MovementAction{waitOneSec, moveToSafeHeight},
 				AfterMove:  []MovementAction{waitTwoSec},

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -1,11 +1,57 @@
 package wtype
 
 import (
+	"encoding/json"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )
+
+func TestMovementbehaviourJSONSerialise(t *testing.T) {
+
+	wait1, err := NewGenericAction(wunit.NewTime(5.0, "min"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wait2, err := NewGenericAction(wunit.NewTime(2.0, "ms"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	safety, err := NewMoveToSafetyHeightAction(wunit.NewLength(104, "mm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x, err := NewLinearAcceleration(wunit.NewVelocity(0.1, "mm/s"), wunit.NewVelocity(15, "mm/s"), wunit.NewVelocity(100, "mm/s"), wunit.NewAcceleration(0.0, "mm/s^2"), wunit.NewAcceleration(50, "mm/s^2"), wunit.NewAcceleration(500, "mm/s^2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	y, err := NewLinearAcceleration(wunit.NewVelocity(0.1, "mm/s"), wunit.NewVelocity(20, "mm/s"), wunit.NewVelocity(100, "mm/s"), wunit.NewAcceleration(0.0, "mm/s^2"), wunit.NewAcceleration(60, "mm/s^2"), wunit.NewAcceleration(500, "mm/s^2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	z, err := NewLinearAcceleration(wunit.NewVelocity(0.1, "mm/s"), wunit.NewVelocity(3, "mm/s"), wunit.NewVelocity(10, "mm/s"), wunit.NewAcceleration(0.0, "mm/s^2"), wunit.NewAcceleration(20, "mm/s^2"), wunit.NewAcceleration(50, "mm/s^2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var b MovementBehaviour
+
+	if a, err := NewMovementBehaviour(x, y, z, [][]Dimension{{XDim, YDim}, {ZDim}}, []MovementAction{wait2, safety}, []MovementAction{wait1}); err != nil {
+		t.Fatal(err)
+	} else if bytes, err := json.Marshal(a); err != nil {
+		t.Fatal(err)
+	} else if err := json.Unmarshal(bytes, &b); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(a, b) {
+		t.Errorf("deserialised MovementBehaviour didn't match:\n e: %v\n g:%v", a, b)
+	}
+}
 
 type DurationToMoveBetweenTest struct {
 	Initial                 Coordinates

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -57,12 +57,12 @@ func (self LASetAccelerationTests) Run(t *testing.T, la *LinearAcceleration) {
 type LAGetTimeToTravelTest struct {
 	Distance            wunit.Length
 	ExpectedTimeSeconds float64
-	TolerancePercent    float64
+	Tolerance           float64
 }
 
 func (self *LAGetTimeToTravelTest) Run(t *testing.T, la *LinearAcceleration) {
 	timeInS := la.GetTimeToTravel(self.Distance).MustInStringUnit("s").RawValue()
-	if tol := self.TolerancePercent * self.ExpectedTimeSeconds / 100.0; math.Abs(self.ExpectedTimeSeconds-timeInS) > tol {
+	if math.Abs(self.ExpectedTimeSeconds-timeInS) > self.Tolerance {
 		t.Errorf("GetTimeToTravel(%v): got %f s expected %f s", self.Distance, timeInS, self.ExpectedTimeSeconds)
 	}
 }
@@ -148,17 +148,17 @@ func TestLinearAcceleration(t *testing.T) {
 				{ //constantly accelerating or decelerating to full speed
 					Distance:            wunit.NewLength(5, "mm"),
 					ExpectedTimeSeconds: 2.0,
-					TolerancePercent:    0.01,
+					Tolerance:           1.0e-5,
 				},
 				{ //constantly accelerating or decelerating to half speed
 					Distance:            wunit.NewLength(2.5, "mm"),
 					ExpectedTimeSeconds: math.Sqrt(2.0),
-					TolerancePercent:    0.01,
+					Tolerance:           1.0e-5,
 				},
 				{ //1 second at constant velocity
 					Distance:            wunit.NewLength(10, "mm"),
 					ExpectedTimeSeconds: 3.0,
-					TolerancePercent:    0.01,
+					Tolerance:           1.0e-5,
 				},
 			},
 		},

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -319,33 +319,34 @@ func (self LASetAccelerationTests) Run(t *testing.T, la *LinearAcceleration) {
 	}
 }
 
-type LAGetTimeToTravelTest struct {
-	Distance            wunit.Length
+type LATimeToTravelBetweenTest struct {
+	Start               wunit.Length
+	End                 wunit.Length
 	ExpectedTimeSeconds float64
 	Tolerance           float64
 }
 
-func (self *LAGetTimeToTravelTest) Run(t *testing.T, la *LinearAcceleration) {
-	timeInS := la.GetTimeToTravel(self.Distance).MustInStringUnit("s").RawValue()
+func (self *LATimeToTravelBetweenTest) Run(t *testing.T, la *LinearAcceleration) {
+	timeInS := la.TimeToTravelBetween(self.Start, self.End).MustInStringUnit("s").RawValue()
 	if math.Abs(self.ExpectedTimeSeconds-timeInS) > self.Tolerance {
-		t.Errorf("GetTimeToTravel(%v): got %f s expected %f s", self.Distance, timeInS, self.ExpectedTimeSeconds)
+		t.Errorf("TimeToTravelBetween(%v, %v): got %f s expected %f s", self.Start, self.End, timeInS, self.ExpectedTimeSeconds)
 	}
 }
 
-type LAGetTimeToTravelTests []*LAGetTimeToTravelTest
+type LATimeToTravelBetweenTests []*LATimeToTravelBetweenTest
 
-func (self LAGetTimeToTravelTests) Run(t *testing.T, la *LinearAcceleration) {
+func (self LATimeToTravelBetweenTests) Run(t *testing.T, la *LinearAcceleration) {
 	for _, test := range self {
 		test.Run(t, la)
 	}
 }
 
 type LinearAccelerationTest struct {
-	Input           *LinearAcceleration
-	ShouldError     bool //should initialisation result in an error
-	SetVelocity     LASetVelocityTests
-	SetAcceleration LASetAccelerationTests
-	GetTimeToTravel LAGetTimeToTravelTests
+	Input               *LinearAcceleration
+	ShouldError         bool //should initialisation result in an error
+	SetVelocity         LASetVelocityTests
+	SetAcceleration     LASetAccelerationTests
+	TimeToTravelBetween LATimeToTravelBetweenTests
 }
 
 func (self *LinearAccelerationTest) expectingError(err error) bool {
@@ -359,7 +360,7 @@ func (self *LinearAccelerationTest) Run(t *testing.T) {
 		} else if !self.ShouldError {
 			self.SetVelocity.Run(t, la)
 			self.SetAcceleration.Run(t, la)
-			self.GetTimeToTravel.Run(t, la)
+			self.TimeToTravelBetween.Run(t, la)
 		}
 	})
 }
@@ -483,19 +484,22 @@ func TestLinearAcceleration(t *testing.T) {
 					Acceleration: wunit.NewAcceleration(5.0, "mm/s^2"),
 				},
 			},
-			GetTimeToTravel: LAGetTimeToTravelTests{
+			TimeToTravelBetween: LATimeToTravelBetweenTests{
 				{ //constantly accelerating or decelerating to full speed
-					Distance:            wunit.NewLength(5, "mm"),
+					Start:               wunit.NewLength(5, "mm"),
+					End:                 wunit.NewLength(10, "mm"),
 					ExpectedTimeSeconds: 2.0,
 					Tolerance:           1.0e-5,
 				},
 				{ //constantly accelerating or decelerating to half speed
-					Distance:            wunit.NewLength(2.5, "mm"),
+					Start:               wunit.NewLength(2.5, "mm"),
+					End:                 wunit.NewLength(5, "mm"),
 					ExpectedTimeSeconds: math.Sqrt(2.0),
 					Tolerance:           1.0e-5,
 				},
 				{ //1 second at constant velocity
-					Distance:            wunit.NewLength(10, "mm"),
+					Start:               wunit.NewLength(10, "mm"),
+					End:                 wunit.NewLength(20, "mm"),
 					ExpectedTimeSeconds: 3.0,
 					Tolerance:           1.0e-5,
 				},

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -331,19 +331,89 @@ func TestLinearAcceleration(t *testing.T) {
 		{
 			Input: &LinearAcceleration{
 				MinSpeed:        wunit.NewVelocity(1.0, "mm/s"),
-				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				Speed:           wunit.NewVelocity(0.0, "mm/s"),
 				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
 				MinAcceleration: wunit.NewAcceleration(1.0, "mm/s^2"),
 				Acceleration:    wunit.NewAcceleration(1.0, "mm/s^2"),
 				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
 			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(1.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(1.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(3.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(1.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(3.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(1.0, "mm/s^2"),
+			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(1.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(-1.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(3.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(1.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(1.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(11.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(-2.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(0.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(0.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
+			ShouldError: true,
+		},
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(0.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(0.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(1.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
 			SetVelocity: LASetVelocityTests{
 				{
-					Velocity:    wunit.NewVelocity(0.5, "mm/s"),
+					Velocity:    wunit.NewVelocity(-0.5, "mm/s"),
 					ShouldError: true,
 				},
 				{
 					Velocity:    wunit.NewVelocity(10.5, "mm/s"),
+					ShouldError: true,
+				},
+				{
+					Velocity:    wunit.NewVelocity(0, "mm/s"),
 					ShouldError: true,
 				},
 				{
@@ -352,7 +422,11 @@ func TestLinearAcceleration(t *testing.T) {
 			},
 			SetAcceleration: LASetAccelerationTests{
 				{
-					Acceleration: wunit.NewAcceleration(0.5, "mm/s^2"),
+					Acceleration: wunit.NewAcceleration(0, "mm/s^2"),
+					ShouldError:  true,
+				},
+				{
+					Acceleration: wunit.NewAcceleration(-0.5, "mm/s^2"),
 					ShouldError:  true,
 				},
 				{

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -1,0 +1,166 @@
+package wtype
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+)
+
+type LASetVelocityTest struct {
+	Velocity    wunit.Velocity
+	ShouldError bool
+}
+
+func (self *LASetVelocityTest) expectingError(err error) bool {
+	return (err != nil) == self.ShouldError
+}
+
+func (self *LASetVelocityTest) Run(t *testing.T, la *LinearAcceleration) {
+	if err := la.SetVelocity(self.Velocity); !self.expectingError(err) {
+		t.Errorf("SetVelocity(%v): expecting error = %t, got error %v", self.Velocity, self.ShouldError, err)
+	}
+}
+
+type LASetVelocityTests []*LASetVelocityTest
+
+func (self LASetVelocityTests) Run(t *testing.T, la *LinearAcceleration) {
+	for _, test := range self {
+		test.Run(t, la)
+	}
+}
+
+type LASetAccelerationTest struct {
+	Acceleration wunit.Acceleration
+	ShouldError  bool
+}
+
+func (self *LASetAccelerationTest) expectingError(err error) bool {
+	return (err != nil) == self.ShouldError
+}
+
+func (self *LASetAccelerationTest) Run(t *testing.T, la *LinearAcceleration) {
+	if err := la.SetAcceleration(self.Acceleration); !self.expectingError(err) {
+		t.Errorf("SetAcceleration(%v): expecting error = %t, got error %v", self.Acceleration, self.ShouldError, err)
+	}
+}
+
+type LASetAccelerationTests []*LASetAccelerationTest
+
+func (self LASetAccelerationTests) Run(t *testing.T, la *LinearAcceleration) {
+	for _, test := range self {
+		test.Run(t, la)
+	}
+}
+
+type LAGetTimeToTravelTest struct {
+	Distance            wunit.Length
+	ExpectedTimeSeconds float64
+	TolerancePercent    float64
+}
+
+func (self *LAGetTimeToTravelTest) Run(t *testing.T, la *LinearAcceleration) {
+	timeInS := la.GetTimeToTravel(self.Distance).MustInStringUnit("s").RawValue()
+	if tol := self.TolerancePercent * self.ExpectedTimeSeconds / 100.0; math.Abs(self.ExpectedTimeSeconds-timeInS) > tol {
+		t.Errorf("GetTimeToTravel(%v): got %f s expected %f s", self.Distance, timeInS, self.ExpectedTimeSeconds)
+	}
+}
+
+type LAGetTimeToTravelTests []*LAGetTimeToTravelTest
+
+func (self LAGetTimeToTravelTests) Run(t *testing.T, la *LinearAcceleration) {
+	for _, test := range self {
+		test.Run(t, la)
+	}
+}
+
+type LinearAccelerationTest struct {
+	Input           *LinearAcceleration
+	ShouldError     bool //should initialisation result in an error
+	SetVelocity     LASetVelocityTests
+	SetAcceleration LASetAccelerationTests
+	GetTimeToTravel LAGetTimeToTravelTests
+}
+
+func (self *LinearAccelerationTest) expectingError(err error) bool {
+	return (err != nil) == self.ShouldError
+}
+
+func (self *LinearAccelerationTest) Run(t *testing.T) {
+	t.Run(fmt.Sprintf("V=[%v-%v],A=[%v-%v]", self.Input.MinSpeed, self.Input.MaxSpeed, self.Input.MinAcceleration, self.Input.MaxAcceleration), func(t *testing.T) {
+		if la, err := NewLinearAcceleration(self.Input.MinSpeed, self.Input.Speed, self.Input.MaxSpeed, self.Input.MinAcceleration, self.Input.Acceleration, self.Input.MaxAcceleration); !self.expectingError(err) {
+			t.Errorf("while validating: expecting error %t, got error %v", self.ShouldError, err)
+		} else if !self.ShouldError {
+			self.SetVelocity.Run(t, la)
+			self.SetAcceleration.Run(t, la)
+			self.GetTimeToTravel.Run(t, la)
+		}
+	})
+}
+
+type LinearAccelerationTests []*LinearAccelerationTest
+
+func (self LinearAccelerationTests) Run(t *testing.T) {
+	for _, test := range self {
+		test.Run(t)
+	}
+}
+
+func TestLinearAcceleration(t *testing.T) {
+	LinearAccelerationTests{
+		{
+			Input: &LinearAcceleration{
+				MinSpeed:        wunit.NewVelocity(1.0, "mm/s"),
+				Speed:           wunit.NewVelocity(4.0, "mm/s"),
+				MaxSpeed:        wunit.NewVelocity(10.0, "mm/s"),
+				MinAcceleration: wunit.NewAcceleration(1.0, "mm/s^2"),
+				Acceleration:    wunit.NewAcceleration(1.0, "mm/s^2"),
+				MaxAcceleration: wunit.NewAcceleration(10.0, "mm/s^2"),
+			},
+			SetVelocity: LASetVelocityTests{
+				{
+					Velocity:    wunit.NewVelocity(0.5, "mm/s"),
+					ShouldError: true,
+				},
+				{
+					Velocity:    wunit.NewVelocity(10.5, "mm/s"),
+					ShouldError: true,
+				},
+				{
+					Velocity: wunit.NewVelocity(5.0, "mm/s"),
+				},
+			},
+			SetAcceleration: LASetAccelerationTests{
+				{
+					Acceleration: wunit.NewAcceleration(0.5, "mm/s^2"),
+					ShouldError:  true,
+				},
+				{
+					Acceleration: wunit.NewAcceleration(10.5, "mm/s^2"),
+					ShouldError:  true,
+				},
+				{
+					Acceleration: wunit.NewAcceleration(5.0, "mm/s^2"),
+				},
+			},
+			GetTimeToTravel: LAGetTimeToTravelTests{
+				{ //constantly accelerating or decelerating to full speed
+					Distance:            wunit.NewLength(5, "mm"),
+					ExpectedTimeSeconds: 2.0,
+					TolerancePercent:    0.01,
+				},
+				{ //constantly accelerating or decelerating to half speed
+					Distance:            wunit.NewLength(2.5, "mm"),
+					ExpectedTimeSeconds: math.Sqrt(2.0),
+					TolerancePercent:    0.01,
+				},
+				{ //1 second at constant velocity
+					Distance:            wunit.NewLength(10, "mm"),
+					ExpectedTimeSeconds: 3.0,
+					TolerancePercent:    0.01,
+				},
+			},
+		},
+	}.Run(t)
+}

--- a/antha/anthalib/wtype/movementprofile_test.go
+++ b/antha/anthalib/wtype/movementprofile_test.go
@@ -48,7 +48,7 @@ func TestMovementbehaviourJSONSerialise(t *testing.T) {
 		t.Fatal(err)
 	} else if err := json.Unmarshal(bytes, &b); err != nil {
 		t.Fatal(err)
-	} else if !reflect.DeepEqual(a, b) {
+	} else if !reflect.DeepEqual(a, &b) {
 		t.Errorf("deserialised MovementBehaviour didn't match:\n e: %v\n g:%v", a, b)
 	}
 }

--- a/antha/anthalib/wunit/serialize.go
+++ b/antha/anthalib/wunit/serialize.go
@@ -300,6 +300,21 @@ func (m *Velocity) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (m Acceleration) MarshalJSON() ([]byte, error) {
+	return marshal(m)
+}
+
+func (m *Acceleration) UnmarshalJSON(b []byte) error {
+	if value, unit, err := unmarshal(b); err != nil {
+		return err
+	} else if unit != "" {
+		*m = NewAcceleration(value, unit)
+	} else {
+		*m = Acceleration{ConcreteMeasurement: &ConcreteMeasurement{}}
+	}
+	return nil
+}
+
 func (m Rate) MarshalJSON() ([]byte, error) {
 	return marshal(m)
 }

--- a/antha/anthalib/wunit/systemunits.go
+++ b/antha/anthalib/wunit/systemunits.go
@@ -174,6 +174,14 @@ func getSystemUnits() baseUnits {
 				Exponent: 1,
 			},
 		},
+		"Acceleration": {
+			{
+				Name:     "meters per second squared",
+				Symbol:   "m/s^2",
+				Prefixes: SIPrefixes,
+				Exponent: 1,
+			},
+		},
 		"FlowRate": {
 			{
 				Name:     "litres per second",

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -58,6 +58,14 @@ func NewLength(v float64, unit string) Length {
 	return Length{NewTypedMeasurement("Length", v, unit)}
 }
 
+// CopyLength duplicate the Length
+func CopyLength(v Length) Length {
+	if isNil(v.ConcreteMeasurement) {
+		return Length{}
+	}
+	return NewLength(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // area
 type Area struct {
 	*ConcreteMeasurement
@@ -66,6 +74,14 @@ type Area struct {
 // make an area unit
 func NewArea(v float64, unit string) Area {
 	return Area{NewTypedMeasurement("Area", v, unit)}
+}
+
+// CopyArea duplicate the Area
+func CopyArea(v Area) Area {
+	if isNil(v.ConcreteMeasurement) {
+		return Area{}
+	}
+	return NewArea(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func ZeroArea() Area {
@@ -86,8 +102,7 @@ func CopyVolume(v Volume) Volume {
 	if isNil(v.ConcreteMeasurement) {
 		return Volume{}
 	}
-	ret := NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
-	return ret
+	return NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // AddVolumes adds a set of volumes.
@@ -157,8 +172,10 @@ func (c Concentration) Dup() Concentration {
 }
 
 func CopyConcentration(v Concentration) Concentration {
-	ret := NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
-	return ret
+	if isNil(v.ConcreteMeasurement) {
+		return Concentration{}
+	}
+	return NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // MultiplyConcentration multiplies a concentration by a factor.
@@ -246,6 +263,14 @@ func NewTemperature(v float64, unit string) Temperature {
 	return Temperature{NewTypedMeasurement("Temperature", v, unit)}
 }
 
+// CopyTemperature duplicate the Temperature
+func CopyTemperature(v Temperature) Temperature {
+	if isNil(v.ConcreteMeasurement) {
+		return Temperature{}
+	}
+	return NewTemperature(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // time
 type Time struct {
 	*ConcreteMeasurement
@@ -254,7 +279,14 @@ type Time struct {
 // NewTime creates a time unit.
 func NewTime(v float64, unit string) (t Time) {
 	return Time{NewTypedMeasurement("Time", v, unit)}
+}
 
+// CopyTime duplicate the Time
+func CopyTime(v Time) Time {
+	if isNil(v.ConcreteMeasurement) {
+		return Time{}
+	}
+	return NewTime(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func (t Time) Seconds() float64 {
@@ -285,6 +317,14 @@ func NewMass(v float64, unit string) Mass {
 	return Mass{NewTypedMeasurement("Mass", v, unit)}
 }
 
+// CopyMass duplicate the Mass
+func CopyMass(v Mass) Mass {
+	if isNil(v.ConcreteMeasurement) {
+		return Mass{}
+	}
+	return NewMass(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // defines mass to be a SubstanceQuantity
 func (m *Mass) Quantity() Measurement {
 	return m
@@ -300,9 +340,25 @@ func NewMoles(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
 }
 
+// CopyMoles duplicate the Moles
+func CopyMoles(v Moles) Moles {
+	if isNil(v.ConcreteMeasurement) {
+		return Moles{}
+	}
+	return NewMoles(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // generate a new Amount in moles
 func NewAmount(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
+}
+
+// CopyAmount duplicate the Moles
+func CopyAmount(v Moles) Moles {
+	if isNil(v.ConcreteMeasurement) {
+		return Moles{}
+	}
+	return NewAmount(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines Moles to be a SubstanceQuantity
@@ -320,6 +376,14 @@ func NewAngle(v float64, unit string) Angle {
 	return Angle{NewTypedMeasurement("Angle", v, unit)}
 }
 
+// CopyAngle duplicate the Angle
+func CopyAngle(v Angle) Angle {
+	if isNil(v.ConcreteMeasurement) {
+		return Angle{}
+	}
+	return NewAngle(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // angular velocity (one way or another)
 
 type AngularVelocity struct {
@@ -328,6 +392,14 @@ type AngularVelocity struct {
 
 func NewAngularVelocity(v float64, unit string) AngularVelocity {
 	return AngularVelocity{NewTypedMeasurement("AngularVelocity", v, unit)}
+}
+
+// CopyAngularVelocity duplicate the AngularVelocity
+func CopyAngularVelocity(v AngularVelocity) AngularVelocity {
+	if isNil(v.ConcreteMeasurement) {
+		return AngularVelocity{}
+	}
+	return NewAngularVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // this is really Mass Length/Time^2
@@ -340,6 +412,14 @@ func NewEnergy(v float64, unit string) Energy {
 	return Energy{NewTypedMeasurement("Energy", v, unit)}
 }
 
+// CopyEnergy duplicate the Energy
+func CopyEnergy(v Energy) Energy {
+	if isNil(v.ConcreteMeasurement) {
+		return Energy{}
+	}
+	return NewEnergy(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a Force
 type Force struct {
 	*ConcreteMeasurement
@@ -350,6 +430,14 @@ func NewForce(v float64, unit string) Force {
 	return Force{NewTypedMeasurement("Force", v, unit)}
 }
 
+// CopyForce duplicate the Force
+func CopyForce(v Force) Force {
+	if isNil(v.ConcreteMeasurement) {
+		return Force{}
+	}
+	return NewForce(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a Pressure structure
 type Pressure struct {
 	*ConcreteMeasurement
@@ -358,6 +446,14 @@ type Pressure struct {
 // make a new pressure in Pascals
 func NewPressure(v float64, unit string) Pressure {
 	return Pressure{NewTypedMeasurement("Pressure", v, unit)}
+}
+
+// CopyPressure duplicate the Pressure
+func CopyPressure(v Pressure) Pressure {
+	if isNil(v.ConcreteMeasurement) {
+		return Pressure{}
+	}
+	return NewPressure(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines a concentration unit
@@ -432,6 +528,14 @@ func NewSpecificHeatCapacity(v float64, unit string) SpecificHeatCapacity {
 	return SpecificHeatCapacity{NewTypedMeasurement("SpecificHeatCapacity", v, unit)}
 }
 
+// CopySpecificHeatCapacity duplicate the SpecificHeatCapacity
+func CopySpecificHeatCapacity(v SpecificHeatCapacity) SpecificHeatCapacity {
+	if isNil(v.ConcreteMeasurement) {
+		return SpecificHeatCapacity{}
+	}
+	return NewSpecificHeatCapacity(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 // a structure which defines a density
 type Density struct {
 	*ConcreteMeasurement
@@ -440,6 +544,14 @@ type Density struct {
 // make a new density structure in SI units
 func NewDensity(v float64, unit string) Density {
 	return Density{NewTypedMeasurement("Density", v, unit)}
+}
+
+// CopyDensity duplicate the Density
+func CopyDensity(v Density) Density {
+	if isNil(v.ConcreteMeasurement) {
+		return Density{}
+	}
+	return NewDensity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 type FlowRate struct {
@@ -452,6 +564,14 @@ func NewFlowRate(v float64, unit string) FlowRate {
 	return FlowRate{NewTypedMeasurement("FlowRate", v, unit)}
 }
 
+// CopyFlowRate duplicate the FlowRate
+func CopyFlowRate(v FlowRate) FlowRate {
+	if isNil(v.ConcreteMeasurement) {
+		return FlowRate{}
+	}
+	return NewFlowRate(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 type Velocity struct {
 	*ConcreteMeasurement
 }
@@ -460,6 +580,14 @@ type Velocity struct {
 
 func NewVelocity(v float64, unit string) Velocity {
 	return Velocity{NewTypedMeasurement("Velocity", v, unit)}
+}
+
+// CopyVelocity duplicate the Velocity
+func CopyVelocity(v Velocity) Velocity {
+	if isNil(v.ConcreteMeasurement) {
+		return Velocity{}
+	}
+	return NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 type Acceleration struct {
@@ -472,6 +600,14 @@ func NewAcceleration(v float64, unit string) Acceleration {
 	return Acceleration{NewTypedMeasurement("Acceleration", v, unit)}
 }
 
+// CopyAcceleration duplicate the Acceleration
+func CopyAcceleration(v Acceleration) Acceleration {
+	if isNil(v.ConcreteMeasurement) {
+		return Acceleration{}
+	}
+	return NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
+}
+
 type Rate struct {
 	*ConcreteMeasurement
 }
@@ -480,10 +616,34 @@ func NewRate(v float64, unit string) (r Rate, err error) {
 	return Rate{NewTypedMeasurement("Rate", v, unit)}, nil
 }
 
+// CopyRate duplicate the Rate
+func CopyRate(v Rate) Rate {
+	if isNil(v.ConcreteMeasurement) {
+		return Rate{}
+	}
+	if r, err := NewRate(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
+		panic(err)
+	} else {
+		return r
+	}
+}
+
 type Voltage struct {
 	*ConcreteMeasurement
 }
 
 func NewVoltage(value float64, unit string) (Voltage, error) {
 	return Voltage{NewTypedMeasurement("Voltage", value, unit)}, nil
+}
+
+// CopyVoltage duplicate the Voltage
+func CopyVoltage(v Voltage) Voltage {
+	if isNil(v.ConcreteMeasurement) {
+		return Voltage{}
+	}
+	if v, err := NewVoltage(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
 }

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -462,6 +462,16 @@ func NewVelocity(v float64, unit string) Velocity {
 	return Velocity{NewTypedMeasurement("Velocity", v, unit)}
 }
 
+type Acceleration struct {
+	*ConcreteMeasurement
+}
+
+// NewAcceleration create a new acceleration with the given units which will
+// be looked up in the global unit registry
+func NewAcceleration(v float64, unit string) Acceleration {
+	return Acceleration{NewTypedMeasurement("Acceleration", v, unit)}
+}
+
 type Rate struct {
 	*ConcreteMeasurement
 }

--- a/antha/anthalib/wunit/wdimension.go
+++ b/antha/anthalib/wunit/wdimension.go
@@ -58,14 +58,6 @@ func NewLength(v float64, unit string) Length {
 	return Length{NewTypedMeasurement("Length", v, unit)}
 }
 
-// CopyLength duplicate the Length
-func CopyLength(v Length) Length {
-	if isNil(v.ConcreteMeasurement) {
-		return Length{}
-	}
-	return NewLength(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // area
 type Area struct {
 	*ConcreteMeasurement
@@ -74,14 +66,6 @@ type Area struct {
 // make an area unit
 func NewArea(v float64, unit string) Area {
 	return Area{NewTypedMeasurement("Area", v, unit)}
-}
-
-// CopyArea duplicate the Area
-func CopyArea(v Area) Area {
-	if isNil(v.ConcreteMeasurement) {
-		return Area{}
-	}
-	return NewArea(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func ZeroArea() Area {
@@ -102,7 +86,8 @@ func CopyVolume(v Volume) Volume {
 	if isNil(v.ConcreteMeasurement) {
 		return Volume{}
 	}
-	return NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
+	ret := NewVolume(v.RawValue(), v.Unit().PrefixedSymbol())
+	return ret
 }
 
 // AddVolumes adds a set of volumes.
@@ -172,10 +157,8 @@ func (c Concentration) Dup() Concentration {
 }
 
 func CopyConcentration(v Concentration) Concentration {
-	if isNil(v.ConcreteMeasurement) {
-		return Concentration{}
-	}
-	return NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
+	ret := NewConcentration(v.RawValue(), v.Unit().PrefixedSymbol())
+	return ret
 }
 
 // MultiplyConcentration multiplies a concentration by a factor.
@@ -263,14 +246,6 @@ func NewTemperature(v float64, unit string) Temperature {
 	return Temperature{NewTypedMeasurement("Temperature", v, unit)}
 }
 
-// CopyTemperature duplicate the Temperature
-func CopyTemperature(v Temperature) Temperature {
-	if isNil(v.ConcreteMeasurement) {
-		return Temperature{}
-	}
-	return NewTemperature(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // time
 type Time struct {
 	*ConcreteMeasurement
@@ -279,14 +254,7 @@ type Time struct {
 // NewTime creates a time unit.
 func NewTime(v float64, unit string) (t Time) {
 	return Time{NewTypedMeasurement("Time", v, unit)}
-}
 
-// CopyTime duplicate the Time
-func CopyTime(v Time) Time {
-	if isNil(v.ConcreteMeasurement) {
-		return Time{}
-	}
-	return NewTime(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 func (t Time) Seconds() float64 {
@@ -317,14 +285,6 @@ func NewMass(v float64, unit string) Mass {
 	return Mass{NewTypedMeasurement("Mass", v, unit)}
 }
 
-// CopyMass duplicate the Mass
-func CopyMass(v Mass) Mass {
-	if isNil(v.ConcreteMeasurement) {
-		return Mass{}
-	}
-	return NewMass(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // defines mass to be a SubstanceQuantity
 func (m *Mass) Quantity() Measurement {
 	return m
@@ -340,25 +300,9 @@ func NewMoles(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
 }
 
-// CopyMoles duplicate the Moles
-func CopyMoles(v Moles) Moles {
-	if isNil(v.ConcreteMeasurement) {
-		return Moles{}
-	}
-	return NewMoles(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // generate a new Amount in moles
 func NewAmount(v float64, unit string) Moles {
 	return Moles{NewTypedMeasurement("Moles", v, unit)}
-}
-
-// CopyAmount duplicate the Moles
-func CopyAmount(v Moles) Moles {
-	if isNil(v.ConcreteMeasurement) {
-		return Moles{}
-	}
-	return NewAmount(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines Moles to be a SubstanceQuantity
@@ -376,14 +320,6 @@ func NewAngle(v float64, unit string) Angle {
 	return Angle{NewTypedMeasurement("Angle", v, unit)}
 }
 
-// CopyAngle duplicate the Angle
-func CopyAngle(v Angle) Angle {
-	if isNil(v.ConcreteMeasurement) {
-		return Angle{}
-	}
-	return NewAngle(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // angular velocity (one way or another)
 
 type AngularVelocity struct {
@@ -392,14 +328,6 @@ type AngularVelocity struct {
 
 func NewAngularVelocity(v float64, unit string) AngularVelocity {
 	return AngularVelocity{NewTypedMeasurement("AngularVelocity", v, unit)}
-}
-
-// CopyAngularVelocity duplicate the AngularVelocity
-func CopyAngularVelocity(v AngularVelocity) AngularVelocity {
-	if isNil(v.ConcreteMeasurement) {
-		return AngularVelocity{}
-	}
-	return NewAngularVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // this is really Mass Length/Time^2
@@ -412,14 +340,6 @@ func NewEnergy(v float64, unit string) Energy {
 	return Energy{NewTypedMeasurement("Energy", v, unit)}
 }
 
-// CopyEnergy duplicate the Energy
-func CopyEnergy(v Energy) Energy {
-	if isNil(v.ConcreteMeasurement) {
-		return Energy{}
-	}
-	return NewEnergy(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // a Force
 type Force struct {
 	*ConcreteMeasurement
@@ -430,14 +350,6 @@ func NewForce(v float64, unit string) Force {
 	return Force{NewTypedMeasurement("Force", v, unit)}
 }
 
-// CopyForce duplicate the Force
-func CopyForce(v Force) Force {
-	if isNil(v.ConcreteMeasurement) {
-		return Force{}
-	}
-	return NewForce(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // a Pressure structure
 type Pressure struct {
 	*ConcreteMeasurement
@@ -446,14 +358,6 @@ type Pressure struct {
 // make a new pressure in Pascals
 func NewPressure(v float64, unit string) Pressure {
 	return Pressure{NewTypedMeasurement("Pressure", v, unit)}
-}
-
-// CopyPressure duplicate the Pressure
-func CopyPressure(v Pressure) Pressure {
-	if isNil(v.ConcreteMeasurement) {
-		return Pressure{}
-	}
-	return NewPressure(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 // defines a concentration unit
@@ -528,14 +432,6 @@ func NewSpecificHeatCapacity(v float64, unit string) SpecificHeatCapacity {
 	return SpecificHeatCapacity{NewTypedMeasurement("SpecificHeatCapacity", v, unit)}
 }
 
-// CopySpecificHeatCapacity duplicate the SpecificHeatCapacity
-func CopySpecificHeatCapacity(v SpecificHeatCapacity) SpecificHeatCapacity {
-	if isNil(v.ConcreteMeasurement) {
-		return SpecificHeatCapacity{}
-	}
-	return NewSpecificHeatCapacity(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 // a structure which defines a density
 type Density struct {
 	*ConcreteMeasurement
@@ -544,14 +440,6 @@ type Density struct {
 // make a new density structure in SI units
 func NewDensity(v float64, unit string) Density {
 	return Density{NewTypedMeasurement("Density", v, unit)}
-}
-
-// CopyDensity duplicate the Density
-func CopyDensity(v Density) Density {
-	if isNil(v.ConcreteMeasurement) {
-		return Density{}
-	}
-	return NewDensity(v.RawValue(), v.Unit().PrefixedSymbol())
 }
 
 type FlowRate struct {
@@ -564,14 +452,6 @@ func NewFlowRate(v float64, unit string) FlowRate {
 	return FlowRate{NewTypedMeasurement("FlowRate", v, unit)}
 }
 
-// CopyFlowRate duplicate the FlowRate
-func CopyFlowRate(v FlowRate) FlowRate {
-	if isNil(v.ConcreteMeasurement) {
-		return FlowRate{}
-	}
-	return NewFlowRate(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 type Velocity struct {
 	*ConcreteMeasurement
 }
@@ -582,32 +462,6 @@ func NewVelocity(v float64, unit string) Velocity {
 	return Velocity{NewTypedMeasurement("Velocity", v, unit)}
 }
 
-// CopyVelocity duplicate the Velocity
-func CopyVelocity(v Velocity) Velocity {
-	if isNil(v.ConcreteMeasurement) {
-		return Velocity{}
-	}
-	return NewVelocity(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
-type Acceleration struct {
-	*ConcreteMeasurement
-}
-
-// NewAcceleration create a new acceleration with the given units which will
-// be looked up in the global unit registry
-func NewAcceleration(v float64, unit string) Acceleration {
-	return Acceleration{NewTypedMeasurement("Acceleration", v, unit)}
-}
-
-// CopyAcceleration duplicate the Acceleration
-func CopyAcceleration(v Acceleration) Acceleration {
-	if isNil(v.ConcreteMeasurement) {
-		return Acceleration{}
-	}
-	return NewAcceleration(v.RawValue(), v.Unit().PrefixedSymbol())
-}
-
 type Rate struct {
 	*ConcreteMeasurement
 }
@@ -616,34 +470,10 @@ func NewRate(v float64, unit string) (r Rate, err error) {
 	return Rate{NewTypedMeasurement("Rate", v, unit)}, nil
 }
 
-// CopyRate duplicate the Rate
-func CopyRate(v Rate) Rate {
-	if isNil(v.ConcreteMeasurement) {
-		return Rate{}
-	}
-	if r, err := NewRate(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
-		panic(err)
-	} else {
-		return r
-	}
-}
-
 type Voltage struct {
 	*ConcreteMeasurement
 }
 
 func NewVoltage(value float64, unit string) (Voltage, error) {
 	return Voltage{NewTypedMeasurement("Voltage", value, unit)}, nil
-}
-
-// CopyVoltage duplicate the Voltage
-func CopyVoltage(v Voltage) Voltage {
-	if isNil(v.ConcreteMeasurement) {
-		return Voltage{}
-	}
-	if v, err := NewVoltage(v.RawValue(), v.Unit().PrefixedSymbol()); err != nil {
-		panic(err)
-	} else {
-		return v
-	}
 }

--- a/antha/anthalib/wunit/wdimension_test.go
+++ b/antha/anthalib/wunit/wdimension_test.go
@@ -547,6 +547,25 @@ func TestNewVelocity(t *testing.T) {
 	})
 }
 
+func TestNewAcceleration(t *testing.T) {
+	NewMeasurementTests{
+		{
+			Value:            1.0,
+			Unit:             "mm/s^2",
+			ExpectedSIValue:  1.0e-3,
+			ExpectedBaseUnit: "m/s^2",
+			ExpectedPrefix:   "m",
+		},
+		{
+			Value:       1.0,
+			Unit:        "shane williams",
+			ShouldPanic: true,
+		},
+	}.Run(t, func(v float64, u string) Measurement {
+		return NewAcceleration(v, u)
+	})
+}
+
 func TestNewRate(t *testing.T) {
 	NewMeasurementTests{
 		{

--- a/antha/anthalib/wunit/wunit.go
+++ b/antha/anthalib/wunit/wunit.go
@@ -61,6 +61,10 @@ type Measurement interface {
 	InUnit(p PrefixedUnit) (Measurement, error)
 	// InStringUnit wrapper for InUnit which fetches the unit from the global UnitRegistry
 	InStringUnit(symbol string) (Measurement, error)
+	// MustInUnit equivalent to InUnit, but panics instead of returning error
+	MustInUnit(p PrefixedUnit) Measurement
+	// MustInStringUnit equivalent to InStringUnit, but panics instead of returning error
+	MustInStringUnit(symbol string) Measurement
 	// ConvertToString deprecated, please use ConvertTo or InStringUnit
 	ConvertToString(s string) float64
 	// IncrBy add to this measurement
@@ -136,7 +140,7 @@ func (cm *ConcreteMeasurement) SetValue(v float64) float64 {
 	return v
 }
 
-// ConvertTo return a new measurement in the new units
+// InUnit return a new measurement in the new units
 func (cm *ConcreteMeasurement) InUnit(p PrefixedUnit) (Measurement, error) {
 	if isNil(cm) {
 		return &ConcreteMeasurement{}, nil
@@ -151,12 +155,30 @@ func (cm *ConcreteMeasurement) InUnit(p PrefixedUnit) (Measurement, error) {
 	}
 }
 
+// MustInUnit return a new measurement in the new units
+func (cm *ConcreteMeasurement) MustInUnit(p PrefixedUnit) Measurement {
+	if ret, err := cm.InUnit(p); err != nil {
+		panic(err)
+	} else {
+		return ret
+	}
+}
+
 // InStringUnit return a new measurement in the new units
 func (cm *ConcreteMeasurement) InStringUnit(symbol string) (Measurement, error) {
 	if unit, err := GetGlobalUnitRegistry().GetUnit(symbol); err != nil {
 		return nil, err
 	} else {
 		return cm.InUnit(unit)
+	}
+}
+
+// MustInStringUnit return a new measurement in the new units
+func (cm *ConcreteMeasurement) MustInStringUnit(symbol string) Measurement {
+	if ret, err := cm.InStringUnit(symbol); err != nil {
+		panic(err)
+	} else {
+		return ret
 	}
 }
 


### PR DESCRIPTION
We need to allow instruction generators (e.g. PipetMaxDriver) to better report the movement behaviour of head assemblies within liquidhandlers, specifically so that:
1. we know the range of allowable velocities that can be requested (this will allow us to catch more issues at simulation time)
2. we can accurately calculate how long movement actions will take in order to improve our timing estimates

This change achieves these with MovementBehaviour, which defines the movement in each of the X, Y, and Z directions, as well as the allowable parameter ranges. It also defines the order in which movements are carried out - e.g. for gilson X and Y are moved together, the Z is moved separately - and also some actions which can occur before or after the movement, such as moving to the safety height.

Currently we only support linear acceleration and deceleration as a movement profile -- I have no evidence that this is actually the case for gilson though it seems like a likely first order estimate -- but it should be easy to add new movement profiles along with associated serialisation and deserialisation.

This change introduces just under 450 non test loc, though will hopefully lead to simplifying some tests in `microArch/simulator/liquidhandling` and the complete removal of `microArch/scheduler/liquidhandling/simulator`