### PR TITLE
bundles and workflow+params are mututally exclusive. Bundles win.

### DIFF
--- a/execute/executeutil/unmarshal.go
+++ b/execute/executeutil/unmarshal.go
@@ -58,7 +58,7 @@ func UnmarshalAll(paths ...string) (map[string]*Bundle, map[string]*workflow.Des
 // the bundlePath alone, or from both the workflowPath and
 // paramsPath. Any other combination will error.
 func UnmarshalSingle(bundlePath, workflowPath, paramsPath string) (*Bundle, error) {
-	if bundlePath != "" && workflowPath == "" && paramsPath == "" {
+	if bundlePath != "" {
 		if bundles, _, _, err := UnmarshalAll(bundlePath); err != nil {
 			return nil, err
 		} else if len(bundles) != 1 {
@@ -70,7 +70,7 @@ func UnmarshalSingle(bundlePath, workflowPath, paramsPath string) (*Bundle, erro
 			panic("Unreachable")
 		}
 
-	} else if bundlePath == "" && workflowPath != "" && paramsPath != "" {
+	} else if workflowPath != "" && paramsPath != "" {
 		if _, workflows, params, err := UnmarshalAll(workflowPath, paramsPath); err != nil {
 			return nil, err
 		} else if len(workflows) != 1 {


### PR DESCRIPTION
Bundle files were not being executed from the command line as a consequence of how defaults currently work (workflow.json & params.json are *always* present)

This PR reverts the test for exclusivity in favour of the old system, since it was making command-line invocation impossible. 