### PR TITLE
Unify LHInstruction.Add{Product,Result} into .AddOutput.

### DIFF
--- a/antha/anthalib/wtype/lhinstruction.go
+++ b/antha/anthalib/wtype/lhinstruction.go
@@ -154,12 +154,9 @@ func (inst *LHInstruction) AddInput(cmp *Liquid) {
 func (ins *LHInstruction) Generation() int {
 	return ins.gen
 }
+
 func (ins *LHInstruction) SetGeneration(i int) {
 	ins.gen = i
-}
-
-func (ins *LHInstruction) GetPlateID() string {
-	return ins.PlateID
 }
 
 func (ins *LHInstruction) SetPlateID(pid string) {

--- a/antha/anthalib/wtype/lhinstruction.go
+++ b/antha/anthalib/wtype/lhinstruction.go
@@ -32,7 +32,8 @@ func InsType(i int) string {
 type LHInstruction struct {
 	ID               string
 	BlockID          BlockID
-	Components       []*Liquid
+	Inputs           []*Liquid
+	Outputs          []*Liquid
 	ContainerType    string
 	Welladdress      string
 	PlateID          string
@@ -42,7 +43,6 @@ type LHInstruction struct {
 	Conc             float64
 	Tvol             float64
 	Majorlayoutgroup int
-	Results          []*Liquid
 	gen              int
 	PlateName        string
 	OutPlate         *Plate
@@ -56,11 +56,11 @@ func (ins LHInstruction) String() string {
 		ins.InsType(),
 		ins.Generation(),
 		ins.ID,
-		ComponentVector(ins.Components),
+		ComponentVector(ins.Inputs),
 		ins.PlateName,
 		ins.PlateID,
 		ins.Welladdress,
-		ComponentVector(ins.Results),
+		ComponentVector(ins.Outputs),
 	)
 
 	if ins.IsMixInPlace() {
@@ -82,7 +82,7 @@ func (ins *LHInstruction) Summarize(indent int) string {
 
 	switch ins.Type {
 	case LHIMIX:
-		for _, cmp := range ins.Components {
+		for _, cmp := range ins.Inputs {
 			lines = append(lines, fmt.Sprintf("%s  %s", indentStr, cmp.Summarize()))
 		}
 		if ins.Welladdress != "" && ins.OutPlate != nil {
@@ -91,8 +91,8 @@ func (ins *LHInstruction) Summarize(indent int) string {
 			lines = append(lines, fmt.Sprintf(indentStr+"to plate of type %s", ins.Platetype))
 		}
 
-		if len(ins.Results) > 0 {
-			lines = append(lines, fmt.Sprintf(indentStr+"Resulting volume: %v", ins.Results[0].Summarize()))
+		if len(ins.Outputs) > 0 {
+			lines = append(lines, fmt.Sprintf(indentStr+"Resulting volume: %v", ins.Outputs[0].Summarize()))
 		}
 
 	default:
@@ -139,12 +139,8 @@ func (inst *LHInstruction) GetID() string {
 	return inst.ID
 }
 
-func (ins *LHInstruction) AddResult(cmp *Liquid) {
-	ins.AddProduct(cmp)
-}
-
-func (inst *LHInstruction) AddProduct(cmp *Liquid) {
-	inst.Results = append(inst.Results, cmp)
+func (inst *LHInstruction) AddOutput(cmp *Liquid) {
+	inst.Outputs = append(inst.Outputs, cmp)
 }
 
 func (inst *LHInstruction) AddComponent(cmp *Liquid) {
@@ -152,7 +148,7 @@ func (inst *LHInstruction) AddComponent(cmp *Liquid) {
 		return
 	}
 
-	inst.Components = append(inst.Components, cmp)
+	inst.Inputs = append(inst.Inputs, cmp)
 }
 
 func (ins *LHInstruction) Generation() int {
@@ -175,17 +171,17 @@ func (ins *LHInstruction) IsMixInPlace() bool {
 		return false
 	}
 
-	if len(ins.Components) == 0 {
+	if len(ins.Inputs) == 0 {
 		return false
 	}
 
-	smp := ins.Components[0].IsSample()
+	smp := ins.Inputs[0].IsSample()
 	return !smp
 }
 
 //IsDummy return true if the instruction has no effect
 func (ins *LHInstruction) IsDummy() bool {
-	if ins.Type == LHIMIX && ins.IsMixInPlace() && len(ins.Components) == 1 {
+	if ins.Type == LHIMIX && ins.IsMixInPlace() && len(ins.Inputs) == 1 {
 		// instructions of this form generally mean "do nothing"
 		// but they have the effect of ensuring that the compoenent ID is changed
 		return true
@@ -195,7 +191,7 @@ func (ins *LHInstruction) IsDummy() bool {
 }
 
 func (ins *LHInstruction) HasAnyParent() bool {
-	for _, v := range ins.Components {
+	for _, v := range ins.Inputs {
 		if v.HasAnyParent() {
 			return true
 		}
@@ -205,7 +201,7 @@ func (ins *LHInstruction) HasAnyParent() bool {
 }
 
 func (ins *LHInstruction) HasParent(id string) bool {
-	for _, v := range ins.Components {
+	for _, v := range ins.Inputs {
 		if v.HasParent(id) {
 			return true
 		}
@@ -220,7 +216,7 @@ func (ins *LHInstruction) ParentString() string {
 
 	tx := make([]string, 0, 1)
 
-	for _, v := range ins.Components {
+	for _, v := range ins.Inputs {
 		//s += v.ParentID + "_"
 
 		pid := v.ParentID
@@ -252,7 +248,7 @@ func (ins *LHInstruction) NamesOfComponentsMoving() string {
 
 func (ins *LHInstruction) ComponentsMoving() []*Liquid {
 	ca := make([]*Liquid, 0)
-	for i, v := range ins.Components {
+	for i, v := range ins.Inputs {
 		// ignore component 1 if this is a mix-in-place
 		if i == 0 && ins.IsMixInPlace() {
 			continue
@@ -269,17 +265,17 @@ func (ins *LHInstruction) Wellcoords() WellCoords {
 
 func (ins *LHInstruction) AdjustVolumesBy(r float64) {
 	// each subcomponent is assumed to scale linearly
-	for _, c := range ins.Components {
+	for _, c := range ins.Inputs {
 		c.Vol *= r
 	}
-	for _, rslt := range ins.Results {
+	for _, rslt := range ins.Outputs {
 		rslt.Vol *= r
 	}
 }
 
 func (ins *LHInstruction) InputVolumeMap(addition wunit.Volume) map[string]wunit.Volume {
-	r := make(map[string]wunit.Volume, len(ins.Components))
-	for i, c := range ins.Components {
+	r := make(map[string]wunit.Volume, len(ins.Inputs))
+	for i, c := range ins.Inputs {
 		nom := c.FullyQualifiedName()
 		myAdd := addition.Dup()
 

--- a/antha/anthalib/wtype/lhinstruction.go
+++ b/antha/anthalib/wtype/lhinstruction.go
@@ -143,7 +143,7 @@ func (inst *LHInstruction) AddOutput(cmp *Liquid) {
 	inst.Outputs = append(inst.Outputs, cmp)
 }
 
-func (inst *LHInstruction) AddComponent(cmp *Liquid) {
+func (inst *LHInstruction) AddInput(cmp *Liquid) {
 	if inst == nil {
 		return
 	}

--- a/execute/intrinsics.go
+++ b/execute/intrinsics.go
@@ -152,7 +152,7 @@ func mixerPrompt(ctx context.Context, opts mixerPromptOpts) *commandInst {
 	inst.SetGeneration(opts.ComponentIn.Generation())
 	inst.Message = opts.Message
 	inst.AddOutput(opts.Component)
-	inst.AddComponent(opts.ComponentIn)
+	inst.AddInput(opts.ComponentIn)
 	inst.PassThrough[opts.ComponentIn.ID] = opts.Component
 
 	return &commandInst{

--- a/microArch/driver/liquidhandling/convertinstructions.go
+++ b/microArch/driver/liquidhandling/convertinstructions.go
@@ -322,8 +322,8 @@ func makeTransfers(parallelTransfer ParallelTransfer, cmps []*wtype.Liquid, robo
 		wellTo.WContents.Loc = wtype.IDOf(wellTo.Plate) + ":" + wellTo.Crds.FormatA1()
 
 		// make sure the wellTo gets the right ID (ultimately)
-		cmpFrom.ReplaceDaughterID(wellTo.WContents.ID, inssIn[ci].Results[0].ID)
-		wellTo.WContents.ID = inssIn[ci].Results[0].ID
+		cmpFrom.ReplaceDaughterID(wellTo.WContents.ID, inssIn[ci].Outputs[0].ID)
+		wellTo.WContents.ID = inssIn[ci].Outputs[0].ID
 		wellTo.WContents.DeclareInstance()
 		//fmt.Println("ADDED :", cmpFrom.CName, " ", cmpFrom.Vol, " TO ", dstPlate.ID, " ", wt[ci])
 	}

--- a/microArch/driver/liquidhandling/lhivector.go
+++ b/microArch/driver/liquidhandling/lhivector.go
@@ -24,7 +24,7 @@ func (lhiv LHIVector) MaxLen() int {
 		if i == nil {
 			continue
 		}
-		ll := len(i.Components)
+		ll := len(i.Inputs)
 
 		if ll > l {
 			l = ll
@@ -42,11 +42,11 @@ func (lhiv LHIVector) CompsAt(i int) []*wtype.Liquid {
 			continue
 		}
 
-		if ins == nil || i >= len(ins.Components) {
+		if ins == nil || i >= len(ins.Inputs) {
 			continue
 		}
 
-		ret[ix] = ins.Components[i].Dup()
+		ret[ix] = ins.Inputs[i].Dup()
 
 		ret[ix].Loc = ins.PlateID + ":" + ins.Welladdress
 	}

--- a/microArch/driver/liquidhandling/splitblock.go
+++ b/microArch/driver/liquidhandling/splitblock.go
@@ -37,13 +37,13 @@ func (sp SplitBlockInstruction) Generate(ctx context.Context, policy *wtype.LHPo
 
 		// if Components is a sample we'll probably want to change ParentID instead
 		// that may not work
-		robot.UpdateComponentID(ins.Components[0].ID, ins.Results[1])
+		robot.UpdateComponentID(ins.Inputs[0].ID, ins.Outputs[1])
 
 		/*
 			question over whether this is needed
 			if !ok {
-				fmt.Printf("Warning: cannot update component ID %s to %s: Not found\n", ins.Components[0].ID, ins.Results[1].ID)
-				//return []RobotInstruction{}, fmt.Errorf("Error updating component ID %s to %s: Not found", ins.Components[0].ID, ins.Results[1].ID)
+				fmt.Printf("Warning: cannot update component ID %s to %s: Not found\n", ins.Inputs[0].ID, ins.Results[1].ID)
+				//return []RobotInstruction{}, fmt.Errorf("Error updating component ID %s to %s: Not found", ins.Inputs[0].ID, ins.Results[1].ID)
 			}
 		*/
 	}

--- a/microArch/driver/liquidhandling/transferblock.go
+++ b/microArch/driver/liquidhandling/transferblock.go
@@ -189,7 +189,7 @@ type InsByComponent []*wtype.LHInstruction
 func (ibc InsByComponent) Len() int      { return len(ibc) }
 func (ibc InsByComponent) Swap(i, j int) { ibc[i], ibc[j] = ibc[j], ibc[i] }
 func (ibc InsByComponent) Less(i, j int) bool {
-	return strings.Compare(ibc[i].Results[0].CName, ibc[j].Results[0].CName) < 0
+	return strings.Compare(ibc[i].Outputs[0].CName, ibc[j].Outputs[0].CName) < 0
 }
 
 type InsByRow []*wtype.LHInstruction
@@ -239,7 +239,7 @@ func get_parallel_sets_head(ctx context.Context, head *wtype.LHHead, ins []*wtyp
 
 	for _, i := range ins {
 		// ignore empty instructions
-		if len(i.Components) == 0 {
+		if len(i.Inputs) == 0 {
 			continue
 		}
 

--- a/microArch/driver/liquidhandling/transferblock_test.go
+++ b/microArch/driver/liquidhandling/transferblock_test.go
@@ -50,7 +50,7 @@ func getMixInstructions(ctx context.Context, numInstructions int, componentNames
 		}
 
 		ins := wtype.NewLHMixInstruction()
-		ins.Components = append(ins.Components, components...)
+		ins.Inputs = append(ins.Inputs, components...)
 
 		result := components[0].Dup()
 		for j, c := range components {
@@ -59,7 +59,7 @@ func getMixInstructions(ctx context.Context, numInstructions int, componentNames
 			}
 			result.Mix(c)
 		}
-		ins.AddResult(result)
+		ins.AddOutput(result)
 
 		ret = append(ret, ins)
 	}

--- a/microArch/scheduler/liquidhandling/autoallocate_test.go
+++ b/microArch/scheduler/liquidhandling/autoallocate_test.go
@@ -31,10 +31,10 @@ func TestInputSampleAutoAllocate(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(25.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{s1, s2},
-		PlateType:  "pcrplate_skirted_riser20",
-		Address:    "A1",
-		PlateNum:   1,
+		Inputs:    []*wtype.Liquid{s1, s2},
+		PlateType: "pcrplate_skirted_riser20",
+		Address:   "A1",
+		PlateNum:  1,
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -103,10 +103,10 @@ func TestInPlaceAutoAllocate(t *testing.T) {
 	cmp2.Vol = 50.0
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{cmp1, cmp2},
-		PlateType:  "pcrplate_skirted_riser20",
-		Address:    "A1",
-		PlateNum:   1,
+		Inputs:    []*wtype.Liquid{cmp1, cmp2},
+		PlateType: "pcrplate_skirted_riser20",
+		Address:   "A1",
+		PlateNum:  1,
 	}
 
 	ins := mixer.GenericMix(mo)

--- a/microArch/scheduler/liquidhandling/determinism_test.go
+++ b/microArch/scheduler/liquidhandling/determinism_test.go
@@ -24,9 +24,9 @@ func configure_request_quitebig(ctx context.Context, rq *LHRequest) {
 		mmxs := mixer.Sample(mmx, wunit.NewVolume(21.0, "ul"))
 		ps := mixer.Sample(part, wunit.NewVolume(1.0, "ul"))
 
-		ins.AddComponent(ws)
-		ins.AddComponent(mmxs)
-		ins.AddComponent(ps)
+		ins.AddInput(ws)
+		ins.AddInput(mmxs)
+		ins.AddInput(ps)
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(43.0, "ul")))
 		ins.Outputs[0].CName = fmt.Sprintf("DANGER_MIX_%d", k)
 		ins.SetGeneration(k + 1)

--- a/microArch/scheduler/liquidhandling/determinism_test.go
+++ b/microArch/scheduler/liquidhandling/determinism_test.go
@@ -27,8 +27,8 @@ func configure_request_quitebig(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(ws)
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(43.0, "ul")))
-		ins.Results[0].CName = fmt.Sprintf("DANGER_MIX_%d", k)
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(43.0, "ul")))
+		ins.Outputs[0].CName = fmt.Sprintf("DANGER_MIX_%d", k)
 		ins.SetGeneration(k + 1)
 		rq.Add_instruction(ins)
 	}

--- a/microArch/scheduler/liquidhandling/executionhelpers.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers.go
@@ -192,11 +192,11 @@ func aggregatePromptsWithSameMessage(inss []*wtype.LHInstruction, topolGraph gra
 		for _, ar := range iar {
 			ins := wtype.NewLHPromptInstruction()
 			ins.Message = msg
-			ins.AddResult(wtype.NewLHComponent())
+			ins.AddOutput(wtype.NewLHComponent())
 			for _, ins2 := range ar {
-				for _, cmp := range ins2.Components {
-					ins.Components = append(ins.Components, cmp)
-					ins.PassThrough[cmp.ID] = ins2.Results[0]
+				for _, cmp := range ins2.Inputs {
+					ins.Inputs = append(ins.Inputs, cmp)
+					ins.PassThrough[cmp.ID] = ins2.Outputs[0]
 				}
 			}
 			insOut = append(insOut, graph.Node(ins))
@@ -268,9 +268,9 @@ func (bo ByOrdinal) Less(i, j int) bool {
 
 // TODO -- refactor this to pass robot through
 func ConvertInstruction(insIn *wtype.LHInstruction, robot *driver.LHProperties, carryvol wunit.Volume, legacyVolume bool) (insOut *driver.TransferInstruction, err error) {
-	cmps := insIn.Components
+	cmps := insIn.Inputs
 
-	lenToMake := len(insIn.Components)
+	lenToMake := len(insIn.Inputs)
 
 	if insIn.IsMixInPlace() {
 		lenToMake = lenToMake - 1
@@ -394,7 +394,7 @@ func ConvertInstruction(insIn *wtype.LHInstruction, robot *driver.LHProperties, 
 			}
 
 			// TODO -- danger here, is result definitely set?
-			wlt.WContents.ID = insIn.Results[0].ID
+			wlt.WContents.ID = insIn.Outputs[0].ID
 			wlf.WContents.AddDaughterComponent(wlt.WContents)
 
 			//fmt.Println("HERE GOES: ", i, wh[i], vf[i].ToString(), vt[i].ToString(), va[i].ToString(), pt[i], wt[i], pf[i], wf[i], pfwx[i], pfwy[i], ptwx[i], ptwy[i])

--- a/microArch/scheduler/liquidhandling/executionhelpers_test.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers_test.go
@@ -19,7 +19,7 @@ func GetMixForTest(id string, input ...*wtype.Liquid) (*wtype.LHInstruction, *wt
 	for _, ip := range input {
 		mix.AddComponent(ip)
 	}
-	mix.AddProduct(output)
+	mix.AddOutput(output)
 
 	return mix, output
 }
@@ -30,8 +30,8 @@ func GetSplitForTest(id string, input *wtype.Liquid, volume float64) (*wtype.LHI
 	moving, remaining := mixer.SplitSample(input, wunit.NewVolume(volume, "ul"))
 
 	split.AddComponent(input)
-	split.AddProduct(moving)
-	split.AddProduct(remaining)
+	split.AddOutput(moving)
+	split.AddOutput(remaining)
 
 	return split, moving, remaining
 }
@@ -45,10 +45,10 @@ func GetPromptForTest(message string, inputs ...*wtype.Liquid) (*wtype.LHInstruc
 		output.ParentID = input.ID
 		input.DaughterID = output.ID
 		ret.AddComponent(input)
-		ret.AddResult(output)
+		ret.AddOutput(output)
 	}
 
-	return ret, ret.Results
+	return ret, ret.Outputs
 }
 
 func GetLiquidForTest(name string, volume float64) *wtype.Liquid {

--- a/microArch/scheduler/liquidhandling/executionhelpers_test.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers_test.go
@@ -17,7 +17,7 @@ func GetMixForTest(id string, input ...*wtype.Liquid) (*wtype.LHInstruction, *wt
 	mix := wtype.NewLHMixInstruction()
 	mix.ID = id
 	for _, ip := range input {
-		mix.AddComponent(ip)
+		mix.AddInput(ip)
 	}
 	mix.AddOutput(output)
 
@@ -29,7 +29,7 @@ func GetSplitForTest(id string, input *wtype.Liquid, volume float64) (*wtype.LHI
 	split.ID = id
 	moving, remaining := mixer.SplitSample(input, wunit.NewVolume(volume, "ul"))
 
-	split.AddComponent(input)
+	split.AddInput(input)
 	split.AddOutput(moving)
 	split.AddOutput(remaining)
 
@@ -44,7 +44,7 @@ func GetPromptForTest(message string, inputs ...*wtype.Liquid) (*wtype.LHInstruc
 		output := input.Cp()
 		output.ParentID = input.ID
 		input.DaughterID = output.ID
-		ret.AddComponent(input)
+		ret.AddInput(input)
 		ret.AddOutput(output)
 	}
 

--- a/microArch/scheduler/liquidhandling/fixvolumes.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes.go
@@ -108,8 +108,8 @@ func updateIDsAfterSplit(values []*wtype.LHInstruction, wanted map[string]wunit.
 // update IDs in this case
 func updateIDAfterSplit(ins *wtype.LHInstruction, in, out map[string]wunit.Volume) {
 	// splits convert their first argument into their second result
-	IDin := ins.Components[0].ID
-	cmpOut := ins.Results[1]
+	IDin := ins.Inputs[0].ID
+	cmpOut := ins.Outputs[1]
 	IDout := cmpOut.ID
 
 	vol, ok := getWantVol(in, cmpOut.FullyQualifiedName())
@@ -136,9 +136,9 @@ func findUpdateInstructionVolumes(ch *IChain, wanted map[string]wunit.Volume, pl
 
 	newWanted := make(map[string]wunit.Volume)
 	for _, ins := range ch.Values {
-		//wantVol, ok := wanted[ins.Results[0].FullyQualifiedName()]
+		//wantVol, ok := wanted[ins.Outputs[0].FullyQualifiedName()]
 
-		wantVol, ok := getWantVol(wanted, ins.Results[0].FullyQualifiedName())
+		wantVol, ok := getWantVol(wanted, ins.Outputs[0].FullyQualifiedName())
 
 		if ok {
 			_, reallyOK := plates[ins.PlateID]
@@ -147,20 +147,20 @@ func findUpdateInstructionVolumes(ch *IChain, wanted map[string]wunit.Volume, pl
 				if ins.PlateID != "" {
 					panic("Cannot fix volume for plate ID without corresponding type")
 				}
-			} else if !wantInPlace(wanted, ins.Results[0].FullyQualifiedName()) {
+			} else if !wantInPlace(wanted, ins.Outputs[0].FullyQualifiedName()) {
 				wantVol.Add(plates[ins.PlateID].Rows[0][0].ResidualVolume())
 				wantVol.Subtract(carryVol)
 			}
 
-			if wantVol.GreaterThan(ins.Results[0].Volume()) {
-				if r, err := wunit.DivideVolumes(wantVol, ins.Results[0].Volume()); err != nil {
+			if wantVol.GreaterThan(ins.Outputs[0].Volume()) {
+				if r, err := wunit.DivideVolumes(wantVol, ins.Outputs[0].Volume()); err != nil {
 					return nil, err
 				} else {
 					ins.AdjustVolumesBy(r)
 				}
 
-				//delete(wanted, ins.Results[0].FullyQualifiedName())
-				deleteWantOf(wanted, ins.Results[0].FullyQualifiedName())
+				//delete(wanted, ins.Outputs[0].FullyQualifiedName())
+				deleteWantOf(wanted, ins.Outputs[0].FullyQualifiedName())
 			}
 		}
 

--- a/microArch/scheduler/liquidhandling/fixvolumes_test.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes_test.go
@@ -307,7 +307,7 @@ func TestFixVolumesSplitSample(t *testing.T) {
 
 		// make the split instruction
 		splitIns := wtype.NewLHSplitInstruction()
-		splitIns.AddComponent(c3)
+		splitIns.AddInput(c3)
 		splitIns.AddOutput(smp)
 		splitIns.AddOutput(newC3)
 		c3.Vol = 100.0

--- a/microArch/scheduler/liquidhandling/fixvolumes_test.go
+++ b/microArch/scheduler/liquidhandling/fixvolumes_test.go
@@ -28,8 +28,8 @@ func TestFixVolumes(t *testing.T) {
 	c3.DeclareInstance()
 
 	ins := wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c1, c2}
-	ins.AddResult(c3)
+	ins.Inputs = []*wtype.Liquid{c1, c2}
+	ins.AddOutput(c3)
 
 	req.LHInstructions[ins.ID] = ins
 
@@ -55,11 +55,11 @@ func TestFixVolumes(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 		c3.Vol = 100.0
-		ins.Components = []*wtype.Liquid{smp}
+		ins.Inputs = []*wtype.Liquid{smp}
 		res := getComponentWithNameVolume("water+milk", 15.0)
-		res.ParentID = ins.Components[0].ID
+		res.ParentID = ins.Inputs[0].ID
 		res.DeclareInstance()
-		ins.AddResult(res)
+		ins.AddOutput(res)
 		req.LHInstructions[ins.ID] = ins
 		inss = append(inss, ins)
 	}
@@ -78,8 +78,8 @@ func TestFixVolumes(t *testing.T) {
 
 	mix1 := req.InstructionChain.Values[0]
 
-	if mix1.Results[0].Vol != 155.0 {
-		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
+	if mix1.Outputs[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Outputs[0].Volume()))
 	}
 }
 
@@ -93,8 +93,8 @@ func TestFixVolumes2(t *testing.T) {
 	c3.DeclareInstance()
 
 	ins := wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c1, c2}
-	ins.AddResult(c3)
+	ins.Inputs = []*wtype.Liquid{c1, c2}
+	ins.AddOutput(c3)
 
 	inss := []*wtype.LHInstruction{ins}
 
@@ -127,9 +127,9 @@ func TestFixVolumes3(t *testing.T) {
 	c3.DeclareInstance()
 
 	ins := wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c1}
+	ins.Inputs = []*wtype.Liquid{c1}
 
-	ins.AddResult(c3)
+	ins.AddOutput(c3)
 	req.LHInstructions[ins.ID] = ins
 
 	ic := &IChain{
@@ -145,10 +145,10 @@ func TestFixVolumes3(t *testing.T) {
 
 	c2 := getComponentWithNameVolume("milk", 50.0)
 	ins = wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c3, c2}
+	ins.Inputs = []*wtype.Liquid{c3, c2}
 	c4 := c3.Dup()
 	c3.Mix(c2)
-	ins.AddResult(c4)
+	ins.AddOutput(c4)
 	req.LHInstructions[ins.ID] = ins
 
 	ic = &IChain{
@@ -173,11 +173,11 @@ func TestFixVolumes3(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 		c4.Vol = 100.0
-		ins.Components = []*wtype.Liquid{smp}
+		ins.Inputs = []*wtype.Liquid{smp}
 		res := getComponentWithNameVolume("water+milk", 15.0)
-		res.ParentID = ins.Components[0].ID
+		res.ParentID = ins.Inputs[0].ID
 		res.DeclareInstance()
-		ins.AddResult(res)
+		ins.AddOutput(res)
 		req.LHInstructions[ins.ID] = ins
 		inss = append(inss, ins)
 	}
@@ -196,8 +196,8 @@ func TestFixVolumes3(t *testing.T) {
 
 	mix1 := req.InstructionChain.Values[0]
 
-	if mix1.Results[0].Vol != 155.0 {
-		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
+	if mix1.Outputs[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Outputs[0].Volume()))
 	}
 }
 
@@ -210,9 +210,9 @@ func TestFixVolumes4(t *testing.T) {
 	c3.DeclareInstance()
 
 	ins := wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c1}
+	ins.Inputs = []*wtype.Liquid{c1}
 
-	ins.AddResult(c3)
+	ins.AddOutput(c3)
 	req.LHInstructions[ins.ID] = ins
 
 	ic := &IChain{
@@ -242,8 +242,8 @@ func TestFixVolumes4(t *testing.T) {
 	c5 := c4.Cp()
 	c5.Vol = 200.0
 
-	ins.Components = []*wtype.Liquid{c4}
-	ins.AddResult(c5)
+	ins.Inputs = []*wtype.Liquid{c4}
+	ins.AddOutput(c5)
 
 	ic.Child.Child = &IChain{
 		Parent: ic.Child,
@@ -271,8 +271,8 @@ func TestFixVolumesSplitSample(t *testing.T) {
 	c3.DeclareInstance()
 
 	ins := wtype.NewLHMixInstruction()
-	ins.Components = []*wtype.Liquid{c1, c2}
-	ins.AddResult(c3)
+	ins.Inputs = []*wtype.Liquid{c1, c2}
+	ins.AddOutput(c3)
 
 	req.LHInstructions[ins.ID] = ins
 
@@ -298,18 +298,18 @@ func TestFixVolumesSplitSample(t *testing.T) {
 
 		smp, newC3 := mixer.SplitSample(c3, wunit.NewVolume(15.0, "ul"))
 
-		ins.Components = []*wtype.Liquid{smp}
+		ins.Inputs = []*wtype.Liquid{smp}
 		res := getComponentWithNameVolume("water+milk", 15.0)
-		res.ParentID = ins.Components[0].ID
+		res.ParentID = ins.Inputs[0].ID
 		res.DeclareInstance()
-		ins.AddResult(res)
+		ins.AddOutput(res)
 		req.LHInstructions[ins.ID] = ins
 
 		// make the split instruction
 		splitIns := wtype.NewLHSplitInstruction()
 		splitIns.AddComponent(c3)
-		splitIns.AddProduct(smp)
-		splitIns.AddProduct(newC3)
+		splitIns.AddOutput(smp)
+		splitIns.AddOutput(newC3)
 		c3.Vol = 100.0
 		c3 = newC3
 
@@ -332,7 +332,7 @@ func TestFixVolumesSplitSample(t *testing.T) {
 
 	mix1 := req.InstructionChain.Values[0]
 
-	if mix1.Results[0].Vol != 155.0 {
-		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Results[0].Volume()))
+	if mix1.Outputs[0].Vol != 155.0 {
+		t.Errorf(fmt.Sprintf("Expected 155.0 got volume %s", mix1.Outputs[0].Volume()))
 	}
 }

--- a/microArch/scheduler/liquidhandling/getinputs.go
+++ b/microArch/scheduler/liquidhandling/getinputs.go
@@ -64,7 +64,7 @@ func GetInputs(
 			continue
 		}
 
-		for ix, component := range instruction.Components {
+		for ix, component := range instruction.Inputs {
 			// Ignore components which already exist
 			if component.IsInstance() {
 				continue

--- a/microArch/scheduler/liquidhandling/ichain.go
+++ b/microArch/scheduler/liquidhandling/ichain.go
@@ -124,10 +124,10 @@ func (it *IChain) Print() {
 		for j := 0; j < len(it.Values); j++ {
 			if it.Values[j].Type == wtype.LHIMIX {
 				fmt.Printf("MIX    %2d: %s \n", j, it.Values[j].ID)
-				for i := 0; i < len(it.Values[j].Components); i++ {
-					fmt.Print(" ", it.Values[j].Components[i].ID, ":", it.Values[j].Components[i].FullyQualifiedName(), "@", it.Values[j].Components[i].Volume().ToString(), " \n")
+				for i := 0; i < len(it.Values[j].Inputs); i++ {
+					fmt.Print(" ", it.Values[j].Inputs[i].ID, ":", it.Values[j].Inputs[i].FullyQualifiedName(), "@", it.Values[j].Inputs[i].Volume().ToString(), " \n")
 				}
-				fmt.Println(":", it.Values[j].Results[0].ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
+				fmt.Println(":", it.Values[j].Outputs[0].ID, ":", it.Values[j].Platetype, " ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
 				fmt.Printf("-- ")
 			} else if it.Values[j].Type == wtype.LHIPRM {
 				fmt.Println("PROMPT ", it.Values[j].Message, "-- ")
@@ -136,9 +136,9 @@ func (it *IChain) Print() {
 				}
 			} else if it.Values[j].Type == wtype.LHISPL {
 				fmt.Printf("SPLIT %2d: %s ", j, it.Values[j].ID)
-				fmt.Println(" ", it.Values[j].Components[0].ID, ":", it.Values[j].Components[0].FullyQualifiedName(), " : ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
-				fmt.Println(" MOVE:", it.Values[j].Results[0].ID, ":", it.Values[j].Results[0].FullyQualifiedName(), "@", it.Values[j].Results[0].Volume().ToString())
-				fmt.Println(" STAY:", it.Values[j].Results[1].ID, ":", it.Values[j].Results[1].FullyQualifiedName(), "@", it.Values[j].Results[1].Volume().ToString())
+				fmt.Println(" ", it.Values[j].Inputs[0].ID, ":", it.Values[j].Inputs[0].FullyQualifiedName(), " : ", it.Values[j].PlateName, " ", it.Values[j].Welladdress)
+				fmt.Println(" MOVE:", it.Values[j].Outputs[0].ID, ":", it.Values[j].Outputs[0].FullyQualifiedName(), "@", it.Values[j].Outputs[0].Volume().ToString())
+				fmt.Println(" STAY:", it.Values[j].Outputs[1].ID, ":", it.Values[j].Outputs[1].FullyQualifiedName(), "@", it.Values[j].Outputs[1].Volume().ToString())
 				fmt.Printf("-- \n")
 			} else {
 				fmt.Println("WTF?   ", wtype.InsType(it.Values[j].Type), "-- ")
@@ -344,7 +344,7 @@ func (bg ByResultComponent) Less(i, j int) bool {
 	}
 
 	// compare the names of the resultant components
-	c = strings.Compare(bg[i].Results[0].CName, bg[j].Results[0].CName)
+	c = strings.Compare(bg[i].Outputs[0].CName, bg[j].Outputs[0].CName)
 
 	if c != 0 {
 		return c < 0

--- a/microArch/scheduler/liquidhandling/ichain_test.go
+++ b/microArch/scheduler/liquidhandling/ichain_test.go
@@ -19,7 +19,7 @@ func TestIChain(t *testing.T) {
 		cmp.ID = k
 
 		ins.AddComponent(cmp)
-		ins.AddResult(wtype.NewLHComponent())
+		ins.AddOutput(wtype.NewLHComponent())
 		chain.Add(ins)
 	}
 }
@@ -50,9 +50,9 @@ func TestIChain2(t *testing.T) {
 		ins := wtype.NewLHMixInstruction()
 		ins.AddComponent(k)
 		if i != len(s)-1 {
-			ins.AddProduct(cmps[i+1])
+			ins.AddOutput(cmps[i+1])
 		} else {
-			ins.AddResult(wtype.NewLHComponent())
+			ins.AddOutput(wtype.NewLHComponent())
 		}
 		chain.Add(ins)
 	}
@@ -94,9 +94,9 @@ func TestIChain3(t *testing.T) {
 		ins := wtype.NewLHMixInstruction()
 		ins.AddComponent(k)
 		if i != len(s)-1 && cmp.ID != "Z" && cmp.ID != "Y" {
-			ins.AddProduct(cmps[i+1])
+			ins.AddOutput(cmps[i+1])
 		} else {
-			ins.AddProduct(wtype.NewLHComponent())
+			ins.AddOutput(wtype.NewLHComponent())
 		}
 		chain.Add(ins)
 	}

--- a/microArch/scheduler/liquidhandling/ichain_test.go
+++ b/microArch/scheduler/liquidhandling/ichain_test.go
@@ -18,7 +18,7 @@ func TestIChain(t *testing.T) {
 
 		cmp.ID = k
 
-		ins.AddComponent(cmp)
+		ins.AddInput(cmp)
 		ins.AddOutput(wtype.NewLHComponent())
 		chain.Add(ins)
 	}
@@ -48,7 +48,7 @@ func TestIChain2(t *testing.T) {
 
 	for i, k := range cmps {
 		ins := wtype.NewLHMixInstruction()
-		ins.AddComponent(k)
+		ins.AddInput(k)
 		if i != len(s)-1 {
 			ins.AddOutput(cmps[i+1])
 		} else {
@@ -92,7 +92,7 @@ func TestIChain3(t *testing.T) {
 
 	for i, k := range cmps {
 		ins := wtype.NewLHMixInstruction()
-		ins.AddComponent(k)
+		ins.AddInput(k)
 		if i != len(s)-1 && cmp.ID != "Z" && cmp.ID != "Y" {
 			ins.AddOutput(cmps[i+1])
 		} else {

--- a/microArch/scheduler/liquidhandling/input_output_state_test.go
+++ b/microArch/scheduler/liquidhandling/input_output_state_test.go
@@ -57,7 +57,7 @@ func TestBeforeVsAfterUserPlateMixInPlace(t *testing.T) {
 	pl2.Cols[0][1].AddComponent(cmp2)
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{cmp1, cmp2},
+		Inputs: []*wtype.Liquid{cmp1, cmp2},
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -126,7 +126,7 @@ func TestBeforeVsAfterUserPlateDest(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(10.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components:  []*wtype.Liquid{s1, s2},
+		Inputs:      []*wtype.Liquid{s1, s2},
 		PlateType:   "pcrplate_skirted_riser20",
 		Address:     "C1",
 		Destination: pl2,
@@ -171,7 +171,7 @@ func TestBeforeVsAfterUserPlateAutoDest(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(10.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{s1, s2},
+		Inputs: []*wtype.Liquid{s1, s2},
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -230,10 +230,10 @@ func TestBeforeVsAfterUserPlate(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(10.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{s1, s2},
-		PlateType:  "pcrplate_skirted_riser20",
-		Address:    "C1",
-		PlateNum:   1,
+		Inputs:    []*wtype.Liquid{s1, s2},
+		PlateType: "pcrplate_skirted_riser20",
+		Address:   "C1",
+		PlateNum:  1,
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -290,7 +290,7 @@ func TestBeforeVsAfterMixInPlace(t *testing.T) {
 	cmp2.Vol = 50.0
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{cmp1, cmp2},
+		Inputs: []*wtype.Liquid{cmp1, cmp2},
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -336,7 +336,7 @@ func TestBeforeVsAfterAutoAllocateDest(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(25.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{s1, s2},
+		Inputs: []*wtype.Liquid{s1, s2},
 	}
 
 	ins := mixer.GenericMix(mo)
@@ -374,10 +374,10 @@ func TestBeforeVsAfterAutoAllocate(t *testing.T) {
 	s2 := mixer.Sample(cmp2, wunit.NewVolume(25.0, "ul"))
 
 	mo := mixer.MixOptions{
-		Components: []*wtype.Liquid{s1, s2},
-		PlateType:  "pcrplate_skirted_riser20",
-		Address:    "A1",
-		PlateNum:   1,
+		Inputs:    []*wtype.Liquid{s1, s2},
+		PlateType: "pcrplate_skirted_riser20",
+		Address:   "A1",
+		PlateNum:  1,
 	}
 
 	ins := mixer.GenericMix(mo)

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -224,23 +224,23 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 			// as the input
 			// set pass throughs
 
-			for i := 0; i < len(v.Components); i++ {
-				v.PassThrough[v.Components[i].ID].Loc = v.Components[i].Loc
+			for i := 0; i < len(v.Inputs); i++ {
+				v.PassThrough[v.Inputs[i].ID].Loc = v.Inputs[i].Loc
 			}
 			continue
 		} else if v.Type == wtype.LHISPL {
 			// similar to the above, just ensure the results both have the right location set
-			v.Results[0].Loc = v.Components[0].Loc
-			v.Results[1].Loc = v.Components[0].Loc
+			v.Outputs[0].Loc = v.Inputs[0].Loc
+			v.Outputs[1].Loc = v.Inputs[0].Loc
 		}
 
-		lkp[v.ID] = make([]*wtype.Liquid, 0, 1) //v.Result
-		lk2[v.Results[0].ID] = v.ID
+		lkp[v.ID] = make([]*wtype.Liquid, 0, 1) //v.Output
+		lk2[v.Outputs[0].ID] = v.ID
 	}
 
 	for _, id := range order {
 		v := request.LHInstructions[id]
-		for _, c := range v.Components {
+		for _, c := range v.Inputs {
 			// if this component has the same ID
 			// as the result of another instruction
 			// we map it in
@@ -253,7 +253,7 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 		}
 
 		// now we put the actual result in
-		lkp[v.ID] = append(lkp[v.ID], v.Results[0])
+		lkp[v.ID] = append(lkp[v.ID], v.Outputs[0])
 	}
 
 	sampletracker := sampletracker.GetSampleTracker()
@@ -391,22 +391,22 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 			// and now it should indeed be set
 
 			// really?
-			if len(v.Components) == 0 {
+			if len(v.Inputs) == 0 {
 				continue
 			}
 
-			if v.Components[0].PlateLocation().ID == "" {
-				addr, ok := st.GetLocationOf(v.Components[0].ID)
+			if v.Inputs[0].PlateLocation().ID == "" {
+				addr, ok := st.GetLocationOf(v.Inputs[0].ID)
 
 				if !ok {
-					err := wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("MIX IN PLACE WITH NO LOCATION SET FOR %s", v.Components[0].Name()))
+					err := wtype.LHError(wtype.LH_ERR_DIRE, fmt.Sprintf("MIX IN PLACE WITH NO LOCATION SET FOR %s", v.Inputs[0].Name()))
 					return s, m, err
 				}
 
-				v.Components[0].Loc = addr
+				v.Inputs[0].Loc = addr
 			}
 
-			addr := v.Components[0].Loc
+			addr := v.Inputs[0].Loc
 			tx := strings.Split(addr, ":")
 
 			// do we know about the plate?
@@ -421,7 +421,7 @@ func get_and_complete_assignments(request *LHRequest, order []string, s []PlateC
 			request.LHInstructions[k].SetPlateID(tx[0])
 			request.LHInstructions[k].Platetype = lookUp.Type
 			request.LHInstructions[k].OutPlate = lookUp
-			request.LHInstructions[k].Results[0].Loc = addr
+			request.LHInstructions[k].Outputs[0].Loc = addr
 
 			// same as condition 1 except we get the plate id somewhere else
 			i := defined(tx[0], s)

--- a/microArch/scheduler/liquidhandling/lhrequest.go
+++ b/microArch/scheduler/liquidhandling/lhrequest.go
@@ -107,8 +107,8 @@ func (req *LHRequest) GetSolutionsFromInputPlates() (map[string][]*wtype.Liquid,
 			continue
 		}
 		if ins.IsMixInPlace() {
-			if !ins.Components[0].PlateLocation().IsZero() {
-				uniques[ins.Components[0].PlateLocation()] = ins.Components[0]
+			if !ins.Inputs[0].PlateLocation().IsZero() {
+				uniques[ins.Inputs[0].PlateLocation()] = ins.Inputs[0]
 			}
 			//else {
 			// this will be autoallocated

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -115,7 +115,7 @@ func configure_request_simple(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(ws)
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -135,7 +135,7 @@ func configure_request_total_volume(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(ws)
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -155,7 +155,7 @@ func configure_request_bigger(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(ws)
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -170,7 +170,7 @@ func configureMultiChannelTestRequest(ctx context.Context, rq *LHRequest) {
 
 		ins.AddComponent(ws)
 
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -221,7 +221,7 @@ func configureTransferRequestForZTest(policyName string, transferVol wunit.Volum
 		}
 		expectedProduct.SetName(policyName)
 
-		ins.AddProduct(expectedProduct)
+		ins.AddOutput(expectedProduct)
 
 		rq.Add_instruction(ins)
 	}
@@ -247,7 +247,7 @@ func configureSingleChannelTestRequest(ctx context.Context, rq *LHRequest) {
 
 		ins.AddComponent(ws)
 
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -290,7 +290,7 @@ func configureTransferRequestMutliSamplesTest(policyName string, samples ...*wty
 		sample.SetPolicyName(wtype.PolicyName(policyName))
 
 		ins.AddComponent(sample)
-		ins.AddProduct(GetComponentForTest(ctx, "water", sample.Volume()))
+		ins.AddOutput(GetComponentForTest(ctx, "water", sample.Volume()))
 
 		if !it.Valid() {
 			return nil, errors.New("out of space on input plate")
@@ -340,7 +340,7 @@ func configure_request_overfilled(ctx context.Context, rq *LHRequest) {
 		ins.AddComponent(ws)
 		ins.AddComponent(mmxs)
 		ins.AddComponent(ps)
-		ins.AddProduct(GetComponentForTest(ctx, "water", wunit.NewVolume(340.0, "ul")))
+		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(340.0, "ul")))
 		rq.Add_instruction(ins)
 	}
 
@@ -982,7 +982,7 @@ func TestEP3Negative(t *testing.T) {
 
 	//make one volume of one instruction negative
 	for _, ins := range rq.LHInstructions {
-		cmp := ins.Components[0]
+		cmp := ins.Inputs[0]
 		cmp.Vol = -1.0
 		break
 	}
@@ -1006,7 +1006,7 @@ func TestEP3WrongResult(t *testing.T) {
 
 	//make one of the results wrong
 	for _, ins := range rq.LHInstructions {
-		ins.Results[0].Vol = 299792458.0
+		ins.Outputs[0].Vol = 299792458.0
 		break
 	}
 	rq.InputPlatetypes = append(rq.InputPlatetypes, GetPlateForTest())
@@ -1029,7 +1029,7 @@ func TestEP3WrongTotalVolume(t *testing.T) {
 
 	//set an invalid total volume for one of the instructions
 	for _, ins := range rq.LHInstructions {
-		for _, cmp := range ins.Components {
+		for _, cmp := range ins.Inputs {
 			if cmp.Tvol > 0.0 {
 				cmp.Tvol = 5.0
 			}
@@ -1087,10 +1087,10 @@ func TestEP3DummyInstruction(t *testing.T) {
 
 	//add a dummy instruction for each instruction
 	for _, ins := range rq.LHInstructions {
-		for _, cmp := range ins.Results {
-			mix := mixer.GenericMix(mixer.MixOptions{Components: []*wtype.Liquid{cmp}})
+		for _, cmp := range ins.Outputs {
+			mix := mixer.GenericMix(mixer.MixOptions{Inputs: []*wtype.Liquid{cmp}})
 			if !mix.IsDummy() {
-				t.Fatalf("failed to make a dummy instruction: mix.Components[0].IsSample() = %t, cmp.IsSample() = %t", mix.Components[0].IsSample(), cmp.IsSample())
+				t.Fatalf("failed to make a dummy instruction: mix.Inputs[0].IsSample() = %t, cmp.IsSample() = %t", mix.Inputs[0].IsSample(), cmp.IsSample())
 			}
 			rq.Add_instruction(mix)
 		}
@@ -1223,18 +1223,18 @@ func TestPlateIDMap(t *testing.T) {
 func getTestSplitSample(component *wtype.Liquid, volume float64) *wtype.LHInstruction {
 	ret := wtype.NewLHSplitInstruction()
 
-	ret.Components = append(ret.Components, component.Dup())
+	ret.Inputs = append(ret.Inputs, component.Dup())
 	cmpMoving, cmpStaying := mixer.SplitSample(component, wunit.NewVolume(volume, "ul"))
 
-	ret.Results = append(ret.Results, cmpMoving, cmpStaying)
+	ret.Outputs = append(ret.Outputs, cmpMoving, cmpStaying)
 
 	return ret
 }
 
 func getTestMix(components []*wtype.Liquid, address string) *wtype.LHInstruction {
 	mix := mixer.GenericMix(mixer.MixOptions{
-		Components: components,
-		Address:    address,
+		Inputs:  components,
+		Address: address,
 	})
 
 	mx := 0
@@ -1244,8 +1244,8 @@ func getTestMix(components []*wtype.Liquid, address string) *wtype.LHInstruction
 		}
 	}
 	mix.SetGeneration(mx)
-	mix.Results[0].SetGeneration(mx + 1)
-	mix.Results[0].DeclareInstance()
+	mix.Outputs[0].SetGeneration(mx + 1)
+	mix.Outputs[0].DeclareInstance()
 
 	return mix
 }
@@ -1271,9 +1271,9 @@ func TestSplitSampleMultichannel(t *testing.T) {
 
 			split := getTestSplitSample(lastStock, 20.0)
 
-			mix := getTestMix([]*wtype.Liquid{split.Results[0], diluentSample}, wc.FormatA1())
+			mix := getTestMix([]*wtype.Liquid{split.Outputs[0], diluentSample}, wc.FormatA1())
 
-			lastStock = mix.Results[0]
+			lastStock = mix.Outputs[0]
 
 			instructions = append(instructions, mix, split)
 		}

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -112,9 +112,9 @@ func configure_request_simple(ctx context.Context, rq *LHRequest) {
 		mmxs := mixer.Sample(mmx, wunit.NewVolume(8.0, "ul"))
 		ps := mixer.Sample(part, wunit.NewVolume(1.0, "ul"))
 
-		ins.AddComponent(ws)
-		ins.AddComponent(mmxs)
-		ins.AddComponent(ps)
+		ins.AddInput(ws)
+		ins.AddInput(mmxs)
+		ins.AddInput(ps)
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
@@ -132,9 +132,9 @@ func configure_request_total_volume(ctx context.Context, rq *LHRequest) {
 		mmxs := mixer.Sample(mmx, wunit.NewVolume(8.0, "ul"))
 		ps := mixer.Sample(part, wunit.NewVolume(1.0, "ul"))
 
-		ins.AddComponent(ws)
-		ins.AddComponent(mmxs)
-		ins.AddComponent(ps)
+		ins.AddInput(ws)
+		ins.AddInput(mmxs)
+		ins.AddInput(ps)
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
@@ -152,9 +152,9 @@ func configure_request_bigger(ctx context.Context, rq *LHRequest) {
 		mmxs := mixer.Sample(mmx, wunit.NewVolume(8.0, "ul"))
 		ps := mixer.Sample(part, wunit.NewVolume(1.0, "ul"))
 
-		ins.AddComponent(ws)
-		ins.AddComponent(mmxs)
-		ins.AddComponent(ps)
+		ins.AddInput(ws)
+		ins.AddInput(mmxs)
+		ins.AddInput(ps)
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(17.0, "ul")))
 		rq.Add_instruction(ins)
 	}
@@ -168,7 +168,7 @@ func configureMultiChannelTestRequest(ctx context.Context, rq *LHRequest) {
 		ins := wtype.NewLHMixInstruction()
 		ws := mixer.Sample(water, wunit.NewVolume(50.0, "ul"))
 
-		ins.AddComponent(ws)
+		ins.AddInput(ws)
 
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
 		rq.Add_instruction(ins)
@@ -211,7 +211,7 @@ func configureTransferRequestForZTest(policyName string, transferVol wunit.Volum
 		ins := wtype.NewLHMixInstruction()
 		ws := mixer.Sample(liq, transferVol)
 
-		ins.AddComponent(ws)
+		ins.AddInput(ws)
 
 		expectedProduct := GetComponentForTest(ctx, "water", transferVol)
 
@@ -245,7 +245,7 @@ func configureSingleChannelTestRequest(ctx context.Context, rq *LHRequest) {
 		ins := wtype.NewLHMixInstruction()
 		ws := mixer.Sample(water, wunit.NewVolume(50.0, "ul"))
 
-		ins.AddComponent(ws)
+		ins.AddInput(ws)
 
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(50, "ul")))
 		rq.Add_instruction(ins)
@@ -289,7 +289,7 @@ func configureTransferRequestMutliSamplesTest(policyName string, samples ...*wty
 
 		sample.SetPolicyName(wtype.PolicyName(policyName))
 
-		ins.AddComponent(sample)
+		ins.AddInput(sample)
 		ins.AddOutput(GetComponentForTest(ctx, "water", sample.Volume()))
 
 		if !it.Valid() {
@@ -337,9 +337,9 @@ func configure_request_overfilled(ctx context.Context, rq *LHRequest) {
 		mmxs := mixer.Sample(mmx, wunit.NewVolume(160.0, "ul"))
 		ps := mixer.Sample(part, wunit.NewVolume(20.0, "ul"))
 
-		ins.AddComponent(ws)
-		ins.AddComponent(mmxs)
-		ins.AddComponent(ps)
+		ins.AddInput(ws)
+		ins.AddInput(mmxs)
+		ins.AddInput(ps)
 		ins.AddOutput(GetComponentForTest(ctx, "water", wunit.NewVolume(340.0, "ul")))
 		rq.Add_instruction(ins)
 	}

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -115,7 +115,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 			if ins.Type != wtype.LHIMIX {
 				continue
 			}
-			tx := strings.Split(ins.Results[0].Loc, ":")
+			tx := strings.Split(ins.Outputs[0].Loc, ":")
 
 			if len(tx) == 2 {
 				pa := tx[0]

--- a/microArch/scheduler/liquidhandling/solution_setup.go
+++ b/microArch/scheduler/liquidhandling/solution_setup.go
@@ -59,7 +59,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 
 	// -- migrate this to chains of dependent instructions
 	for _, instruction := range instructions {
-		components := instruction.Components
+		components := instruction.Inputs
 
 		// we need to identify the concentration components
 		// and the total volume components, if we have
@@ -222,7 +222,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 	newInstructions := make(map[string]*wtype.LHInstruction, len(instructions))
 
 	for _, instruction := range instructions {
-		components := instruction.Components
+		components := instruction.Inputs
 		arrCncs := make([]*wtype.Liquid, 0, len(components))
 		arrTvol := make([]*wtype.Liquid, 0, len(components))
 		arrSvol := make([]*wtype.Liquid, 0, len(components))
@@ -280,7 +280,7 @@ func solution_setup(request *LHRequest, prms *liquidhandling.LHProperties) (map[
 
 		// finally we replace the components in this instruction
 
-		instruction.Components = arrFinalComponents
+		instruction.Inputs = arrFinalComponents
 
 		// and put the new instruction in the array
 

--- a/microArch/scheduler/liquidhandling/tgraph.go
+++ b/microArch/scheduler/liquidhandling/tgraph.go
@@ -62,7 +62,7 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 	res := make(map[string]*wtype.LHInstruction, len(inss))
 	for _, ins := range inss {
 		if ins.Type == wtype.LHIMIX {
-			res[ins.Results[0].ID] = ins
+			res[ins.Outputs[0].ID] = ins
 		} else if ins.Type == wtype.LHIPRM {
 			// we use passthrough instead
 			for _, cmp := range ins.PassThrough {
@@ -71,7 +71,7 @@ func resultCmpMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 		} else if ins.Type == wtype.LHISPL {
 			// Splits need to go after the use of result 0
 			// and before the use of result 1
-			res[ins.Results[1].ID] = ins
+			res[ins.Outputs[1].ID] = ins
 		}
 	}
 
@@ -82,7 +82,7 @@ func cmpInsMap(inss []*wtype.LHInstruction) map[string]*wtype.LHInstruction {
 	res := make(map[string]*wtype.LHInstruction, len(inss))
 	for _, ins := range inss {
 		if ins.Type == wtype.LHIMIX {
-			for _, c := range ins.Components {
+			for _, c := range ins.Inputs {
 				res[c.ID] = ins
 			}
 		} else if ins.Type == wtype.LHIPRM {
@@ -105,7 +105,7 @@ func getEdges(n *wtype.LHInstruction, resultMap, cmpMap map[string]*wtype.LHInst
 
 	if n.Type == wtype.LHISPL {
 		// cmpMap answers the question "which instruction *uses* this?"
-		cmp := n.Results[0]
+		cmp := n.Outputs[0]
 
 		var lhi *wtype.LHInstruction
 		var ok bool
@@ -123,7 +123,7 @@ func getEdges(n *wtype.LHInstruction, resultMap, cmpMap map[string]*wtype.LHInst
 	// we make this backwards since it's easier to say where something's coming from than where
 	// it's going to
 
-	for _, cmp := range n.Components {
+	for _, cmp := range n.Inputs {
 		// resultMap answers the question "which instruction *makes* this?"
 		// for samples we need to ask for the parent component
 		var lhi *wtype.LHInstruction

--- a/microArch/scheduler/liquidhandling/tgraph_test.go
+++ b/microArch/scheduler/liquidhandling/tgraph_test.go
@@ -17,7 +17,7 @@ func TestTGraph(t *testing.T) {
 		ins := wtype.NewLHMixInstruction()
 		cmpOut := wtype.NewLHComponent()
 		ins.AddComponent(cmpIn)
-		ins.AddProduct(cmpOut)
+		ins.AddOutput(cmpOut)
 		tIns = append(tIns, ins)
 		cmpIn = cmpOut
 	}
@@ -77,15 +77,15 @@ func TestTGraphSplit(t *testing.T) {
 	ins := wtype.NewLHMixInstruction()
 
 	ins.AddComponent(moving)
-	ins.AddProduct(cmpOut)
+	ins.AddOutput(cmpOut)
 	tIns = append(tIns, ins)
 
 	// split
 	ins = wtype.NewLHSplitInstruction()
 	ins.AddComponent(cmpOut)
 
-	ins.AddProduct(moving)
-	ins.AddProduct(remaining)
+	ins.AddOutput(moving)
+	ins.AddOutput(remaining)
 
 	tIns = append(tIns, ins)
 
@@ -94,7 +94,7 @@ func TestTGraphSplit(t *testing.T) {
 	ins = wtype.NewLHMixInstruction()
 
 	ins.AddComponent(remaining)
-	ins.AddProduct(wtype.NewLHComponent())
+	ins.AddOutput(wtype.NewLHComponent())
 	tIns = append(tIns, ins)
 
 	tgraph, err := MakeTGraph(tIns)

--- a/microArch/scheduler/liquidhandling/tgraph_test.go
+++ b/microArch/scheduler/liquidhandling/tgraph_test.go
@@ -16,7 +16,7 @@ func TestTGraph(t *testing.T) {
 	for k := 0; k < 10; k++ {
 		ins := wtype.NewLHMixInstruction()
 		cmpOut := wtype.NewLHComponent()
-		ins.AddComponent(cmpIn)
+		ins.AddInput(cmpIn)
 		ins.AddOutput(cmpOut)
 		tIns = append(tIns, ins)
 		cmpIn = cmpOut
@@ -76,13 +76,13 @@ func TestTGraphSplit(t *testing.T) {
 	// mix
 	ins := wtype.NewLHMixInstruction()
 
-	ins.AddComponent(moving)
+	ins.AddInput(moving)
 	ins.AddOutput(cmpOut)
 	tIns = append(tIns, ins)
 
 	// split
 	ins = wtype.NewLHSplitInstruction()
-	ins.AddComponent(cmpOut)
+	ins.AddInput(cmpOut)
 
 	ins.AddOutput(moving)
 	ins.AddOutput(remaining)
@@ -93,7 +93,7 @@ func TestTGraphSplit(t *testing.T) {
 
 	ins = wtype.NewLHMixInstruction()
 
-	ins.AddComponent(remaining)
+	ins.AddInput(remaining)
 	ins.AddOutput(wtype.NewLHComponent())
 	tIns = append(tIns, ins)
 

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -309,7 +309,7 @@ func addCustomPolicies(mixes []*wtype.LHInstruction, lhreq *planner.LHRequest) e
 	userPolicyRuleSet := wtype.NewLHPolicyRuleSet()
 
 	for _, mixInstruction := range mixes {
-		for _, component := range mixInstruction.Components {
+		for _, component := range mixInstruction.Inputs {
 			if len(component.Policy) > 0 {
 				if matchingSystemPolicy, found := allPolicies[string(component.Type)]; found {
 					mergedPolicy := mergePolicies(matchingSystemPolicy, component.Policy)


### PR DESCRIPTION
Not sure what to do about AddComponent: I'm happy to change it to AddInput, but there are 3 elements that I can find that use it (Transformation, Setup_Input_Plate, Transformation_Multi). Just fearful of changing a public API that may be used by 3rd party elements - how do we normally handle this case?

NB: this PR is entirely find and replace, with the exception of lhinstruction.go itself.

Local tests pass. Just running through antha-tester now...