### PR TITLE
[Antha-2123] store SampleTracker in context object

### DIFF
--- a/antha/anthalib/mixer/mixer.go
+++ b/antha/anthalib/mixer/mixer.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
-	"github.com/antha-lang/antha/microArch/sampletracker"
 )
 
 // SampleAll takes all of this liquid
@@ -67,10 +66,6 @@ func SplitSample(l *wtype.Liquid, v wunit.Volume) (moving, remaining *wtype.Liqu
 
 	remaining.Vol -= v.ConvertToString(remaining.Vunit)
 	remaining.ID = wtype.GetUUID()
-
-	sampletracker := sampletracker.GetSampleTracker()
-
-	sampletracker.UpdateIDOf(l.ID, remaining.ID)
 
 	return
 }

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/codegen"
 	"github.com/antha-lang/antha/inject"
+	"github.com/antha-lang/antha/microArch/sampletracker"
 	"github.com/antha-lang/antha/target"
 	"github.com/antha-lang/antha/workflow"
 )
@@ -38,7 +39,7 @@ type Opt struct {
 
 // Run is a simple entrypoint for one-shot execution of workflows.
 func Run(parent context.Context, opt Opt) (res *Result, err error) {
-	ctx := target.WithTarget(withID(parent, opt.ID), opt.Target)
+	ctx := sampletracker.NewContext(target.WithTarget(withID(parent, opt.ID), opt.Target))
 
 	w, err := workflow.New(workflow.Opt{FromDesc: opt.Workflow})
 	if err != nil {

--- a/execute/intrinsics.go
+++ b/execute/intrinsics.go
@@ -22,7 +22,8 @@ type commandInst struct {
 	Command *ast.Command
 }
 
-// SetInputPlate notifies the planner about an input plate
+// SetInputPlate Indicate to the scheduler the the contents of the plate is user
+// supplied. This modifies the argument to mark each well as such.
 func SetInputPlate(ctx context.Context, plate *wtype.Plate) {
 	sampletracker.FromContext(ctx).SetInputPlate(plate)
 }

--- a/microArch/driver/liquidhandling/lhproperties.go
+++ b/microArch/driver/liquidhandling/lhproperties.go
@@ -36,7 +36,6 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/inventory"
 	"github.com/antha-lang/antha/microArch/logger"
-	"github.com/antha-lang/antha/microArch/sampletracker"
 )
 
 // describes a liquid handler, its capabilities and current state
@@ -684,49 +683,6 @@ func (lhp *LHProperties) AddWashTo(pos string, wash *wtype.Plate) bool {
 	lhp.PosLookup[pos] = wash.ID
 	lhp.PlateIDLookup[wash.ID] = pos
 	return true
-}
-
-func GetLocTox(cmp *wtype.Liquid) ([]string, error) {
-	// try the cmp's own loc
-
-	if cmp.Loc != "" {
-		return strings.Split(cmp.Loc, ":"), nil
-	} else {
-		// try the ID of the thing
-
-		tx, err := getSTLocTox(cmp.ID)
-
-		if err == nil {
-			return tx, err
-		}
-
-		// now try its parent
-
-		tx, err = getSTLocTox(cmp.ParentID)
-
-		if err == nil {
-			return tx, err
-		}
-	}
-
-	return []string{}, fmt.Errorf("No location found")
-}
-
-func getSTLocTox(ID string) ([]string, error) {
-	st := sampletracker.GetSampleTracker()
-	loc, ok := st.GetLocationOf(ID)
-
-	if !ok {
-		return []string{}, fmt.Errorf("No location found")
-	}
-
-	tx := strings.Split(loc, ":")
-
-	if len(tx) == 2 {
-		return tx, nil
-	} else {
-		return []string{}, fmt.Errorf("No location found")
-	}
 }
 
 func (lhp *LHProperties) InputSearchPreferences() []string {

--- a/microArch/sampletracker/context.go
+++ b/microArch/sampletracker/context.go
@@ -1,0 +1,21 @@
+package sampletracker
+
+import "context"
+
+type contextKey string
+
+const theContextKey contextKey = "sampletracker"
+
+// NewContext return a new context inheriting the parent with the sampletracker added
+func NewContext(parent context.Context) context.Context {
+	return context.WithValue(parent, theContextKey, NewSampleTracker())
+}
+
+// FromContext fetch the SampleTracker from the context, calls panic() if the SampleTracker has not been set
+func FromContext(ctx context.Context) *SampleTracker {
+	if st, ok := ctx.Value(theContextKey).(*SampleTracker); !ok {
+		panic("no SampleTracker in context")
+	} else {
+		return st
+	}
+}

--- a/microArch/sampletracker/sampletracker.go
+++ b/microArch/sampletracker/sampletracker.go
@@ -9,6 +9,8 @@ import (
 var stLock sync.Mutex
 var st *SampleTracker
 
+// SampleTracker record the location of components generated during element execution
+// as well as any explicitly set input plates
 type SampleTracker struct {
 	lock     sync.Mutex
 	records  map[string]string
@@ -17,12 +19,11 @@ type SampleTracker struct {
 }
 
 func newSampleTracker() *SampleTracker {
-	st := SampleTracker{
+	return &SampleTracker{
 		records:  make(map[string]string),
 		forwards: make(map[string]string),
 		plates:   make(map[string]*wtype.Plate),
 	}
-	return &st
 }
 
 func GetSampleTracker() *SampleTracker {
@@ -36,6 +37,8 @@ func GetSampleTracker() *SampleTracker {
 	return st
 }
 
+// SetInputPlate declare the given plate as an input to the experiment
+// recording the id and location of every sample in it
 func (st *SampleTracker) SetInputPlate(p *wtype.Plate) {
 	st.lock.Lock()
 	defer st.lock.Unlock()
@@ -50,8 +53,8 @@ func (st *SampleTracker) SetInputPlate(p *wtype.Plate) {
 	}
 }
 
-// this is destructive, i.e. once asked for that's it
-// that's one way to make it thread-safe...
+// GetInputPlates return a list of all input plates explicitly set during element
+// execution
 func (st *SampleTracker) GetInputPlates() []*wtype.Plate {
 	st.lock.Lock()
 	defer st.lock.Unlock()
@@ -75,6 +78,7 @@ func (st *SampleTracker) setLocationOf(ID string, loc string) {
 	st.records[ID] = loc
 }
 
+// SetLocationOf set the string encoded location of the component with the given ID
 func (st *SampleTracker) SetLocationOf(ID string, loc string) {
 	st.lock.Lock()
 	defer st.lock.Unlock()
@@ -98,6 +102,8 @@ func (st *SampleTracker) getLocationOf(ID string) (string, bool) {
 	return s, ok
 }
 
+// GetLocationOf return the string location of the component with the given ID.
+// If no such component is known, the returned location will be the empty string
 func (st *SampleTracker) GetLocationOf(ID string) (string, bool) {
 	st.lock.Lock()
 	defer st.lock.Unlock()
@@ -105,6 +111,7 @@ func (st *SampleTracker) GetLocationOf(ID string) (string, bool) {
 	return st.getLocationOf(ID)
 }
 
+// UpdateIDOf add newID as an alias for ID, such that both refer to the same location
 func (st *SampleTracker) UpdateIDOf(ID string, newID string) {
 	st.lock.Lock()
 	defer st.lock.Unlock()

--- a/microArch/sampletracker/sampletracker.go
+++ b/microArch/sampletracker/sampletracker.go
@@ -6,9 +6,6 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 )
 
-var stLock sync.Mutex
-var st *SampleTracker
-
 // SampleTracker record the location of components generated during element execution
 // as well as any explicitly set input plates
 type SampleTracker struct {
@@ -18,23 +15,12 @@ type SampleTracker struct {
 	plates   map[string]*wtype.Plate
 }
 
-func newSampleTracker() *SampleTracker {
+func NewSampleTracker() *SampleTracker {
 	return &SampleTracker{
 		records:  make(map[string]string),
 		forwards: make(map[string]string),
 		plates:   make(map[string]*wtype.Plate),
 	}
-}
-
-func GetSampleTracker() *SampleTracker {
-	stLock.Lock()
-	defer stLock.Unlock()
-
-	if st == nil {
-		st = newSampleTracker()
-	}
-
-	return st
 }
 
 // SetInputPlate declare the given plate as an input to the experiment

--- a/microArch/sampletracker/sampletracker.go
+++ b/microArch/sampletracker/sampletracker.go
@@ -12,14 +12,13 @@ type SampleTracker struct {
 	lock     sync.Mutex
 	records  map[string]string
 	forwards map[string]string
-	plates   map[string]*wtype.Plate
+	plates   []*wtype.Plate
 }
 
 func NewSampleTracker() *SampleTracker {
 	return &SampleTracker{
 		records:  make(map[string]string),
 		forwards: make(map[string]string),
-		plates:   make(map[string]*wtype.Plate),
 	}
 }
 
@@ -29,7 +28,7 @@ func (st *SampleTracker) SetInputPlate(p *wtype.Plate) {
 	st.lock.Lock()
 	defer st.lock.Unlock()
 
-	st.plates[p.ID] = p
+	st.plates = append(st.plates, p)
 
 	for _, w := range p.HWells {
 		if !w.IsEmpty() {
@@ -45,19 +44,7 @@ func (st *SampleTracker) GetInputPlates() []*wtype.Plate {
 	st.lock.Lock()
 	defer st.lock.Unlock()
 
-	var ret []*wtype.Plate
-	if len(st.plates) == 0 {
-		return ret
-	}
-	ret = make([]*wtype.Plate, 0, len(st.plates))
-
-	for _, p := range st.plates {
-		ret = append(ret, p)
-	}
-
-	st.plates = make(map[string]*wtype.Plate)
-
-	return ret
+	return st.plates
 }
 
 func (st *SampleTracker) setLocationOf(ID string, loc string) {

--- a/microArch/sampletracker/sampletracker_test.go
+++ b/microArch/sampletracker/sampletracker_test.go
@@ -63,11 +63,13 @@ func TestUpdateIDOfAfterLocation(t *testing.T) {
 	st := NewSampleTracker()
 
 	st.SetLocationOf("oldID", "Location")
+	assertLocation(t, st, "oldID", "Location", true)
 
 	assertLocation(t, st, "newID", "", false)
 	st.UpdateIDOf("oldID", "newID")
 
 	assertLocation(t, st, "newID", "Location", true)
+	assertLocation(t, st, "oldID", "Location", true)
 }
 
 func TestInputPlates(t *testing.T) {
@@ -89,20 +91,20 @@ func TestInputPlates(t *testing.T) {
 
 	st.SetInputPlate(p)
 
-	for it := wtype.NewAddressIterator(p, wtype.ColumnWise, wtype.TopToBottom, wtype.LeftToRight, false); it.Valid(); it.Next() {
-		well := p.GetChildByAddress(it.Curr()).(*wtype.LHWell)
-		if !well.IsUserAllocated() {
-			t.Errorf("Well %s wasn't marked as user allocated", well)
-		}
-
-		cmp := well.Contents()
-		assertLocation(t, st, cmp.ID, cmp.Loc, true)
-	}
-
 	if inputs := st.GetInputPlates(); len(inputs) != 1 {
 		t.Errorf("expected one input plate, got %d", len(inputs))
 	} else if inputs[0] != p {
 		t.Errorf("input plate didn't match %p != %p", inputs[0], p)
+	} else {
+		for it := wtype.NewAddressIterator(p, wtype.ColumnWise, wtype.TopToBottom, wtype.LeftToRight, false); it.Valid(); it.Next() {
+			well := inputs[0].GetChildByAddress(it.Curr()).(*wtype.LHWell)
+			if !well.IsUserAllocated() {
+				t.Errorf("Well %s wasn't marked as user allocated", well)
+			}
+
+			cmp := well.Contents()
+			assertLocation(t, st, cmp.ID, cmp.Loc, true)
+		}
 	}
 
 }

--- a/microArch/sampletracker/sampletracker_test.go
+++ b/microArch/sampletracker/sampletracker_test.go
@@ -1,0 +1,108 @@
+package sampletracker
+
+import (
+	"testing"
+
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+)
+
+func assertLocation(t *testing.T, st *SampleTracker, id string, eloc string, eok bool) {
+	if loc, ok := st.GetLocationOf(id); ok != eok || eloc != loc {
+		t.Errorf("GetLocationOf(%q) returned %q, %t - expected %q, %t", id, loc, ok, eloc, eok)
+	}
+}
+
+func getPlateForTest() *wtype.Plate {
+	cone := wtype.NewShape("cylinder", "mm", 5.5, 5.5, 20.4)
+	welltype := wtype.NewLHWell("ul", 200, 5, cone, wtype.UWellBottom, 5.5, 5.5, 20.4, 1.4, "mm")
+	return wtype.NewLHPlate("pcrplate_skirted_riser", "Unknown", 8, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 25.7}, welltype, 9, 9, 0.0, 0.0, 38.5)
+}
+
+func getLiquidForTest(name string, volume float64) *wtype.Liquid {
+	ret := wtype.NewLHComponent()
+	ret.CName = name
+	ret.Vol = volume
+
+	return ret
+}
+
+func TestLocations(t *testing.T) {
+	st := newSampleTracker()
+
+	positions := map[string]string{
+		"Who":          "First Base",
+		"What":         "Second base",
+		"I Don't Know": "Third base",
+		"Why":          "Left field",
+		"Because":      "Center field",
+		"Tomorrow":     "Pitcher",
+		"Today":        "Catcher",
+		"I Don't Care": "Shortstop",
+	}
+
+	for id, pos := range positions {
+		st.SetLocationOf(id, pos)
+	}
+
+	for id, epos := range positions {
+		assertLocation(t, st, id, epos, true)
+	}
+}
+
+func TestUpdateIDOfBeforeLocation(t *testing.T) {
+	st := newSampleTracker()
+
+	st.UpdateIDOf("oldID", "newID")
+	assertLocation(t, st, "newID", "", false)
+
+	st.SetLocationOf("oldID", "Location")
+	assertLocation(t, st, "newID", "Location", true)
+}
+
+func TestUpdateIDOfAfterLocation(t *testing.T) {
+	st := newSampleTracker()
+
+	st.SetLocationOf("oldID", "Location")
+
+	assertLocation(t, st, "newID", "", false)
+	st.UpdateIDOf("oldID", "newID")
+
+	assertLocation(t, st, "newID", "Location", true)
+}
+
+func TestInputPlates(t *testing.T) {
+	p := getPlateForTest()
+
+	for it := wtype.NewAddressIterator(p, wtype.ColumnWise, wtype.TopToBottom, wtype.LeftToRight, false); it.Valid(); it.Next() {
+		well := p.GetChildByAddress(it.Curr()).(*wtype.LHWell)
+		cmp := getLiquidForTest("water", 100.0)
+		cmp.ID = it.Curr().FormatA1()
+
+		well.SetContents(cmp)
+	}
+
+	st := newSampleTracker()
+
+	if got := len(st.GetInputPlates()); got != 0 {
+		t.Errorf("new sample tracker had %d input plates", got)
+	}
+
+	st.SetInputPlate(p)
+
+	for it := wtype.NewAddressIterator(p, wtype.ColumnWise, wtype.TopToBottom, wtype.LeftToRight, false); it.Valid(); it.Next() {
+		well := p.GetChildByAddress(it.Curr()).(*wtype.LHWell)
+		if !well.IsUserAllocated() {
+			t.Errorf("Well %s wasn't marked as user allocated", well)
+		}
+
+		cmp := well.Contents()
+		assertLocation(t, st, cmp.ID, cmp.Loc, true)
+	}
+
+	if inputs := st.GetInputPlates(); len(inputs) != 1 {
+		t.Errorf("expected one input plate, got %d", len(inputs))
+	} else if inputs[0] != p {
+		t.Errorf("input plate didn't match %p != %p", inputs[0], p)
+	}
+
+}

--- a/microArch/sampletracker/sampletracker_test.go
+++ b/microArch/sampletracker/sampletracker_test.go
@@ -27,7 +27,7 @@ func getLiquidForTest(name string, volume float64) *wtype.Liquid {
 }
 
 func TestLocations(t *testing.T) {
-	st := newSampleTracker()
+	st := NewSampleTracker()
 
 	positions := map[string]string{
 		"Who":          "First Base",
@@ -50,7 +50,7 @@ func TestLocations(t *testing.T) {
 }
 
 func TestUpdateIDOfBeforeLocation(t *testing.T) {
-	st := newSampleTracker()
+	st := NewSampleTracker()
 
 	st.UpdateIDOf("oldID", "newID")
 	assertLocation(t, st, "newID", "", false)
@@ -60,7 +60,7 @@ func TestUpdateIDOfBeforeLocation(t *testing.T) {
 }
 
 func TestUpdateIDOfAfterLocation(t *testing.T) {
-	st := newSampleTracker()
+	st := NewSampleTracker()
 
 	st.SetLocationOf("oldID", "Location")
 
@@ -81,7 +81,7 @@ func TestInputPlates(t *testing.T) {
 		well.SetContents(cmp)
 	}
 
-	st := newSampleTracker()
+	st := NewSampleTracker()
 
 	if got := len(st.GetInputPlates()); got != 0 {
 		t.Errorf("new sample tracker had %d input plates", got)

--- a/microArch/scheduler/liquidhandling/autoallocate_test.go
+++ b/microArch/scheduler/liquidhandling/autoallocate_test.go
@@ -1,19 +1,17 @@
 package liquidhandling
 
 import (
-	"context"
 	"testing"
 
 	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/inventory"
-	"github.com/antha-lang/antha/inventory/testinventory"
 	"github.com/antha-lang/antha/microArch/driver/liquidhandling"
 )
 
 func TestInputSampleAutoAllocate(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	rbt := makeGilson(ctx)
 	rq := NewLHRequest()
@@ -85,7 +83,7 @@ func testSetup(rbt *liquidhandling.LHProperties, expected map[string]float64, t 
 
 }
 func TestInPlaceAutoAllocate(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	rbt := makeGilson(ctx)
 	rq := NewLHRequest()

--- a/microArch/scheduler/liquidhandling/input_output_state_test.go
+++ b/microArch/scheduler/liquidhandling/input_output_state_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/inventory"
-	"github.com/antha-lang/antha/inventory/testinventory"
 )
 
 type initFinalCmp struct {
@@ -38,7 +37,7 @@ func getComponents(ctx context.Context, t *testing.T) (cmp1, cmp2 *wtype.Liquid)
 
 /*
 func TestBeforeVsAfterUserPlateMixInPlace(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -97,7 +96,7 @@ func TestBeforeVsAfterUserPlateMixInPlace(t *testing.T) {
 */
 
 func TestBeforeVsAfterUserPlateDest(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -158,7 +157,7 @@ func TestBeforeVsAfterUserPlateDest(t *testing.T) {
 	compareInitFinalStates(t, lh, expected)
 }
 func TestBeforeVsAfterUserPlateAutoDest(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -217,7 +216,7 @@ func TestBeforeVsAfterUserPlateAutoDest(t *testing.T) {
 }
 
 func TestBeforeVsAfterUserPlate(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -280,7 +279,7 @@ func TestBeforeVsAfterUserPlate(t *testing.T) {
 
 /*
 func TestBeforeVsAfterMixInPlace(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -326,7 +325,7 @@ func TestBeforeVsAfterMixInPlace(t *testing.T) {
 }
 */
 func TestBeforeVsAfterAutoAllocateDest(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 
@@ -364,7 +363,7 @@ func TestBeforeVsAfterAutoAllocateDest(t *testing.T) {
 }
 
 func TestBeforeVsAfterAutoAllocate(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 	rq := makeRequest()
 	lh := makeLiquidhandler(ctx)
 

--- a/microArch/scheduler/liquidhandling/input_plate_setup.go
+++ b/microArch/scheduler/liquidhandling/input_plate_setup.go
@@ -79,7 +79,7 @@ func (is InputSorter) Less(i, j int) bool {
 //OUTPUT: 	"input_plates"      -- these each have components in wells
 //		"input_assignments" -- map with arrays of assignment strings, i.e. {tea: [plate1:A:1, plate1:A:2...] }etc.
 func input_plate_setup(ctx context.Context, request *LHRequest) (*LHRequest, error) {
-	st := sampletracker.GetSampleTracker()
+	st := sampletracker.FromContext(ctx)
 	// I think this might need moving too
 	input_platetypes := request.InputPlatetypes
 

--- a/microArch/scheduler/liquidhandling/layoutagent2.go
+++ b/microArch/scheduler/liquidhandling/layoutagent2.go
@@ -161,7 +161,8 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 
 	// find existing assignments and copy into the plate_choices structure
 	// this may be because 1) the user has set the assignment 2) the assignment derives from a component
-	plate_choices, mapchoices, err := get_and_complete_assignments(request, chain.ValueIDs(), plate_choices, mapchoices)
+	st := sampletracker.FromContext(ctx)
+	plate_choices, mapchoices, err := getAndCompleteAssignments(st, request, chain.ValueIDs(), plate_choices, mapchoices)
 
 	// map choices maps layout groups to (temp)plate IDs
 
@@ -256,8 +257,6 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 		lkp[v.ID] = append(lkp[v.ID], v.Outputs[0])
 	}
 
-	sampletracker := sampletracker.GetSampleTracker()
-
 	// now map the output assignments in
 	for k, v := range request.OutputAssignments {
 		for _, id := range v {
@@ -270,10 +269,10 @@ func LayoutStage(ctx context.Context, request *LHRequest, params *liquidhandling
 
 				if ok {
 					x.Loc = remap[tx[0]] + ":" + tx[1]
-					sampletracker.SetLocationOf(x.ID, x.Loc)
+					st.SetLocationOf(x.ID, x.Loc)
 				} else {
 					x.Loc = tx[0] + ":" + tx[1]
-					sampletracker.SetLocationOf(x.ID, x.Loc)
+					st.SetLocationOf(x.ID, x.Loc)
 				}
 			}
 		}
@@ -300,11 +299,9 @@ type PlateChoice struct {
 	Output    []bool
 }
 
-func get_and_complete_assignments(request *LHRequest, order []string, s []PlateChoice, m map[string]string) ([]PlateChoice, map[string]string, error) {
+func getAndCompleteAssignments(st *sampletracker.SampleTracker, request *LHRequest, order []string, s []PlateChoice, m map[string]string) ([]PlateChoice, map[string]string, error) {
 	//s := make([]PlateChoice, 0, 3)
 	//m := make(map[int]string)
-
-	st := sampletracker.GetSampleTracker()
 
 	// inconsistent plate types will be assigned randomly!
 	x := 0
@@ -673,7 +670,6 @@ func make_plates(ctx context.Context, request *LHRequest, order []string) (map[s
 }
 
 func make_layouts(ctx context.Context, request *LHRequest, pc []PlateChoice) error {
-	//sampletracker := sampletracker.GetSampleTracker()
 	// we need to fill in the platechoice structure then
 	// transfer the info across to the solutions
 	//opa := request.OutputAssignments

--- a/microArch/scheduler/liquidhandling/layoutagent_test.go
+++ b/microArch/scheduler/liquidhandling/layoutagent_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wutil"
 	"github.com/antha-lang/antha/inventory"
-	"github.com/antha-lang/antha/inventory/testinventory"
 	"testing"
 )
 
@@ -52,7 +51,7 @@ func (self layoutAgentTest) Run(ctx context.Context, t *testing.T) {
 }
 
 func TestLayoutAgent1(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_simple(ctx, req)
@@ -67,7 +66,7 @@ func TestLayoutAgent1(t *testing.T) {
 }
 
 func TestLayoutAgent2(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_simple(ctx, req)
@@ -89,7 +88,7 @@ func TestLayoutAgent2(t *testing.T) {
 
 // a mix of specific dests and no dest
 func TestLayoutAgent3(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_simple(ctx, req)
@@ -119,7 +118,7 @@ func TestLayoutAgent3(t *testing.T) {
 }
 
 func TestLayoutAgent4(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_simple(ctx, req)
@@ -152,7 +151,7 @@ func TestLayoutAgent4(t *testing.T) {
 
 // bigger tests
 func TestLayoutAgent5(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_bigger(ctx, req)
@@ -176,7 +175,7 @@ func TestLayoutAgent5(t *testing.T) {
 }
 
 func TestLayoutAgent6(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_bigger(ctx, req)
@@ -201,7 +200,7 @@ func TestLayoutAgent6(t *testing.T) {
 }
 
 func TestLayoutAgent7(t *testing.T) {
-	ctx := testinventory.NewContext(context.Background())
+	ctx := GetContextForTest()
 
 	req := GetLHRequestForTest()
 	configure_request_simple(ctx, req)

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -179,7 +179,7 @@ func (a *Mixer) makeLhreq(ctx context.Context) (*lhreq, error) {
 
 	// add plates requested via protocol
 
-	st := sampletracker.GetSampleTracker()
+	st := sampletracker.FromContext(ctx)
 
 	parr := st.GetInputPlates()
 


### PR DESCRIPTION
Previously the SampleTracker was a global variable which prevented parallel execution/simulation of workflows. 

This PR creates a new SampleTracker stored in the context in `execute.Run` so that each thread has a different sample tracker. Each instance where the global SampleTracker was used is then replaced by fetching the sample tracker from the context. `microArch/driver/liquidhandling/GetLocTox` was removed entirely as it is no longer used.

One other change of note is that previously `antha/anthalib/mixer/mixer.SplitSample` was responsible for recording the change of ID in the SampleTracker. Since functions in `mixer` don't have access to the `context` object they can't access the SampleTracker, and so the call to SampleTracker was pushed up to `execute/SplitSample`, which is consistent with other intrinsics such as `Prompt` and `Incubate`