### PR TITLE
Overhaul ParseConcentration

### DIFF
--- a/antha/anthalib/wunit/parse.go
+++ b/antha/anthalib/wunit/parse.go
@@ -60,16 +60,26 @@ func extractLastFloat(s string) (float64, string) {
 }
 
 // extractSymbol extract the longest valid unit symbol from the left hand side
-// of the given string, returning the unit and the remaining string.
-// If no valid units are found, return "" and the entire string
+// of the given string, returning the symbol and the remaining string.
+// The symbol must either be terminated with a space (which will not be included
+// in the remainder) or the end of the string.
+// If no valid symbol is found, return "" and the entire string.
+// Examples
+//   extractSymbol("M Glucose", []string{"M"}) -> ("M", "Glucose")
+//   extractSymbol("M-Glucose", []string{"M"}) -> ("", "M-Glucose")
+//   extractSymbol("M", []string{"M"}) -> ("M", "")
 func extractSymbol(s string, validSymbols []string) (string, string) {
 	longest := ""
+	remainder := s
 	for _, v := range validSymbols {
 		if len(v) > len(longest) && strings.HasPrefix(s, v) {
-			longest = v
+			if r := s[len(v):]; strings.HasPrefix(r, " ") {
+				remainder = r
+				longest = v
+			}
 		}
 	}
-	return longest, s[len(longest):]
+	return longest, remainder
 }
 
 // extractLastSymbol extract the longest valid unit symbol from the right hand side

--- a/antha/anthalib/wunit/parse.go
+++ b/antha/anthalib/wunit/parse.go
@@ -24,6 +24,7 @@ package wunit
 
 import (
 	"strconv"
+	"strings"
 )
 
 // extractFloat extract the longest valid float from the left hand side of
@@ -33,11 +34,53 @@ func extractFloat(s string) (float64, string) {
 	var longest int
 	var ret float64
 	for i := range s {
-		if f, err := strconv.ParseFloat(s[:i], 64); err == nil {
+		if f, err := strconv.ParseFloat(s[:i+1], 64); err == nil {
+			ret = f
+			longest = i + 1
+		}
+	}
+
+	return ret, s[longest:]
+}
+
+// extractLastFloat extract the longest valid float from the right hand side of
+// the string and return the float and the remaining string.
+// If no float is found, returns zero and the entire string.
+func extractLastFloat(s string) (float64, string) {
+	longest := len(s)
+	var ret float64
+	for i := len(s) - 1; i >= 0; i-- {
+		if f, err := strconv.ParseFloat(s[i:], 64); err == nil {
 			ret = f
 			longest = i
 		}
 	}
 
-	return ret, s[longest:]
+	return ret, s[:longest]
+}
+
+// extractSymbol extract the longest valid unit symbol from the left hand side
+// of the given string, returning the unit and the remaining string.
+// If no valid units are found, return "" and the entire string
+func extractSymbol(s string, validSymbols []string) (string, string) {
+	longest := ""
+	for _, v := range validSymbols {
+		if len(v) > len(longest) && strings.HasPrefix(s, v) {
+			longest = v
+		}
+	}
+	return longest, s[len(longest):]
+}
+
+// extractLastSymbol extract the longest valid unit symbol from the right hand side
+// of the given string, returning the unit and the remaining string.
+// If no valid units are found, return "" and the entire string
+func extractLastSymbol(s string, validSymbols []string) (string, string) {
+	longest := ""
+	for _, v := range validSymbols {
+		if len(v) > len(longest) && strings.HasSuffix(s, v) {
+			longest = v
+		}
+	}
+	return longest, s[:len(s)-len(longest)]
 }

--- a/antha/anthalib/wunit/parse.go
+++ b/antha/anthalib/wunit/parse.go
@@ -47,16 +47,16 @@ func extractFloat(s string) (float64, string) {
 // the string and return the float and the remaining string.
 // If no float is found, returns zero and the entire string.
 func extractLastFloat(s string) (float64, string) {
-	longest := len(s)
+	startAt := len(s)
 	var ret float64
 	for i := len(s) - 1; i >= 0; i-- {
 		if f, err := strconv.ParseFloat(s[i:], 64); err == nil {
 			ret = f
-			longest = i
+			startAt = i
 		}
 	}
 
-	return ret, s[:longest]
+	return ret, s[:startAt]
 }
 
 // extractSymbol extract the longest valid unit symbol from the left hand side

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -54,8 +54,7 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 
 	// unit location indicated by parentheses - e.g. "Glucose (6M)"
 	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l < r {
-		inParentheses := strings.TrimSpace(s[l+1 : r])
-		value, unit := extractFloat(inParentheses)
+		value, unit := extractFloat(strings.TrimSpace(s[l+1 : r]))
 		if trimUnit := strings.TrimSpace(unit); !reg.ValidUnitForType("Concentration", trimUnit) {
 			return false, NewConcentration(0, "g/l"), s
 		} else if componentName := strings.TrimSpace(s[:l] + s[r+1:]); componentName != "" {

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -51,7 +51,6 @@ func SplitValueAndUnit(str string) (float64, string) {
 func ParseConcentration(s string) (bool, Concentration, string) {
 
 	reg := GetGlobalUnitRegistry()
-	approvedUnits := reg.ListValidUnitsForType("Concentration")
 
 	// unit location indicated by parentheses
 	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l < r {
@@ -66,11 +65,14 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 		}
 	}
 
-	// unit at left
-	value, remainder := SplitValueAndUnit(s)
-	if sym, componentName := extractSymbol(remainder, approvedUnits); sym != "" {
-		if componentName := strings.TrimSpace(componentName); componentName != "" {
-			return true, NewConcentration(value, sym), componentName
+	approvedUnits := reg.ListValidUnitsForType("Concentration")
+
+	// value and unit at left
+	if value, remainder := SplitValueAndUnit(s); len(remainder) < len(s) { // value must be given for unit at left
+		if sym, componentName := extractSymbol(remainder, approvedUnits); sym != "" {
+			if componentName := strings.TrimSpace(componentName); componentName != "" {
+				return true, NewConcentration(value, sym), componentName
+			}
 		}
 	}
 

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -52,7 +52,7 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 
 	reg := GetGlobalUnitRegistry()
 
-	// unit location indicated by parentheses
+	// unit location indicated by parentheses - e.g. "Glucose (6M)"
 	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l < r {
 		inParentheses := strings.TrimSpace(s[l+1 : r])
 		value, unit := extractFloat(inParentheses)
@@ -67,7 +67,7 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 
 	approvedUnits := reg.ListValidUnitsForType("Concentration")
 
-	// value and unit at left
+	// value and unit at left - e.g. "6M Glucose", but not "6 Glucose"
 	if value, remainder := SplitValueAndUnit(s); len(remainder) < len(s) { // value must be given for unit at left
 		if sym, componentName := extractSymbol(remainder, approvedUnits); sym != "" {
 			if componentName := strings.TrimSpace(componentName); componentName != "" {
@@ -76,7 +76,7 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 		}
 	}
 
-	// unit at right
+	// unit at right - e.g. "Glucose 6M" or "Glucose M", but not "SolutionX"
 	if sym, remainder := extractLastSymbol(s, approvedUnits); sym != "" && remainder != "" {
 		trimRemainder := strings.TrimSpace(remainder)
 		// units at the right must be preceded by either a number or a space

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -53,7 +53,7 @@ func ParseConcentration(s string) (bool, Concentration, string) {
 	reg := GetGlobalUnitRegistry()
 
 	// unit location indicated by parentheses - e.g. "Glucose (6M)"
-	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l < r {
+	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l >= 0 && l < r {
 		value, unit := extractFloat(strings.TrimSpace(s[l+1 : r]))
 		if trimUnit := strings.TrimSpace(unit); !reg.ValidUnitForType("Concentration", trimUnit) {
 			return false, NewConcentration(0, "g/l"), s

--- a/antha/anthalib/wunit/unitfromstring.go
+++ b/antha/anthalib/wunit/unitfromstring.go
@@ -26,8 +26,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/antha-lang/antha/antha/anthalib/wutil"
 )
 
 // SplitValueAndUnit splits a joined value and unit in string format into seperate typed value and unit fields.
@@ -35,173 +33,62 @@ import (
 // If a value on its own is given the unit will be returned blank, if the unit is given alone the value will be 0.0
 // valid: 10s, 10 s, 10.5s, 2.16e+04 s, 10, s
 // invalid: s 10 s10
-func SplitValueAndUnit(str string) (value float64, unit string) {
-
-	fields := strings.Fields(str)
-
-	if len(fields) == 2 {
-		if value, err := strconv.ParseFloat(fields[0], 64); err == nil {
-			return value, fields[1]
-		}
-		if value, err := strconv.Atoi(fields[0]); err == nil {
-			return float64(value), fields[1]
-		}
-	} else if len(fields) == 1 {
-		for i := 0; i < len(str); i++ {
-			if value, err := strconv.ParseFloat(str[:len(str)-i], 64); err == nil {
-				return value, str[len(str)-i:]
-			}
-		}
-	}
-	return value, str
+func SplitValueAndUnit(str string) (float64, string) {
+	value, unit := extractFloat(str)
+	return value, strings.TrimSpace(unit)
 }
 
-// Utility function to parse concentration from a component name.
-// Not currently robust to situations where the component name (without the concentration) is more than one field (e.g. ammonium sulphate) or if the component name is a concatenation of component names (e.g. 1mM Glucose + 10mM Glycerol).
-func ParseConcentration(componentname string) (containsconc bool, conc Concentration, componentNameOnly string) {
+// ParseConcentration utility to extract concentration and component name from a string.
+// Valid inputs include
+//   - "6M Glucose", "6 M Glucose"
+//   - "Glucose 6 M", "Glucose 6M"
+//   - "Glucose (M)", "Glucose M", "Glucose (6 M)"
+//   - "Glucose"
+// returns three values - a boolean which is true if the value of the concentration was set,
+// the parsed concentration, and the remaining component name.
+// if removing the concentration would leave the empty string, the component name is
+// set as the input string
+func ParseConcentration(s string) (bool, Concentration, string) {
 
 	reg := GetGlobalUnitRegistry()
 	approvedUnits := reg.ListValidUnitsForType("Concentration")
 
-	fields := strings.Fields(componentname)
-
-	if len(fields) == 1 {
-		trimmed := strings.Trim(componentname, "()")
-		value, unit := SplitValueAndUnit(trimmed)
-		if unit == componentname {
-			return false, conc, componentname
-		}
-		if !reg.ValidUnitForType("Concentration", unit) {
-			return false, conc, componentname
-		}
-		return true, NewConcentration(value, unit), componentname
-	}
-	var unitmatchlength int
-	var longestmatchedunit string
-	var valueandunit string
-	var unit string
-	var valueString string
-	var notConcFields []string
-	for _, key := range approvedUnits {
-		for i, field := range fields {
-
-			/// if value and unit are separate fields
-			if field == key && i != 0 {
-				f, err := strconv.ParseFloat(fields[i-1], 64)
-				if err == nil && f != 0 {
-					if len(key) > unitmatchlength {
-						notConcFields = make([]string, 0)
-						longestmatchedunit = key
-						unitmatchlength = len(key)
-						valueString = fields[i-1]
-						unit = field
-						valueandunit = valueString + unit
-						if (i - 1) > 0 {
-							notConcFields = append(notConcFields, fields[:i-1]...)
-						}
-						if len(fields) > i+1 {
-							notConcFields = append(notConcFields, fields[i+1:]...)
-						}
-						//break
-					}
-					// support for cases where concentration unit is given but no value
-				} else if trimmed := strings.Trim(field, "()"); trimmed == key || field == key {
-					if len(key) > unitmatchlength {
-						notConcFields = make([]string, 0)
-						longestmatchedunit = key
-						unitmatchlength = len(key)
-						valueandunit = field
-						if i > 0 {
-							notConcFields = append(notConcFields, fields[:i]...)
-						}
-						if len(fields) > i+1 {
-							notConcFields = append(notConcFields, fields[i+1:]...)
-						}
-						//break
-					}
-				}
-				// if value and unit are one joined field
-				// change this to separate number and match rest of valueandunit
-			} else if trimmed := strings.Trim(field, "()"); trimmed == key || field == key {
-				if len(key) > unitmatchlength {
-					notConcFields = make([]string, 0)
-					longestmatchedunit = key
-					unitmatchlength = len(key)
-					valueandunit = field
-					if i > 0 {
-						notConcFields = append(notConcFields, fields[:i]...)
-					}
-					if len(fields) > i+1 {
-						notConcFields = append(notConcFields, fields[i+1:]...)
-					}
-					//break
-				}
-			} else if trimmed := strings.Trim(field, "()"); looksLikeNumberAndUnit(field, key) || looksLikeNumberAndUnit(trimmed, key) {
-				if len(key) > unitmatchlength {
-					notConcFields = make([]string, 0)
-					longestmatchedunit = key
-					unitmatchlength = len(key)
-					valueandunit = field
-					if i > 0 {
-						notConcFields = append(notConcFields, fields[:i]...)
-					}
-					if len(fields) > i+1 {
-						notConcFields = append(notConcFields, fields[i+1:]...)
-					}
-					//break
-				}
-			}
+	// unit location indicated by parentheses
+	if l, r := strings.Index(s, "("), strings.LastIndex(s, ")"); l < r {
+		inParentheses := strings.TrimSpace(s[l+1 : r])
+		value, unit := extractFloat(inParentheses)
+		if trimUnit := strings.TrimSpace(unit); !reg.ValidUnitForType("Concentration", trimUnit) {
+			return false, NewConcentration(0, "g/l"), s
+		} else if componentName := strings.TrimSpace(s[:l] + s[r+1:]); componentName != "" {
+			return true, NewConcentration(value, trimUnit), componentName
+		} else {
+			return true, NewConcentration(value, trimUnit), s
 		}
 	}
 
-	componentNameOnly = strings.Join(notConcFields, " ")
-
-	// if no match, return original component name
-	if unitmatchlength == 0 {
-		return false, conc, componentname
+	// unit at left
+	value, remainder := SplitValueAndUnit(s)
+	if sym, componentName := extractSymbol(remainder, approvedUnits); sym != "" {
+		if componentName := strings.TrimSpace(componentName); componentName != "" {
+			return true, NewConcentration(value, sym), componentName
+		}
 	}
 
-	concfields := strings.Split(valueandunit, longestmatchedunit)
-
-	value, err := strconv.ParseFloat(concfields[0], 64)
-	if err != nil {
-		concfields[0] = strings.Trim(concfields[0], "()")
-		value, err = strconv.ParseFloat(concfields[0], 64)
-		if err != nil {
-			if concfields[0] == "" {
-				value = 0.0
+	// unit at right
+	if sym, remainder := extractLastSymbol(s, approvedUnits); sym != "" && remainder != "" {
+		trimRemainder := strings.TrimSpace(remainder)
+		// units at the right must be preceded by either a number or a space
+		if value, componentName := extractLastFloat(trimRemainder); len(componentName) != len(trimRemainder) || strings.HasSuffix(remainder, " ") {
+			if componentName := strings.TrimSpace(componentName); componentName != "" {
+				return true, NewConcentration(value, sym), componentName
 			} else {
-				if strings.Contains(componentname, wutil.MIXDELIMITER) {
-					return false, conc, componentname
-				} else {
-					fmt.Println("warning parsing componentname: ", componentname, ": ", err.Error())
-					return false, conc, componentname
-				}
+				return true, NewConcentration(value, sym), s
 			}
 		}
 	}
 
-	conc = NewConcentration(value, longestmatchedunit)
-	containsconc = true
-
-	return containsconc, conc, componentNameOnly
-}
-func looksLikeNumberAndUnit(testString string, targetUnit string) bool {
-	if strings.HasSuffix(testString, targetUnit) {
-		trimmed := strings.Split(testString, targetUnit)
-		if len(trimmed) == 0 {
-			return false
-		}
-		_, err := strconv.ParseFloat(trimmed[0], 64)
-		if err == nil {
-			return true
-		}
-		_, err = strconv.Atoi(trimmed[0])
-		if err == nil {
-			return true
-		}
-	}
-	return false
+	// no unit found
+	return false, NewConcentration(0, "g/l"), s
 }
 
 // ParseVolume parses a volume and valid unit (nl, ul, ml, l) in string format; handles cases where the volume is split with a space.

--- a/antha/anthalib/wunit/unitfromstring_test.go
+++ b/antha/anthalib/wunit/unitfromstring_test.go
@@ -137,6 +137,18 @@ func TestParseConcentration(t *testing.T) {
 			ComponentNameOnly: "solutionX",
 		},
 		{
+			ComponentName:     "A happy solution :-) 5 g/l",
+			ContainsConc:      true,
+			Conc:              NewConcentration(5.0, "g/l"),
+			ComponentNameOnly: "A happy solution :-)",
+		},
+		{
+			ComponentName:     "A sad solution :-( 5 g/l",
+			ContainsConc:      true,
+			Conc:              NewConcentration(5.0, "g/l"),
+			ComponentNameOnly: "A sad solution :-(",
+		},
+		{
 			ComponentName:     "solutionX (X)",
 			ContainsConc:      true,
 			Conc:              NewConcentration(0.0, "X"),

--- a/antha/anthalib/wunit/unitfromstring_test.go
+++ b/antha/anthalib/wunit/unitfromstring_test.go
@@ -173,6 +173,23 @@ func TestParseConcentration(t *testing.T) {
 			ComponentNameOnly: "1X",
 		},
 		{
+			ComponentName:     "1 MOPS pH 7",
+			ContainsConc:      false,
+			ComponentNameOnly: "1 MOPS pH 7",
+		},
+		{
+			ComponentName:     "1 MOPS pH 7 (mM)",
+			ContainsConc:      true,
+			Conc:              NewConcentration(0.0, "mM"),
+			ComponentNameOnly: "1 MOPS pH 7",
+		},
+		{
+			ComponentName:     "281 mMol/l 1 MOPS pH 7",
+			ContainsConc:      true,
+			Conc:              NewConcentration(281.0, "mM"),
+			ComponentNameOnly: "1 MOPS pH 7",
+		},
+		{
 			ComponentName:     "(1X)",
 			ContainsConc:      true,
 			Conc:              NewConcentration(1, "X"),

--- a/antha/anthalib/wunit/unitfromstring_test.go
+++ b/antha/anthalib/wunit/unitfromstring_test.go
@@ -178,6 +178,11 @@ func TestParseConcentration(t *testing.T) {
 			Conc:              NewConcentration(1, "X"),
 			ComponentNameOnly: "(1X)",
 		},
+		{
+			ComponentName:     "Magnesium Acetate",
+			ContainsConc:      false,
+			ComponentNameOnly: "Magnesium Acetate",
+		},
 	}.Run(t)
 }
 

--- a/antha/anthalib/wunit/unitfromstring_test.go
+++ b/antha/anthalib/wunit/unitfromstring_test.go
@@ -23,7 +23,6 @@
 package wunit
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -35,7 +34,6 @@ type unitFromStringTest struct {
 }
 
 func (test *unitFromStringTest) Run(t *testing.T) {
-
 	t.Run(test.ComponentName, func(t *testing.T) {
 		a, b, c := ParseConcentration(test.ComponentName)
 		if a != test.ContainsConc {
@@ -89,6 +87,12 @@ func TestParseConcentration(t *testing.T) {
 			ContainsConc:      true,
 			Conc:              NewConcentration(5.0, "g/L"),
 			ComponentNameOnly: "Glucose",
+		},
+		{
+			ComponentName:     "1 % w/v C6",
+			ContainsConc:      true,
+			Conc:              NewConcentration(1.0, "% w/v"),
+			ComponentNameOnly: "C6",
 		},
 		{
 			ComponentName:     "1mM/l C6",
@@ -231,62 +235,60 @@ type valueAndUnitTest struct {
 	valueandunit string
 }
 
-var volandUnitTests = []valueAndUnitTest{
-	{
-		value:        10,
-		unit:         "s",
-		valueandunit: "10s",
-	},
-	{
-		value:        10,
-		unit:         "s",
-		valueandunit: "10 s",
-	},
-	{
-		value:        10,
-		unit:         "",
-		valueandunit: "10",
-	},
+func (test *valueAndUnitTest) Run(t *testing.T) {
+	t.Run(test.valueandunit, func(t *testing.T) {
+		if val, unit := SplitValueAndUnit(test.valueandunit); val != test.value || unit != test.unit {
+			t.Errorf("expected = %f, %q; got = %f, %q;", test.value, test.unit, val, unit)
+		}
+	})
+}
 
-	{
-		value:        0,
-		unit:         "s",
-		valueandunit: "s",
-	},
-	{
-		value:        10.9090,
-		unit:         "ms",
-		valueandunit: "10.9090ms",
-	},
-	{
-		value:        2.16e+04,
-		unit:         "s",
-		valueandunit: "2.16e+04 s",
-	},
+type valueAndUnitTests []valueAndUnitTest
 
-	{
-		value:        2.16e+04,
-		unit:         "/s",
-		valueandunit: "2.16e+04 /s",
-	},
+func (tests valueAndUnitTests) Run(t *testing.T) {
+	for _, test := range tests {
+		test.Run(t)
+	}
 }
 
 func TestSplitValueAndUnit(t *testing.T) {
-	for _, test := range volandUnitTests {
-		val, unit := SplitValueAndUnit(test.valueandunit)
-		if val != test.value {
-			t.Error(
-				"for", fmt.Sprintf("%+v", test), "\n",
-				"Expected:", test.value, "\n",
-				"Got:", val, "\n",
-			)
-		}
-		if unit != test.unit {
-			t.Error(
-				"for", fmt.Sprintf("%+v", test), "\n",
-				"Expected:", test.unit, "\n",
-				"Got:", unit, "\n",
-			)
-		}
-	}
+	valueAndUnitTests{
+		{
+			value:        10,
+			unit:         "s",
+			valueandunit: "10s",
+		},
+		{
+			value:        10,
+			unit:         "s",
+			valueandunit: "10 s",
+		},
+		{
+			value:        10,
+			unit:         "",
+			valueandunit: "10",
+		},
+
+		{
+			value:        0,
+			unit:         "s",
+			valueandunit: "s",
+		},
+		{
+			value:        10.9090,
+			unit:         "ms",
+			valueandunit: "10.9090ms",
+		},
+		{
+			value:        2.16e+04,
+			unit:         "s",
+			valueandunit: "2.16e+04 s",
+		},
+
+		{
+			value:        2.16e+04,
+			unit:         "/s",
+			valueandunit: "2.16e+04 /s",
+		},
+	}.Run(t)
 }

--- a/antha/anthalib/wunit/wunit.go
+++ b/antha/anthalib/wunit/wunit.go
@@ -344,7 +344,8 @@ func (cm *ConcreteMeasurement) EqualTo(m Measurement) bool {
 	if isNil(cm) {
 		return false
 	} else if rhs, err := m.InUnit(cm.Unit()); err != nil {
-		panic(err)
+		// the units are incompatible, so the values cannot be equal
+		return false
 	} else {
 		dif := math.Abs(rhs.RawValue() - cm.RawValue())
 		epsilon := math.Nextafter(1, 2) - 1


### PR DESCRIPTION
I noticed that simulation times were really large for workflows with lots of DOE. CPU profiling indicated that we were spending a great deal of time (circa 50% of total in some cases) in `wunit.ParseConcentration`. 

This change simplifies the implementation of the function and more clearly defines its behaviour, extending the test cases to cover units like "% w/v" in the process.

For the bundle used during testing (the one attached to [ANTHA-1947](https://synthace.atlassian.net/browse/ANTHA-1947) ) simulation time is reduced from
```
real	2m4.954s
user	3m10.324s
sys	0m5.274s
```
to 
```
real	0m29.050s
user	0m43.102s
sys	0m3.842s
```

I'm running antha-tester right now, will post results