### PR TITLE
travis to go 1.11, gofmt -s appropriate to this change in 2 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.11
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y libglpk-dev protobuf-compiler

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Assemblydesign.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Assemblydesign.go
@@ -626,11 +626,11 @@ var customStandard = AssemblyStandard{
 		"Level0": {
 			Enzyme: BsaI,
 			PartOverhangs: map[string]StandardOverhangs{
-				"L1Uadaptor":                  {"GTCG", "GGAG"}, // adaptor to add SapI sites to clone into level 1 vector
-				"L1Uadaptor + Pro":            {"GTCG", "TTTT"}, // adaptor to add SapI sites to clone into level 1 vector
-				"L1Uadaptor + Pro(MoClo)":     {"GTCG", "TACT"}, // original MoClo overhang of TACT
-				"L1Uadaptor + Pro + 5U":       {"GTCG", "CCAT"}, // adaptor to add SapI sites to clone into level 1 vector
-				"L1Uadaptor + Pro + 5U + NT1": {"GTCG", "TATG"}, // adaptor to add SapI sites to clone into level 1 vector
+				"L1Uadaptor":                        {"GTCG", "GGAG"}, // adaptor to add SapI sites to clone into level 1 vector
+				"L1Uadaptor + Pro":                  {"GTCG", "TTTT"}, // adaptor to add SapI sites to clone into level 1 vector
+				"L1Uadaptor + Pro(MoClo)":           {"GTCG", "TACT"}, // original MoClo overhang of TACT
+				"L1Uadaptor + Pro + 5U":             {"GTCG", "CCAT"}, // adaptor to add SapI sites to clone into level 1 vector
+				"L1Uadaptor + Pro + 5U + NT1":       {"GTCG", "TATG"}, // adaptor to add SapI sites to clone into level 1 vector
 				"Pro":                               {"GGAG", "TTTT"}, //changed from MoClo TACT to TTTT to conform with Protein Paintbox
 				"5U":                                {"TTTT", "CCAT"}, //changed from MoClo TACT to TTTT to conform with Protein Paintbox
 				"5U(f)":                             {"TTTT", "CCAT"}, //changed from MoClo TACT to TTTT to conform with Protein Paintbox
@@ -647,19 +647,19 @@ var customStandard = AssemblyStandard{
 				"CDS1 + 3U(MoClo)":                  {"TATG", "GGTA"}, //original MoClo overhang of GGTA
 				"CDS1 ns":                           {"TATG", "TTCG"}, //changed AATG to TATG to work with Kosuri paper RBSs
 				"CDS1 + CT + 3U + Ter + L1Dadaptor": {"TATG", "TAAT"}, //changed AATG to TATG to work with Kosuri paper RBSs
-				"NT2":                        {"TATG", "AGGT"}, //changed AATG to TATG to work with Kosuri paper RBSs
-				"SP":                         {"TATG", "AGGT"}, //changed AATG to TATG to work with Kosuri paper RBSs
-				"CDS2 ns":                    {"AGGT", "TTCG"},
-				"CDS2":                       {"AGGT", "GCTT"},
-				"CT":                         {"TTCG", "GCTT"},
-				"3U":                         {"GCTT", "CCCC"}, //changed GGTA to CCCC to conform with Protein Paintbox
-				"Ter":                        {"CCCC", "CGCT"},
-				"3U + Ter":                   {"GCTT", "CGCT"},
-				"3U + Ter + L1Dadaptor":      {"GCTT", "TAAT"},
-				"CT + 3U + Ter + L1Dadaptor": {"TTCG", "TAAT"},
-				"L1Dadaptor":                 {"CGCT", "TAAT"},
-				"Ter + L1Dadaptor":           {"CCCC", "TAAT"},
-				"Ter(MoClo) + L1Dadaptor":    {"GGTA", "TAAT"},
+				"NT2":                               {"TATG", "AGGT"}, //changed AATG to TATG to work with Kosuri paper RBSs
+				"SP":                                {"TATG", "AGGT"}, //changed AATG to TATG to work with Kosuri paper RBSs
+				"CDS2 ns":                           {"AGGT", "TTCG"},
+				"CDS2":                              {"AGGT", "GCTT"},
+				"CT":                                {"TTCG", "GCTT"},
+				"3U":                                {"GCTT", "CCCC"}, //changed GGTA to CCCC to conform with Protein Paintbox
+				"Ter":                               {"CCCC", "CGCT"},
+				"3U + Ter":                          {"GCTT", "CGCT"},
+				"3U + Ter + L1Dadaptor":             {"GCTT", "TAAT"},
+				"CT + 3U + Ter + L1Dadaptor":        {"TTCG", "TAAT"},
+				"L1Dadaptor":                        {"CGCT", "TAAT"},
+				"Ter + L1Dadaptor":                  {"CCCC", "TAAT"},
+				"Ter(MoClo) + L1Dadaptor":           {"GGTA", "TAAT"},
 			},
 			EntryVectorEnds: StandardOverhangs{"TAAT", "GTCG"},
 		},

--- a/antha/anthalib/mixer/subcomponents_test.go
+++ b/antha/anthalib/mixer/subcomponents_test.go
@@ -191,7 +191,7 @@ var serialTests []serialComponentlistTest = []serialComponentlistTest{
 		},
 		mixedList: wtype.ComponentList{
 			Components: map[string]wunit.Concentration{
-				"LB": wunit.NewConcentration(0, "g/L"),
+				"LB":                   wunit.NewConcentration(0, "g/L"),
 				"Ferric Chloride (uM)": wunit.NewConcentration(10, "mM"),
 				"Glucose (g/L)":        wunit.NewConcentration(5.01, "g/L"),
 			},

--- a/cmd/antha/cmd/run.go
+++ b/cmd/antha/cmd/run.go
@@ -172,9 +172,9 @@ func (a *runOpt) Run() error {
 	}
 
 	rout, err := execute.Run(ctx, execute.Opt{
-		Target:   t.Target,
-		Workflow: &bundle.Desc,
-		Params:   &bundle.RawParams,
+		Target:                     t.Target,
+		Workflow:                   &bundle.Desc,
+		Params:                     &bundle.RawParams,
 		TransitionalReadLocalFiles: true,
 	})
 	if err != nil {


### PR DESCRIPTION
differences between gofmt in 1.9 vs 1.11 cause linting failures; this prevents those issues