### PR TITLE
Fix/missing volumes litres

### DIFF
--- a/antha/anthalib/wtype/componentvector.go
+++ b/antha/anthalib/wtype/componentvector.go
@@ -124,17 +124,17 @@ func (cv ComponentVector) getLocTok(x int) []string {
 	return ret
 }
 
-func (cv ComponentVector) Equal(cv2 ComponentVector) bool {
-	if len(cv) != len(cv2) {
+func (cv1 ComponentVector) Equal(cv2 ComponentVector) bool {
+	if len(cv1) != len(cv2) {
 		return false
 	}
 
-	for i := 0; i < len(cv); i++ {
-		if cv[i] != nil && cv2[i] != nil {
-			if !cv[i].EqualTypeVolumeID(cv2[i]) {
+	for i := 0; i < len(cv1); i++ {
+		if cv1[i] != nil && cv2[i] != nil {
+			if !cv1[i].EqualTypeVolumeID(cv2[i]) {
 				return false
 			}
-		} else if !(cv[i] == nil && cv2[i] == nil) {
+		} else if !(cv1[i] == nil && cv2[i] == nil) {
 			return false
 		}
 	}

--- a/antha/anthalib/wtype/componentvector.go
+++ b/antha/anthalib/wtype/componentvector.go
@@ -123,3 +123,21 @@ func (cv ComponentVector) getLocTok(x int) []string {
 
 	return ret
 }
+
+func (cv ComponentVector) Equal(cv2 ComponentVector) bool {
+	if len(cv) != len(cv2) {
+		return false
+	}
+
+	for i := 0; i < len(cv); i++ {
+		if cv[i] != nil && cv2[i] != nil {
+			if !cv[i].EqualTypeVolumeID(cv2[i]) {
+				return false
+			}
+		} else if !(cv[i] == nil && cv2[i] == nil) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/antha/anthalib/wtype/componentvector_test.go
+++ b/antha/anthalib/wtype/componentvector_test.go
@@ -1,0 +1,18 @@
+package wtype
+
+import (
+	"testing"
+)
+
+func TestComponentVectorEqual(t *testing.T) {
+	cv := ComponentVector{
+		&Liquid{},
+		&Liquid{},
+		nil,
+		&Liquid{},
+	}
+
+	if !cv.Equal(cv) {
+		t.Errorf("Vector must be equal to itself")
+	}
+}

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -1134,14 +1134,14 @@ func (cmp Liquid) FullyQualifiedName() string {
 	}
 }
 
-func (l *Liquid) EqualTypeVolume(l2 *Liquid) bool {
-	return l.CName == l2.CName && l.Volume().EqualTo(l2.Volume())
+func (l1 *Liquid) EqualTypeVolume(l2 *Liquid) bool {
+	return l1.CName == l2.CName && l1.Volume().EqualTo(l2.Volume())
 }
 
-func (l *Liquid) EqualTypeVolumeID(l2 *Liquid) bool {
-	if !l.EqualTypeVolume(l2) {
+func (l1 *Liquid) EqualTypeVolumeID(l2 *Liquid) bool {
+	if !l1.EqualTypeVolume(l2) {
 		return false
 	}
 
-	return l.ID == l2.ID
+	return l1.ID == l2.ID
 }

--- a/antha/anthalib/wtype/liquid.go
+++ b/antha/anthalib/wtype/liquid.go
@@ -1133,3 +1133,15 @@ func (cmp Liquid) FullyQualifiedName() string {
 		return cmp.Kind()
 	}
 }
+
+func (l *Liquid) EqualTypeVolume(l2 *Liquid) bool {
+	return l.CName == l2.CName && l.Volume().EqualTo(l2.Volume())
+}
+
+func (l *Liquid) EqualTypeVolumeID(l2 *Liquid) bool {
+	if !l.EqualTypeVolume(l2) {
+		return false
+	}
+
+	return l.ID == l2.ID
+}

--- a/antha/anthalib/wtype/liquid_test.go
+++ b/antha/anthalib/wtype/liquid_test.go
@@ -166,3 +166,60 @@ func TestDeepCopySubComponents(t *testing.T) {
 	}
 
 }
+
+func TestEqualTypeVolume(t *testing.T) {
+	l := &Liquid{}
+
+	if !l.EqualTypeVolume(l) {
+		t.Errorf("Liquid must equal itself")
+	}
+
+	l2 := &Liquid{
+		CName: "which",
+	}
+
+	if l2.EqualTypeVolume(l) {
+		t.Errorf("Liquids with non-equal types must not report equal types")
+	}
+
+	l3 := &Liquid{
+		Vol:   50.0,
+		Vunit: "ul",
+	}
+
+	if l3.EqualTypeVolume(l) {
+		t.Errorf("Liquids with non-equal volumes must not report equal volumes")
+	}
+
+	l4 := &Liquid{
+		CName: "a",
+		Vol:   50.0,
+		Vunit: "ul",
+	}
+
+	l5 := l4.Dup()
+
+	if !l5.EqualTypeVolume(l4) {
+		t.Errorf("Liquids must be of equal type and volume after Dup()")
+	}
+
+	l6 := &Liquid{
+		CName: "b",
+		Vol:   50.0,
+		Vunit: "ul",
+		ID:    "thisismyID",
+	}
+
+	l7 := l6.Dup()
+
+	if !l7.EqualTypeVolumeID(l6) {
+		t.Errorf("Liquids must preserve IDs after Dup()")
+	}
+
+	l8 := l7.Cp()
+
+	if l8.EqualTypeVolumeID(l7) {
+		t.Errorf("Liquids must not preserve IDs after Cp()")
+	}
+
+}

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -369,7 +369,10 @@ func updateDests(dst wtype.ComponentVector, match wtype.Match) wtype.ComponentVe
 	for i := 0; i < len(match.M); i++ {
 		if match.M[i] != -1 {
 			dst[i].Vol -= match.Vols[i].ConvertToString(dst[i].Vunit)
-			if dst[i].Vol < 0.0001 {
+
+			vv := wunit.NewVolume(dst[i].Vol, dst[i].Vunit)
+
+			if vv.MustInStringUnit("ul").RawValue() < 0.0001 {
 				dst[i].Vol = 0.0
 			}
 		}

--- a/microArch/driver/liquidhandling/getComponents.go
+++ b/microArch/driver/liquidhandling/getComponents.go
@@ -370,9 +370,7 @@ func updateDests(dst wtype.ComponentVector, match wtype.Match) wtype.ComponentVe
 		if match.M[i] != -1 {
 			dst[i].Vol -= match.Vols[i].ConvertToString(dst[i].Vunit)
 
-			vv := wunit.NewVolume(dst[i].Vol, dst[i].Vunit)
-
-			if vv.MustInStringUnit("ul").RawValue() < 0.0001 {
+			if dst[i].Volume().MustInStringUnit("ul").RawValue() < 0.0001 {
 				dst[i].Vol = 0.0
 			}
 		}

--- a/microArch/driver/liquidhandling/getComponents_test.go
+++ b/microArch/driver/liquidhandling/getComponents_test.go
@@ -28,9 +28,9 @@ func TestUpdateDests(t *testing.T) {
 	testCases := []testCase{
 		{
 			Name:     "Regression1 - Don't lose relatively small transfers",
-			Cmps:     wtype.ComponentVector{&wtype.Liquid{Vol: 0.01, Vunit: "l"}},
-			Match:    wtype.Match{M: []int{0}, Vols: []wunit.Volume{wunit.NewVolume(0.00999, "l")}},
-			Expected: wtype.ComponentVector{&wtype.Liquid{Vol: 0.00001, Vunit: "l"}},
+			Cmps:     wtype.ComponentVector{&wtype.Liquid{Vol: 0.01, Vunit: "El"}},
+			Match:    wtype.Match{M: []int{0}, Vols: []wunit.Volume{wunit.NewVolume(0.00999, "El")}},
+			Expected: wtype.ComponentVector{&wtype.Liquid{Vol: 0.00001, Vunit: "El"}},
 		},
 		{
 			Name:     "Positive - round very small volumes down to zero",

--- a/microArch/driver/liquidhandling/getComponents_test.go
+++ b/microArch/driver/liquidhandling/getComponents_test.go
@@ -1,0 +1,46 @@
+package liquidhandling
+
+import (
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wunit"
+	"testing"
+)
+
+type testCase struct {
+	Name     string
+	Cmps     wtype.ComponentVector
+	Match    wtype.Match
+	Expected wtype.ComponentVector
+}
+
+func (tc testCase) Run(t *testing.T) {
+
+	got := updateDests(tc.Cmps, tc.Match)
+
+	if !got.Equal(tc.Expected) {
+		t.Errorf("%s: Expected %v got %v", tc.Name, tc.Expected, got)
+	}
+}
+
+func TestUpdateDests(t *testing.T) {
+	// func updateDests(dst wtype.ComponentVector, match wtype.Match) wtype.ComponentVector
+
+	testCases := []testCase{
+		{
+			Name:     "Regression1 - Don't lose relatively small transfers",
+			Cmps:     wtype.ComponentVector{&wtype.Liquid{Vol: 0.01, Vunit: "l"}},
+			Match:    wtype.Match{M: []int{0}, Vols: []wunit.Volume{wunit.NewVolume(0.00999, "l")}},
+			Expected: wtype.ComponentVector{&wtype.Liquid{Vol: 0.00001, Vunit: "l"}},
+		},
+		{
+			Name:     "Positive - round very small volumes down to zero",
+			Cmps:     wtype.ComponentVector{&wtype.Liquid{Vol: 0.1, Vunit: "ul"}},
+			Match:    wtype.Match{M: []int{0}, Vols: []wunit.Volume{wunit.NewVolume(0.9999999, "ul")}},
+			Expected: wtype.ComponentVector{&wtype.Liquid{Vol: 0.0, Vunit: "ul"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t)
+	}
+}


### PR DESCRIPTION
 This PR fixes an issue where some logic meant to prevent trivial volumes being requested (by rounding very small remainders down to zero) ignored the units of the volumes and therefore considered any volume with an absolute value of <0.0001 as trivial *regardless of unit*. 

This caused an issue when volumes were originally specified in larger-than-normal units, such as litres.

I have added a check to take units into account and some tests to show intended behaviour and test for regression. I've also run this against antha-tester with no problems. 