### PR TITLE
Fix issue with splitting mixed instruction layers

### DIFF
--- a/microArch/scheduler/liquidhandling/executionhelpers.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers.go
@@ -49,9 +49,9 @@ func convertToInstructionChain(sortedNodes []graph.Node, tg graph.Graph) *IChain
 		addToIChain(ic, n, tg)
 	}
 
-	// we need to ensure that splits and mixes are kept separate by fissioning nodes
+	// we need to ensure that splits, prompts and mixes are kept separate by fissioning nodes
 
-	ic.SplitMixedNodes()
+	ic = ic.SplitMixedNodes()
 
 	return ic
 }
@@ -210,7 +210,6 @@ func aggregatePromptsWithSameMessage(inss []*wtype.LHInstruction, topolGraph gra
 //buildInstructionChain guarantee all nodes are dependency-ordered
 //in order to aggregate without introducing cycles
 func buildInstructionChain(unsorted map[string]*wtype.LHInstruction) (*IChain, error) {
-
 	unsortedSlice := make([]*wtype.LHInstruction, 0, len(unsorted))
 	for _, instruction := range unsorted {
 		unsortedSlice = append(unsortedSlice, instruction)

--- a/microArch/scheduler/liquidhandling/executionhelpers_test.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers_test.go
@@ -93,7 +93,7 @@ func (self *setOutputOrderTest) Run(t *testing.T) {
 	sorted := ichain.GetOrderedLHInstructions()
 	outputOrder := make([]string, 0, len(sorted))
 	for _, ins := range sorted {
-		//for promts check the message as the ID is overwritten
+		//for prompts check the message as the ID is overwritten
 		if ins.Type == wtype.LHIPRM { //LHIPRM == prompt instruction
 			outputOrder = append(outputOrder, ins.Message)
 		} else {


### PR DESCRIPTION
This PR fixes a bug whereby instruction nodes which contain prompt and split instructions caused a runtime error by extending the existing method for splitting up mixed  nodes to include this case. 

I've run this with the test bundles and it checks out fine. 