### PR TITLE
Antha-2292: only attempt all part combinations for <= than 5 part assemblies

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
@@ -506,7 +506,7 @@ func Assemblysimulator(assemblyparameters Assemblyparameters) (s string, success
 	var failedAssemblies []DigestedFragment
 	var plasmidProducts []wtype.DNASequence
 
-	if len(assemblyparameters.Partsinorder) > 6 {
+	if len(assemblyparameters.Partsinorder) > 4 {
 		failedAssemblies, plasmidProducts, _, err = JoinXNumberOfParts(assemblyparameters.Vector, assemblyparameters.Partsinorder, enzyme)
 	} else {
 		failedAssemblies, plasmidProducts, err = FindAllAssemblyProducts(assemblyparameters.Vector, assemblyparameters.Partsinorder, enzyme)

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
@@ -486,7 +486,18 @@ func (assemblyParameters Assemblyparameters) Insert(result wtype.DNASequence) (i
 	return insert, fmt.Errorf("no insert sequences found which are present in assembled sequence %s. ", result.Name())
 }
 
-// Assemblysimulator simulate assembly of Assemblyparameters: returns status, number of correct assemblies, any restriction sites found, new DNA Sequences and an error.
+const thresholdForOnlyTestingPartsInSpecifiedOrder int = 4
+
+/*
+Assemblysimulator simulate assembly of Assemblyparameters: returns status, number of correct assemblies, any restriction sites found, new DNA Sequences and an error.
+
+Currently the more comprehensive assembly validation function (FindAllAssemblyProducts) tests all part order combinations;
+this is thorough and more powerful at detecting potential mis assemblies but is very computationally expensive hence
+there exists a threshold number of parts above which the simpler assembly validation (JoinXNumberOfParts)
+will occur which will only test the validity of the assembly in the part order specified.
+
+The threshold is currently set to 5 part assemblies (4 parts + vector) which is 5! (120) part order combinations.
+*/
 func Assemblysimulator(assemblyparameters Assemblyparameters) (s string, successfulassemblies int, sites []RestrictionSites, newDNASequences []wtype.DNASequence, err error) {
 
 	// fetch enzyme properties
@@ -506,7 +517,7 @@ func Assemblysimulator(assemblyparameters Assemblyparameters) (s string, success
 	var failedAssemblies []DigestedFragment
 	var plasmidProducts []wtype.DNASequence
 
-	if len(assemblyparameters.Partsinorder) > 4 {
+	if len(assemblyparameters.Partsinorder) > thresholdForOnlyTestingPartsInSpecifiedOrder {
 		failedAssemblies, plasmidProducts, _, err = JoinXNumberOfParts(assemblyparameters.Vector, assemblyparameters.Partsinorder, enzyme)
 	} else {
 		failedAssemblies, plasmidProducts, err = FindAllAssemblyProducts(assemblyparameters.Vector, assemblyparameters.Partsinorder, enzyme)

--- a/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
+++ b/antha/AnthaStandardLibrary/Packages/enzymes/Ligation.go
@@ -489,7 +489,7 @@ func (assemblyParameters Assemblyparameters) Insert(result wtype.DNASequence) (i
 const thresholdForOnlyTestingPartsInSpecifiedOrder int = 4
 
 /*
-Assemblysimulator simulate assembly of Assemblyparameters: returns status, number of correct assemblies, any restriction sites found, new DNA Sequences and an error.
+Assemblysimulator simulates assembly of Assemblyparameters: returns status, number of correct assemblies, any restriction sites found, new DNA Sequences and an error.
 
 Currently the more comprehensive assembly validation function (FindAllAssemblyProducts) tests all part order combinations;
 this is thorough and more powerful at detecting potential mis assemblies but is very computationally expensive hence


### PR DESCRIPTION
Currently the more comprehensive assembly validation function (`FindAllAssemblyProducts`) tests all part order combinations; this is thorough and more powerful at detecting potential mis assemblies but is very computationally expensive hence there exists a threshold number of parts above which the simpler assembly validation will occur which will only test the validity of the assembly in the part order specified. 

The threshold is currently set to 7 part assemblies (6 parts + vector) which is 7! (5040) part order combinations. In practice this is too computationally expensive to run on multiple assemblies; this PR therefore reduces the threshold to 5 part assemblies (4 parts + vector, 5! = 120) which we know simulates fine with the more comprehensive assembly validation. 