### PR TITLE
Give inst.Output a concrete type as it's only used in one place.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -37,7 +37,7 @@ type Command struct {
 	From     []Node      // Inputs
 	Requests []Request   // Requirements for device selection
 	Inst     interface{} // Command-specific data
-	Output   interface{} // Output from compilation
+	Output   []Inst      // Output from compilation
 }
 
 // NodeString implements graph pretty printing

--- a/ast/inst.go
+++ b/ast/inst.go
@@ -1,9 +1,47 @@
 package ast
 
 import (
+	"context"
+
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"github.com/antha-lang/antha/driver"
 )
+
+// An Inst is a instruction
+type Inst interface {
+	// Device that this instruction was generated for
+	Device() Device
+	// DependsOn returns instructions that this instruction depends on
+	DependsOn() []Inst
+	// SetDependsOn sets to the list of dependencies to only the args
+	SetDependsOn(...Inst)
+	// AppendDependsOn adds to the args to the existing list of dependencies
+	AppendDependsOn(...Inst)
+}
+
+// A Device is a scheduling plugin
+type Device interface {
+	CanCompile(Request) bool    // Can this device compile this request
+	MoveCost(from Device) int64 // A non-negative cost to move to this device
+
+	// Compile produces a single-entry, single-exit DAG of instructions where
+	// insts[0] is the entry point and insts[len(insts)-1] is the exit point
+	Compile(ctx context.Context, cmds []Node) (insts []Inst, err error)
+}
+
+type Insts []Inst
+
+// SequentialOrder takes a slice of instructions and modifies them
+// in-place, resetting to sequential dependencies.
+func (insts Insts) SequentialOrder() {
+	if len(insts) > 1 {
+		prev := insts[0]
+		for _, cur := range insts[1:] {
+			cur.SetDependsOn(prev)
+			prev = cur
+		}
+	}
+}
 
 // An IncubateInst is a high-level command to incubate a component
 type IncubateInst struct {

--- a/cmd/antha/pretty/run.go
+++ b/cmd/antha/pretty/run.go
@@ -6,13 +6,14 @@ import (
 	"io"
 	"strings"
 
+	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/execute"
 	"github.com/antha-lang/antha/target"
 	"github.com/antha-lang/antha/target/auto"
 	"golang.org/x/net/context"
 )
 
-func shouldWait(inst target.Inst) bool {
+func shouldWait(inst ast.Inst) bool {
 	switch inst.(type) {
 	case *target.Run:
 		return true

--- a/cmd/antha/pretty/timeline.go
+++ b/cmd/antha/pretty/timeline.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/execute"
 	"github.com/antha-lang/antha/graph"
 	"github.com/antha-lang/antha/target"
@@ -24,7 +25,7 @@ func Timeline(out io.Writer, a *auto.Auto, result *execute.Result) error {
 		lines = append(lines, fmt.Sprintf("== Round %2d:\n", round))
 		var next []graph.Node
 		for _, n := range dag.Roots {
-			inst := n.(target.Inst)
+			inst := n.(ast.Inst)
 			lines = append(lines, fmt.Sprintf("    * %s\n", a.Pretty(inst)))
 			next = append(next, dag.Visit(n)...)
 		}

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -12,22 +12,22 @@ import (
 )
 
 type incubateInst struct {
-	Depends []target.Inst
+	Depends []ast.Inst
 }
 
-func (a *incubateInst) Device() target.Device {
+func (a *incubateInst) Device() ast.Device {
 	return nil
 }
 
-func (a *incubateInst) DependsOn() []target.Inst {
+func (a *incubateInst) DependsOn() []ast.Inst {
 	return a.Depends
 }
 
-func (a *incubateInst) SetDependsOn(xs ...target.Inst) {
+func (a *incubateInst) SetDependsOn(xs ...ast.Inst) {
 	a.Depends = xs
 }
 
-func (a *incubateInst) AppendDependsOn(xs ...target.Inst) {
+func (a *incubateInst) AppendDependsOn(xs ...ast.Inst) {
 	a.Depends = append(a.Depends, xs...)
 }
 
@@ -39,7 +39,7 @@ func (a *incubator) CanCompile(req ast.Request) bool {
 	return can.Contains(req)
 }
 
-func (a *incubator) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
+func (a *incubator) Compile(ctx context.Context, nodes []ast.Node) ([]ast.Inst, error) {
 	for _, n := range nodes {
 		if c, ok := n.(*ast.Command); !ok {
 			return nil, fmt.Errorf("unexpected node %T", n)
@@ -47,10 +47,10 @@ func (a *incubator) Compile(ctx context.Context, nodes []ast.Node) ([]target.Ins
 			return nil, fmt.Errorf("unexpected inst %T", c.Inst)
 		}
 	}
-	return []target.Inst{&incubateInst{}}, nil
+	return []ast.Inst{&incubateInst{}}, nil
 }
 
-func (a *incubator) MoveCost(from target.Device) int64 {
+func (a *incubator) MoveCost(from ast.Device) int64 {
 	if a == from {
 		return 0
 	}

--- a/codegen/implicit.go
+++ b/codegen/implicit.go
@@ -24,7 +24,7 @@ func (a *ir) getMixes() (ret []*target.Mix) {
 	return
 }
 
-func isIncubator(dev target.Device) bool {
+func isIncubator(dev ast.Device) bool {
 	incubates := dev.CanCompile(ast.Request{
 		Selector: []ast.NameValue{
 			target.DriverSelectorV1ShakerIncubator,
@@ -84,7 +84,7 @@ func (a *ir) addImplicitMixInsts() error {
 		)
 	}
 
-	seen := make(map[target.Device]bool)
+	seen := make(map[ast.Device]bool)
 	for d := range a.output {
 		if seen[d.Device] {
 			continue
@@ -134,7 +134,7 @@ func (a *ir) addIzers(deviceOrder []*drun) error {
 		}
 
 		for _, node := range order {
-			inst := node.(target.Inst)
+			inst := node.(ast.Inst)
 			init, ok := inst.(target.Initializer)
 			if ok {
 				a.initializers = append(a.initializers, init.GetInitializers()...)

--- a/codegen/instgraph.go
+++ b/codegen/instgraph.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/graph"
 	"github.com/antha-lang/antha/target"
 )
@@ -10,19 +11,19 @@ import (
 // where we can't depend on target.Graph because we are using this to build the
 // initial DependsOn relation.
 type instGraph struct {
-	insts     []target.Inst
-	added     map[target.Inst]bool
-	dependsOn map[target.Inst][]target.Inst
-	entry     map[graph.Node]target.Inst
-	exit      map[graph.Node]target.Inst
+	insts     []ast.Inst
+	added     map[ast.Inst]bool
+	dependsOn map[ast.Inst][]ast.Inst
+	entry     map[graph.Node]ast.Inst
+	exit      map[graph.Node]ast.Inst
 }
 
 func newInstGraph() *instGraph {
 	return &instGraph{
-		added:     make(map[target.Inst]bool),
-		entry:     make(map[graph.Node]target.Inst),
-		exit:      make(map[graph.Node]target.Inst),
-		dependsOn: make(map[target.Inst][]target.Inst),
+		added:     make(map[ast.Inst]bool),
+		entry:     make(map[graph.Node]ast.Inst),
+		exit:      make(map[graph.Node]ast.Inst),
+		dependsOn: make(map[ast.Inst][]ast.Inst),
 	}
 }
 
@@ -35,15 +36,15 @@ func (a *instGraph) Node(i int) graph.Node {
 }
 
 func (a *instGraph) NumOuts(n graph.Node) int {
-	return len(a.dependsOn[n.(target.Inst)])
+	return len(a.dependsOn[n.(ast.Inst)])
 }
 
 func (a *instGraph) Out(n graph.Node, i int) graph.Node {
-	return a.dependsOn[n.(target.Inst)][i]
+	return a.dependsOn[n.(ast.Inst)][i]
 }
 
 // addInsts adds instructions to the graph
-func (a *instGraph) addInsts(insts target.Insts) {
+func (a *instGraph) addInsts(insts ast.Insts) {
 	// Add dependencies
 	for _, in := range insts {
 		a.dependsOn[in] = append(a.dependsOn[in], in.DependsOn()...)
@@ -68,7 +69,7 @@ func (a *instGraph) addInsts(insts target.Insts) {
 	}
 }
 
-func (a *instGraph) addInitializers(insts target.Insts) {
+func (a *instGraph) addInitializers(insts ast.Insts) {
 	if len(insts) == 0 {
 		return
 	}
@@ -84,7 +85,7 @@ func (a *instGraph) addInitializers(insts target.Insts) {
 	a.addInsts(insts)
 }
 
-func (a *instGraph) addFinalizers(insts target.Insts) {
+func (a *instGraph) addFinalizers(insts ast.Insts) {
 	if len(insts) == 0 {
 		return
 	}
@@ -98,7 +99,7 @@ func (a *instGraph) addFinalizers(insts target.Insts) {
 }
 
 // addRootedInsts adds instructions that correspond to a particular graph Node
-func (a *instGraph) addRootedInsts(root graph.Node, insts target.Insts) {
+func (a *instGraph) addRootedInsts(root graph.Node, insts ast.Insts) {
 	exit := &target.Wait{}
 	entry := &target.Wait{}
 
@@ -113,6 +114,6 @@ func (a *instGraph) addRootedInsts(root graph.Node, insts target.Insts) {
 		exit.AppendDependsOn(last)
 	}
 
-	newInsts := append(target.Insts{entry, exit}, insts...)
+	newInsts := append(ast.Insts{entry, exit}, insts...)
 	a.addInsts(newInsts)
 }

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -18,7 +18,7 @@ import (
 type Result struct {
 	Workflow *workflow.Workflow
 	Input    []ast.Node
-	Insts    []target.Inst
+	Insts    []ast.Inst
 }
 
 // An Opt are options for Run.

--- a/target/auto/auto.go
+++ b/target/auto/auto.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/antha-lang/antha/ast"
 	runner "github.com/antha-lang/antha/driver/antha_runner_v1"
 	"github.com/antha-lang/antha/target"
 	"github.com/antha-lang/antha/target/human"
@@ -33,7 +34,7 @@ type Auto struct {
 	Target  *target.Target
 	Conns   []*grpc.ClientConn
 	runners map[string][]runner.RunnerClient
-	handler map[target.Device]*grpc.ClientConn
+	handler map[ast.Device]*grpc.ClientConn
 }
 
 // Close releases any resources like network connections associated
@@ -55,7 +56,7 @@ func New(opt Opt) (ret *Auto, err error) {
 	ret = &Auto{
 		Target:  target.New(),
 		runners: make(map[string][]runner.RunnerClient),
-		handler: make(map[target.Device]*grpc.ClientConn),
+		handler: make(map[ast.Device]*grpc.ClientConn),
 	}
 
 	defer func() {

--- a/target/auto/execute.go
+++ b/target/auto/execute.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/antha-lang/antha/ast"
 	runner "github.com/antha-lang/antha/driver/antha_runner_v1"
 	"github.com/antha-lang/antha/target"
 	"google.golang.org/grpc"
 )
 
 // Execute runs an instruction based on current target
-func (a *Auto) Execute(ctx context.Context, inst target.Inst) error {
+func (a *Auto) Execute(ctx context.Context, inst ast.Inst) error {
 	switch inst := inst.(type) {
 	case *target.Mix:
 		return a.executeMix(ctx, inst)

--- a/target/auto/pretty.go
+++ b/target/auto/pretty.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/target"
 )
 
 // Pretty returns a human description of instruction
-func (a *Auto) Pretty(inst target.Inst) string {
+func (a *Auto) Pretty(inst ast.Inst) string {
 	switch inst := inst.(type) {
 	case *target.Mix:
 		return prettyMix(inst)

--- a/target/device.go
+++ b/target/device.go
@@ -1,17 +1,1 @@
 package target
-
-import (
-	"context"
-
-	"github.com/antha-lang/antha/ast"
-)
-
-// A Device is a scheduling plugin
-type Device interface {
-	CanCompile(ast.Request) bool // Can this device compile this request
-	MoveCost(from Device) int64  // A non-negative cost to move to this device
-
-	// Compile produces a single-entry, single-exit DAG of instructions where
-	// insts[0] is the entry point and insts[len(insts)-1] is the exit point
-	Compile(ctx context.Context, cmds []ast.Node) (insts []Inst, err error)
-}

--- a/target/graph.go
+++ b/target/graph.go
@@ -1,10 +1,13 @@
 package target
 
-import "github.com/antha-lang/antha/graph"
+import (
+	"github.com/antha-lang/antha/ast"
+	"github.com/antha-lang/antha/graph"
+)
 
 // Graph is a view of instructions as a graph
 type Graph struct {
-	Insts []Inst
+	Insts []ast.Inst
 }
 
 // NumNodes implements a Graph
@@ -19,10 +22,10 @@ func (a *Graph) Node(i int) graph.Node {
 
 // NumOuts implements a Graph
 func (a *Graph) NumOuts(n graph.Node) int {
-	return len(n.(Inst).DependsOn())
+	return len(n.(ast.Inst).DependsOn())
 }
 
 // Out implements a Graph
 func (a *Graph) Out(n graph.Node, i int) graph.Node {
-	return n.(Inst).DependsOn()[i].(graph.Node)
+	return n.(ast.Inst).DependsOn()[i].(graph.Node)
 }

--- a/target/handler/generic.go
+++ b/target/handler/generic.go
@@ -19,7 +19,7 @@ var (
 // A GenericHandler is a configurable version of a Handler suitable for mixins
 type GenericHandler struct {
 	Labels             []ast.NameValue
-	GenFunc            func(cmd interface{}) ([]target.Inst, error)
+	GenFunc            func(cmd interface{}) ([]ast.Inst, error)
 	FilterFieldsForKey func(interface{}) (interface{}, error)
 }
 
@@ -33,7 +33,7 @@ func (a *GenericHandler) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *GenericHandler) MoveCost(target.Device) int64 {
+func (a *GenericHandler) MoveCost(ast.Device) int64 {
 	return 0
 }
 
@@ -98,13 +98,13 @@ func (a GenericHandler) merge(nodes []ast.Node) (*ast.Command, error) {
 }
 
 // Compile implements a Device
-func (a *GenericHandler) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
+func (a *GenericHandler) Compile(ctx context.Context, nodes []ast.Node) ([]ast.Inst, error) {
 	g := ast.Deps(nodes)
 
 	entry := &target.Wait{}
 	exit := &target.Wait{}
-	var insts []target.Inst
-	inst := make(map[ast.Node][]target.Inst)
+	var insts []ast.Inst
+	inst := make(map[ast.Node][]ast.Inst)
 
 	insts = append(insts, entry)
 

--- a/target/handler/handler.go
+++ b/target/handler/handler.go
@@ -12,12 +12,12 @@ type Handler struct {
 	*GenericHandler
 }
 
-func (h *Handler) generate(cmd interface{}) ([]target.Inst, error) {
+func (h *Handler) generate(cmd interface{}) ([]ast.Inst, error) {
 	hinst, ok := cmd.(*ast.HandleInst)
 	if !ok {
 		return nil, fmt.Errorf("expecting %T found %T instead", hinst, cmd)
 	}
-	return []target.Inst{
+	return []ast.Inst{
 		&target.Run{
 			Dev:   h,
 			Label: hinst.Group,

--- a/target/human/human.go
+++ b/target/human/human.go
@@ -3,6 +3,7 @@ package human
 import (
 	"context"
 	"fmt"
+
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/target"
@@ -17,7 +18,7 @@ const (
 )
 
 var (
-	_ target.Device = &Human{}
+	_ ast.Device = &Human{}
 )
 
 // A Human is a device that can do anything
@@ -69,7 +70,7 @@ func (a *Human) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements target.device MoveCost
-func (a *Human) MoveCost(from target.Device) int64 {
+func (a *Human) MoveCost(from ast.Device) int64 {
 	if _, ok := from.(*Human); ok {
 		return HumanByHumanCost
 	}
@@ -77,13 +78,13 @@ func (a *Human) MoveCost(from target.Device) int64 {
 }
 
 // Compile implements target.device Compile
-func (a *Human) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
+func (a *Human) Compile(ctx context.Context, nodes []ast.Node) ([]ast.Inst, error) {
 	return a.impl.Compile(ctx, nodes)
 }
 
-func (a *Human) generate(cmd interface{}) ([]target.Inst, error) {
+func (a *Human) generate(cmd interface{}) ([]ast.Inst, error) {
 
-	var insts []target.Inst
+	var insts []ast.Inst
 
 	switch cmd := cmd.(type) {
 

--- a/target/mixer/mixer.go
+++ b/target/mixer/mixer.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	_ target.Device = &Mixer{}
+	_ ast.Device = &Mixer{}
 )
 
 // A Mixer is a device plugin for mixer devices
@@ -51,7 +51,7 @@ func (a *Mixer) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *Mixer) MoveCost(from target.Device) int64 {
+func (a *Mixer) MoveCost(from ast.Device) int64 {
 	if from == a {
 		return 0
 	}
@@ -226,7 +226,7 @@ func (a *Mixer) makeLhreq(ctx context.Context) (*lhreq, error) {
 }
 
 // Compile implements a Device
-func (a *Mixer) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
+func (a *Mixer) Compile(ctx context.Context, nodes []ast.Node) ([]ast.Inst, error) {
 	var mixes []*wtype.LHInstruction
 	for _, node := range nodes {
 		if c, ok := node.(*ast.Command); !ok {
@@ -243,7 +243,7 @@ func (a *Mixer) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, e
 		return nil, err
 	}
 
-	return []target.Inst{mix}, nil
+	return []ast.Inst{mix}, nil
 }
 
 func (a *Mixer) saveFile(name string) ([]byte, error) {

--- a/target/qpcrdevice/qpcrdevice.go
+++ b/target/qpcrdevice/qpcrdevice.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/antha-lang/antha/ast"
 	"github.com/antha-lang/antha/driver"
 	framework "github.com/antha-lang/antha/driver/antha_framework_v1"
 	quantstudio "github.com/antha-lang/antha/driver/antha_quantstudio_v1"
 	"github.com/antha-lang/antha/target"
 	"github.com/golang/protobuf/proto"
-	"os"
 )
 
 // QPCRDevice defines the state of a qpcr device device
@@ -18,7 +19,7 @@ type QPCRDevice struct {
 }
 
 // Ensure satisfies Device interface
-var _ target.Device = (*QPCRDevice)(nil)
+var _ ast.Device = (*QPCRDevice)(nil)
 
 // NewQPCRDevice returns a new QPCR Machine
 func New() *QPCRDevice {
@@ -34,11 +35,11 @@ func (a *QPCRDevice) CanCompile(req ast.Request) bool {
 }
 
 // MoveCost implements a Device
-func (a *QPCRDevice) MoveCost(from target.Device) int64 {
+func (a *QPCRDevice) MoveCost(from ast.Device) int64 {
 	return 0
 }
 
-func (dev *QPCRDevice) transform(inst *ast.QPCRInstruction) (target.Inst, error) {
+func (dev *QPCRDevice) transform(inst *ast.QPCRInstruction) (ast.Inst, error) {
 	if inst.Definition == "" {
 		return nil, errors.New("Blank experiment file for qPCR instruction.")
 	}
@@ -96,7 +97,7 @@ func (dev *QPCRDevice) transform(inst *ast.QPCRInstruction) (target.Inst, error)
 	}, nil
 }
 
-func (dev *QPCRDevice) makePrompt(inst *ast.QPCRInstruction) target.Inst {
+func (dev *QPCRDevice) makePrompt(inst *ast.QPCRInstruction) ast.Inst {
 	bc := inst.Barcode
 	if bc != "" {
 		bc = " (" + bc + ")" // deliberate leading space
@@ -108,12 +109,12 @@ func (dev *QPCRDevice) makePrompt(inst *ast.QPCRInstruction) target.Inst {
 }
 
 // Compile implements a qPCR device.
-func (dev *QPCRDevice) Compile(ctx context.Context, nodes []ast.Node) ([]target.Inst, error) {
+func (dev *QPCRDevice) Compile(ctx context.Context, nodes []ast.Node) ([]ast.Inst, error) {
 	if len(nodes) > 1 {
 		return nil, fmt.Errorf("Currently only permit a single qPCR instruction per workflow. Received %d", len(nodes))
 	}
 
-	insts := make(target.Insts, 0, 2*len(nodes))
+	insts := make(ast.Insts, 0, 2*len(nodes))
 	for _, node := range nodes {
 		inst := node.(*ast.Command).Inst.(*ast.QPCRInstruction)
 		if call, err := dev.transform(inst); err != nil {

--- a/target/shakerincubator/shakerincubator.go
+++ b/target/shakerincubator/shakerincubator.go
@@ -89,15 +89,15 @@ func (a *ShakerIncubator) shakeStart(rate wunit.Rate, length wunit.Length) drive
 	}
 }
 
-func (a *ShakerIncubator) generate(cmd interface{}) ([]target.Inst, error) {
+func (a *ShakerIncubator) generate(cmd interface{}) ([]ast.Inst, error) {
 	inc, ok := cmd.(*ast.IncubateInst)
 	if !ok {
 		return nil, fmt.Errorf("expecting %T found %T instead", inc, cmd)
 	}
 
-	var initializers []target.Inst
-	var finalizers []target.Inst
-	var insts target.Insts
+	var initializers []ast.Inst
+	var finalizers []ast.Inst
+	var insts ast.Insts
 
 	initializers = append(initializers, &target.Run{
 		Dev:   a,

--- a/target/target.go
+++ b/target/target.go
@@ -71,7 +71,7 @@ func WithTarget(parent context.Context, t *Target) context.Context {
 
 // Target for execution (collection of devices).
 type Target struct {
-	devices []Device
+	devices []ast.Device
 }
 
 // New creates a new target
@@ -79,7 +79,7 @@ func New() *Target {
 	return &Target{}
 }
 
-func (a *Target) canCompile(d Device, reqs ...ast.Request) bool {
+func (a *Target) canCompile(d ast.Device, reqs ...ast.Request) bool {
 	for _, req := range reqs {
 		if !d.CanCompile(req) {
 			return false
@@ -89,7 +89,7 @@ func (a *Target) canCompile(d Device, reqs ...ast.Request) bool {
 }
 
 // CanCompile returns the devices that can compile the given set of requests
-func (a *Target) CanCompile(reqs ...ast.Request) (r []Device) {
+func (a *Target) CanCompile(reqs ...ast.Request) (r []ast.Device) {
 	for _, d := range a.devices {
 		if a.canCompile(d, reqs...) {
 			r = append(r, d)
@@ -99,6 +99,6 @@ func (a *Target) CanCompile(reqs ...ast.Request) (r []Device) {
 }
 
 // AddDevice adds a device to the target configuration
-func (a *Target) AddDevice(d Device) {
+func (a *Target) AddDevice(d ast.Device) {
 	a.devices = append(a.devices, d)
 }


### PR DESCRIPTION
To do this has required moving Inst and Device from target to ast in order to avoid an import cycle.
In fact, I rather suspect that the reason ast.Command.Output was interface{} was solely to break the import cycle, which is a bit crazy.

I'm trying to keep these PRs as short as possible. So this PR doesn't actually make trace serializable, but it's a step in that direction.

Test plan:
antha> go build ./...
works.