### PR TITLE
Avoid very strange string munging for Liquid daughtersID

### DIFF
--- a/execute/maker.go
+++ b/execute/maker.go
@@ -1,8 +1,6 @@
 package execute
 
 import (
-	"strings"
-
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/ast"
 )
@@ -123,7 +121,7 @@ func (a *maker) MakeNodes(insts []*commandInst) ([]ast.Node, error) {
 
 	for comp := range a.byComp {
 		// Contains all descendents rather then direct ones
-		for _, kid := range strings.Split(comp.DaughterID, "_") {
+		for kid := range comp.DaughtersID {
 			if comp.ID != kid {
 				a.afterSample[comp.ID] = append(a.afterSample[comp.ID], kid)
 			}

--- a/microArch/driver/liquidhandling/convertinstructions.go
+++ b/microArch/driver/liquidhandling/convertinstructions.go
@@ -24,6 +24,7 @@ package liquidhandling
 
 import (
 	"context"
+
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
 )

--- a/microArch/scheduler/liquidhandling/executionhelpers_test.go
+++ b/microArch/scheduler/liquidhandling/executionhelpers_test.go
@@ -1,10 +1,11 @@
 package liquidhandling
 
 import (
+	"testing"
+
 	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
 	"github.com/antha-lang/antha/antha/anthalib/wunit"
-	"testing"
 )
 
 func GetMixForTest(id string, input ...*wtype.Liquid) (*wtype.LHInstruction, *wtype.Liquid) {
@@ -43,7 +44,7 @@ func GetPromptForTest(message string, inputs ...*wtype.Liquid) (*wtype.LHInstruc
 	for _, input := range inputs {
 		output := input.Cp()
 		output.ParentID = input.ID
-		input.DaughterID = output.ID
+		input.DaughtersID = map[string]struct{}{output.ID: {}}
 		ret.AddInput(input)
 		ret.AddOutput(output)
 	}


### PR DESCRIPTION
Required semantics are set-semantics, so do that!

go test -v ./... passes, and antha-runner test bundles also passes as before.

Motivation: working through maker.MakeNodes and came across strange strings.Split code.