### PR TITLE
ast.Command.Request never needs to be plural

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -32,7 +32,13 @@ type Node interface {
 	NodeString() string
 }
 
-// A Command is high-level instruction.
+// A Command is high-level instruction. Both UseComp and Bundles are
+// currently issued only by the ast, maker, and codegen areas of
+// code. Command is different: the instruction trace is populated by
+// commandInst objects, each of which contain a Command
+// object. However, at that stage some of the fields of Command are
+// not correctly populated, and so these are modified by the maker at
+// the same point at which UseComp objects are issued.
 type Command struct {
 	From    []Node      // Inputs
 	Request Request     // Requirements for device selection

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -34,20 +34,20 @@ type Node interface {
 
 // A Command is high-level instruction.
 type Command struct {
-	From     []Node      // Inputs
-	Requests []Request   // Requirements for device selection
-	Inst     interface{} // Command-specific data
-	Output   []Inst      // Output from compilation
+	From    []Node      // Inputs
+	Request Request     // Requirements for device selection
+	Inst    interface{} // Command-specific data
+	Output  []Inst      // Output from compilation
 }
 
 // NodeString implements graph pretty printing
 func (a *Command) NodeString() string {
 	return fmt.Sprintf("%+v", struct {
-		Requests interface{}
-		Inst     string
+		Request interface{}
+		Inst    string
 	}{
-		Requests: a.Requests,
-		Inst:     fmt.Sprintf("%T", a.Inst),
+		Request: a.Request,
+		Inst:    fmt.Sprintf("%T", a.Inst),
 	})
 }
 

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -168,7 +168,7 @@ func (a *ir) assignDevices(t *target.Target) error {
 		for i, inum := 0, a.Commands.NumOuts(n); i < inum; i++ {
 			kid := a.Commands.Out(n, i)
 			if c, ok := kid.(*ast.Command); ok {
-				reqs = append(reqs, c.Requests...)
+				reqs = append(reqs, c.Request)
 			}
 		}
 		return
@@ -180,7 +180,7 @@ func (a *ir) assignDevices(t *target.Target) error {
 		var reqs []ast.Request
 		isBundle := false
 		if c, ok := n.(*ast.Command); ok {
-			reqs = c.Requests
+			reqs = append(reqs, c.Request)
 		} else if b, ok := n.(*ast.Bundle); ok {
 			// Try to find device that can do everything
 			reqs = bundleReqs(b)

--- a/codegen/codegen_test.go
+++ b/codegen/codegen_test.go
@@ -56,11 +56,9 @@ func TestWellFormed(t *testing.T) {
 	var nodes []ast.Node
 	for idx := 0; idx < 4; idx++ {
 		m := &ast.Command{
-			Requests: []ast.Request{
-				{
-					Selector: []ast.NameValue{
-						target.DriverSelectorV1Mixer,
-					},
+			Request: ast.Request{
+				Selector: []ast.NameValue{
+					target.DriverSelectorV1Mixer,
 				},
 			},
 			Inst: &wtype.LHInstruction{},
@@ -74,11 +72,9 @@ func TestWellFormed(t *testing.T) {
 		u.From = append(u.From, m)
 
 		i := &ast.Command{
-			Requests: []ast.Request{
-				{
-					Selector: []ast.NameValue{
-						target.DriverSelectorV1ShakerIncubator,
-					},
+			Request: ast.Request{
+				Selector: []ast.NameValue{
+					target.DriverSelectorV1ShakerIncubator,
 				},
 			},
 			Inst: &ast.IncubateInst{},


### PR DESCRIPTION
We never make use of the fact this can be a list.
I'm trying to get this whole area of the code simpler and more obvious to better understand what we need before figuring out larger changes to it.

go test -v ./... still works, as does test-bundles.