### PR TITLE
lhinstruction has .AddOutput method. Use it.

### DIFF
--- a/execute/intrinsics.go
+++ b/execute/intrinsics.go
@@ -428,8 +428,8 @@ func splitSample(ctx context.Context, component *wtype.Liquid, volume wunit.Volu
 	//the ID of the component that is staying has been updated
 	sampletracker.FromContext(ctx).UpdateIDOf(component.ID, cmpStaying.ID)
 
-	split.Outputs = append(split.Outputs, cmpMoving)
-	split.Outputs = append(split.Outputs, cmpStaying)
+	split.AddOutput(cmpMoving)
+	split.AddOutput(cmpStaying)
 
 	// Create Instruction
 	inst := &commandInst{

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -1258,7 +1258,8 @@ func getTestSplitSample(ctx context.Context, component *wtype.Liquid, volume flo
 	cmpMoving, cmpStaying := mixer.SplitSample(component, wunit.NewVolume(volume, "ul"))
 	sampletracker.FromContext(ctx).UpdateIDOf(component.ID, cmpStaying.ID)
 
-	ret.Outputs = append(ret.Outputs, cmpMoving, cmpStaying)
+	ret.AddOutput(cmpMoving)
+	ret.AddOutput(cmpStaying)
 
 	return ret
 }


### PR DESCRIPTION
Context: was trying to figure out if we really need Outputs to be a list. Convinced myself we do due to split.
But found a couple of places where we're directly appending to the slice. Should use the api instead - less code.

Tests: they pass.