### PR TITLE
return actionable error message

### DIFF
--- a/antha/compile/antha.go
+++ b/antha/compile/antha.go
@@ -743,7 +743,7 @@ func (p *Antha) validateMessages(messages []*Message) error {
 			for _, field := range msg.Fields {
 
 				if _, seen := p.tokenByParamName[field.Name]; seen {
-					return fmt.Errorf("%s already declared", name)
+					return fmt.Errorf("%s already declared: %s", name, field.Name)
 				}
 				p.tokenByParamName[field.Name] = msg.Kind
 			}

--- a/cmd/antha/cmd/compile.go
+++ b/cmd/antha/cmd/compile.go
@@ -92,7 +92,10 @@ func runCompile(cmd *cobra.Command, args []string) error {
 
 			// Collect errors processing errors
 			if err := processFile(root, path, outdir); err != nil {
-				errs = append(errs, err)
+				errs = append(
+					errs,
+					fmt.Errorf("error processing file: %s \n Error: %s", path, err),
+				)
 			}
 
 			return nil


### PR DESCRIPTION
add failing file name and problem parameter to error message when antha compile fails due to duplicate parameter specification