### PR TITLE
LHWell .Protect is not used.

### DIFF
--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -204,35 +204,6 @@ Extra     : %v,
 	)
 }
 
-func (w *LHWell) Protected() bool {
-	if w.Extra == nil {
-		return false
-	}
-
-	p, ok := w.Extra["protected"]
-
-	if !ok || !(p.(bool)) {
-		return false
-	}
-
-	return true
-}
-
-func (w *LHWell) Protect() {
-	if w.Extra == nil {
-		w.Extra = make(map[string]interface{}, 3)
-	}
-
-	w.Extra["protected"] = true
-}
-
-func (w *LHWell) UnProtect() {
-	if w.Extra == nil {
-		w.Extra = make(map[string]interface{}, 3)
-	}
-	w.Extra["protected"] = false
-}
-
 func (w *LHWell) Contents() *Liquid {
 	if w == nil {
 		return nil
@@ -959,7 +930,7 @@ func (w *LHWell) UpdateContentID(IDBefore string, after *Liquid) bool {
 
 // CheckExtraKey checks if the key is a reserved name
 func (w LHWell) CheckExtraKey(s string) error {
-	reserved := []string{"protected", "afvfunc", "temporary", "autoallocated", "UserAllocated", "ll_model"}
+	reserved := []string{"afvfunc", "temporary", "autoallocated", "UserAllocated", "ll_model"}
 
 	if wutil.StrInStrArray(s, reserved) {
 		return fmt.Errorf("%s is a system key used by plates", s)

--- a/antha/anthalib/wtype/plate.go
+++ b/antha/anthalib/wtype/plate.go
@@ -706,18 +706,6 @@ func (lhp *Plate) dup(keep_ids bool) *Plate {
 	return ret
 }
 
-func (p *Plate) ProtectAllWells() {
-	for _, v := range p.Wellcoords {
-		v.Protect()
-	}
-}
-
-func (p *Plate) UnProtectAllWells() {
-	for _, v := range p.Wellcoords {
-		v.UnProtect()
-	}
-}
-
 func Initialize_Wells(plate *Plate) {
 	wells := (*plate).HWells
 	newwells := make(map[string]*LHWell, len(wells))


### PR DESCRIPTION
Context: Plates seem odd. They're in wtype and thus seem available to elements, but are sorta managed through sampletracker which is in microArch...
I was trying to figure out if we can drop all pointers to Liquids and just pass around maps from ids to objects, which would at least move us away from the weirdness of Dup with IDs (I found some elements that call Dup()...)
Which then made me think of Plates, which contain Wells, which contain Liquids... so I was looking at Wells and came across the protect stuff.