### PR TITLE
Genbank writer

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/export/export.go
+++ b/antha/AnthaStandardLibrary/Packages/export/export.go
@@ -34,6 +34,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
+	"time"
 
 	anthapath "github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/AnthaPath"
 	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/enzymes"
@@ -303,6 +305,120 @@ func FastaSerialfromMultipleAssemblies(dirname string, multipleassemblyparameter
 	}
 
 	return FastaSerial(ANTHAPATH, dirname, seqs)
+}
+
+// GenbankSerial exports multiple sequences into a multi-record Genbank format file
+// The makeinanthapath argument specifies whether a copy of the file should be saved locally or to the anthapath in a specified sub directory directory.
+func GenbankSerial(makeinanthapath bool, dir string, seqs []wtype.DNASequence) (wtype.File, string, error) {
+
+	var anthafile wtype.File
+
+	// Template for multi-record Genbank file
+	// https://www.ncbi.nlm.nih.gov/Sitemap/samplerecord.html
+	// http://www.insdc.org/documents/feature_table.html
+	tmplStr := `{{ range $i, $s := . -}}
+LOCUS       {{ $s.Nm }}               {{ length $s }} bp ds-DNA     {{ if $s.Plasmid }}circular{{ else }}linear{{ end }} SYN {{ date }}
+DEFINITION  Exported from Antha OS
+ACCESSION   
+VERSION     
+KEYWORDS    
+SOURCE      synthetic DNA construct
+FEATURES             Location/Qualifiers
+     source          1..{{ length . }}
+                     /organism="synthetic DNA construct"
+                     /mol_type="other DNA"
+{{- range $j, $f := $s.Features }}
+     {{  keyf $f  }} {{ if $f.Reverse }}complement({{ $f.StartPosition }}..{{ $f.EndPosition }}){{ else }}{{ $f.StartPosition }}..{{ $f.EndPosition }}{{ end }}
+                     /label="{{ $f.Name }}"
+{{- end }}
+ORIGIN
+{{- range $j, $line := origin $s }}
+{{ $line }}
+{{- end }}
+//
+{{ end }}`
+
+	tmpl, err := template.New("genbank").Funcs(template.FuncMap{
+		"date": func() string {
+			t := time.Now()
+			return t.Format("2-JAN-2006")
+		},
+		"length": func(seq wtype.DNASequence) int {
+			return len(seq.Sequence())
+		},
+		// Formatted feature key
+		// http://www.insdc.org/documents/feature_table.html#3.1
+		"keyf": func(feat wtype.Feature) string {
+			return fmt.Sprintf("%-15s", strings.TrimSpace(feat.Class))
+		},
+		"origin": func(seq wtype.DNASequence) []string {
+			bases := seq.Sequence()
+			lines := []string{}
+			for pos := 0; pos < len(bases); pos += 60 {
+				frags := []string{}
+				frags = append(frags, fmt.Sprintf("%9d ", pos+1))
+				for inner := pos; inner < pos+60 && inner < len(bases); inner += 10 {
+					last := inner + 10
+					if last > len(bases) {
+						last = len(bases)
+					}
+					frags = append(frags, bases[inner:last])
+				}
+				joined := strings.Join(frags, " ")
+				lines = append(lines, joined)
+			}
+			return lines
+		},
+	}).Parse(tmplStr)
+
+	if err != nil {
+		return anthafile, "", err
+	}
+
+	var filename string
+	if makeinanthapath {
+		filename = filepath.Join(anthapath.Path(), fmt.Sprintf("%s.gbk", dir))
+	} else {
+		filename = filepath.Join(fmt.Sprintf("%s.gbk", dir))
+	}
+	if err := os.MkdirAll(filepath.Dir(filename), 0644); err != nil {
+		return anthafile, "", err
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return anthafile, "", err
+	}
+
+	defer closeReader(f)
+
+	var buf bytes.Buffer
+
+	err = tmpl.Execute(&buf, seqs)
+	if err != nil {
+		return anthafile, "", err
+	}
+
+	allbytes, err := streamToByte(&buf)
+	if err != nil {
+		return anthafile, "", err
+	}
+
+	_, err = io.Copy(f, &buf)
+
+	if err != nil {
+		return anthafile, "", err
+	}
+
+	if len(allbytes) == 0 {
+		return anthafile, "", fmt.Errorf("empty Otnol file created for seqs")
+	}
+
+	fmt.Println("About to write file...")
+	anthafile.Name = filename
+	err = anthafile.WriteAll(allbytes)
+
+	return anthafile, filename, err
 }
 
 // TextFile exports data in the format of a set of strings to a file.

--- a/antha/AnthaStandardLibrary/Packages/export/export_test.go
+++ b/antha/AnthaStandardLibrary/Packages/export/export_test.go
@@ -1,0 +1,99 @@
+package export
+
+import (
+	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/sequences"
+	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/sequences/parse/genbank"
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func randomDNA(seed int64, length int) string {
+	nucs := []byte("ACGT")
+	nBases := len(nucs)
+	r := rand.New(rand.NewSource(seed))
+	bases := []byte{}
+	for i := 0; i < length; i++ {
+		bases = append(bases, nucs[r.Intn(nBases)])
+	}
+	return string(bases)
+}
+
+func TestGenbankSerial(t *testing.T) {
+
+	seqStr := randomDNA(1, 500)
+
+	setupFeatures := []struct {
+		Name       string
+		Start, End int // unit offset
+		Class      string
+		Direction  string
+	}{
+		{"f1", 121, 140, wtype.MISC_FEATURE, "forward"},
+		{"f2", 141, 160, wtype.MISC_FEATURE, "reverse"},
+		{"f3", 161, 180, wtype.PROMOTER, "forward"},
+	}
+
+	features := []wtype.Feature{}
+	for _, p := range setupFeatures {
+		featStr := seqStr[p.Start-1 : p.End]
+		if strings.ToLower(p.Direction) == "reverse" {
+			featStr = wtype.RevComp(featStr)
+		}
+		feature := sequences.MakeFeature(p.Name, featStr, p.Start, p.End, "DNA", p.Class, p.Direction)
+		features = append(features, feature)
+	}
+
+	want, err := sequences.MakeAnnotatedSeq("s1", seqStr, false, features)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	seqFile, _, err := GenbankSerial(LOCAL, "MyOutputFile", []wtype.DNASequence{want})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	allBytes, err := seqFile.ReadAll()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fmt.Printf("-----\n%s----\n", string(allBytes))
+
+	got, err := genbank.GenbankContentsToAnnotatedSeq(allBytes)
+
+	if err != nil {
+		t.Fatal("Failed to parse output file")
+	}
+
+	if strings.ToUpper(got.Name()) != strings.ToUpper(want.Name()) {
+		t.Errorf("Name: got %s, want %s\n", got.Name(), want.Name())
+	}
+	if strings.ToUpper(got.Sequence()) != strings.ToUpper(want.Sequence()) {
+		t.Errorf("Sequence: got %s, want %s\n", got.Sequence(), want.Sequence())
+	}
+	if len(got.Features) != len(want.Features) {
+		t.Fatalf("Number of features: got %s, want %s\n", got.Sequence(), want.Sequence())
+	}
+	for i := 0; i < len(want.Features); i++ {
+		if got.Features[i].Name != want.Features[i].Name {
+			t.Errorf("Feature %d Name: got %s, want %s\n", i, got.Features[i].Name, want.Features[i].Name)
+		}
+		if got.Features[i].Class != want.Features[i].Class {
+			t.Errorf("Feature %d Class: got %s, want %s\n", i, got.Features[i].Class, want.Features[i].Class)
+		}
+		if got.Features[i].StartPosition != want.Features[i].StartPosition {
+			t.Errorf("Feature %d StartPosition: got %d, want %d\n", i, got.Features[i].StartPosition, want.Features[i].StartPosition)
+		}
+		if got.Features[i].EndPosition != want.Features[i].EndPosition {
+			t.Errorf("Feature %d EndPosition: got %d, want %d\n", i, got.Features[i].EndPosition, want.Features[i].EndPosition)
+		}
+		if got.Features[i].Reverse != want.Features[i].Reverse {
+			t.Errorf("Feature %d Reverse: got %v, want %v\n", i, got.Features[i].Reverse, want.Features[i].Reverse)
+		}
+
+	}
+
+}


### PR DESCRIPTION
Adds a new method in `Packages/export` to export annotated `DNASequence`(s) in a basic Genbank format.

This is intended to support more user-friendly output from elements such as `Construct_Assembly_Multi` which currently exports only an unannotated Fasta file.  Genbank format will allow the inserted parts to be annotated and viewed in e.g. Snapgene viewer.

The test checks that the output Genbank file can be parsed back to an annotated `DNASequence` using the Genbank parser in `Packages/sequences/parse/genbank`.
