### PR TITLE
Handle unrecognised characters in complement

### DIFF
--- a/antha/anthalib/wtype/biology.go
+++ b/antha/anthalib/wtype/biology.go
@@ -888,7 +888,11 @@ func Comp(s string) string {
 	}
 
 	for _, c := range s {
-		r += m[string(c)]
+		if rc, ok := m[string(c)]; ok {
+			r += rc
+		} else {
+			r += string(c)
+		}
 	}
 
 	return r

--- a/antha/anthalib/wtype/wtype_test.go
+++ b/antha/anthalib/wtype/wtype_test.go
@@ -350,3 +350,21 @@ func TestPlateLocation(t *testing.T) {
 		t.Fatal("PlateLocations in different wells reported equal")
 	}
 }
+
+func TestComp(t *testing.T) {
+
+	// expect unhandled characters to pass through without modification
+
+	test := "GG-.GG"
+
+	got := Comp(test)
+	want := "CC-.CC"
+
+	if len(got) < len(test) {
+		t.Fatal("Complement is shorter than input - some characters ignored?")
+	}
+	if got != want {
+		t.Fatalf("Unexpected complement: got %s, want %s\n", got, want)
+	}
+
+}


### PR DESCRIPTION
Currently `wtype.Comp` silently ignores unrecognised characters.

This leads to output that is shorter than input if there are unrecognised characters in the input.

Separately, it would be handy if some non-DNA characters for example `-` (gap) and `.` (match) were passed through.  Then gapped alignments could be reverse-complemented: a useful extension.

The following changes could be made:
1. raise error if a character is not a recognised nucleotide
2. allow specific extra non-DNA characters - an extended alphabet ([this list of IUPAC codes](http://www.bioinformatics.org/sms2/iupac.html]) allows both `-`and `.`)
3. pass through any unrecognised characters unmodified 

Option 1 may have a big impact. There is code to validate nucleotides in `wtype` but validation is not enforced and may not be used widely.  PR https://github.com/antha-lang/antha/pull/976 suggests no tests would break on CI currently.

Option 2 would have less impact but silent omissions would still be possible. This option seems to entail further development around alphabet handling and (again) use of validation.

Option 3 (implemented here) seems to be the simplest fix.

Or Option 1 with panic per #976.