### PR TITLE
switching to Go 1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11
+- 1.11.5
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y libglpk-dev protobuf-compiler


### PR DESCRIPTION
Go 1.11 has a linter bug (https://github.com/golangci/golangci-lint/issues/148) which results in a fake warning message which breaks feature/datatable branch build