### PR TITLE
Explicitly record the size of positions on the deck

### DIFF
--- a/antha/anthalib/wtype/boundingbox.go
+++ b/antha/anthalib/wtype/boundingbox.go
@@ -31,8 +31,8 @@ import (
 //BBox is a simple LHObject representing a bounding box,
 //useful for checking if there's stuff in the way
 type BBox struct {
-	Position Coordinates
-	Size     Coordinates
+	Position Coordinates3D
+	Size     Coordinates3D
 }
 
 //Equals defines an equivalence relation over bounding boxes
@@ -41,7 +41,7 @@ func (bb BBox) Equals(bb2 BBox) bool {
 	return bb.Position.Equals(bb2.Position) && bb.Size.Equals(bb2.Size)
 }
 
-func NewBBox(pos, Size Coordinates) *BBox {
+func NewBBox(pos, Size Coordinates3D) *BBox {
 	if Size.X < 0. {
 		pos.X = pos.X + Size.X
 		Size.X = -Size.X
@@ -59,33 +59,33 @@ func NewBBox(pos, Size Coordinates) *BBox {
 }
 
 func NewBBox6f(pos_x, pos_y, pos_z, Size_x, Size_y, Size_z float64) *BBox {
-	return NewBBox(Coordinates{pos_x, pos_y, pos_z},
-		Coordinates{Size_x, Size_y, Size_z})
+	return NewBBox(Coordinates3D{pos_x, pos_y, pos_z},
+		Coordinates3D{Size_x, Size_y, Size_z})
 }
 
 func NewXBox4f(pos_y, pos_z, Size_y, Size_z float64) *BBox {
-	return NewBBox(Coordinates{-math.MaxFloat64 / 2., pos_y, pos_z},
-		Coordinates{math.MaxFloat64, Size_y, Size_z})
+	return NewBBox(Coordinates3D{-math.MaxFloat64 / 2., pos_y, pos_z},
+		Coordinates3D{math.MaxFloat64, Size_y, Size_z})
 }
 
 func NewYBox4f(pos_x, pos_z, Size_x, Size_z float64) *BBox {
-	return NewBBox(Coordinates{pos_x, -math.MaxFloat64 / 2., pos_z},
-		Coordinates{Size_x, math.MaxFloat64, Size_z})
+	return NewBBox(Coordinates3D{pos_x, -math.MaxFloat64 / 2., pos_z},
+		Coordinates3D{Size_x, math.MaxFloat64, Size_z})
 }
 
 func NewZBox4f(pos_x, pos_y, Size_x, Size_y float64) *BBox {
-	return NewBBox(Coordinates{pos_x, pos_y, -math.MaxFloat64 / 2.},
-		Coordinates{Size_x, Size_y, math.MaxFloat64})
+	return NewBBox(Coordinates3D{pos_x, pos_y, -math.MaxFloat64 / 2.},
+		Coordinates3D{Size_x, Size_y, math.MaxFloat64})
 }
 
-func (self BBox) GetPosition() Coordinates {
+func (self BBox) GetPosition() Coordinates3D {
 	return self.Position
 }
 func (self BBox) ZMax() float64 {
 	return self.Position.Z + self.Size.Z
 }
 
-func (self BBox) GetSize() Coordinates {
+func (self BBox) GetSize() Coordinates3D {
 	return self.Size
 }
 
@@ -102,21 +102,21 @@ func (self *BBox) Dup() *BBox {
 	return &BBox{self.Position, self.Size}
 }
 
-func (self *BBox) SetPosition(c Coordinates) {
+func (self *BBox) SetPosition(c Coordinates3D) {
 	if self == nil {
 		return
 	}
 	self.Position = c
 }
 
-func (self *BBox) SetSize(c Coordinates) {
+func (self *BBox) SetSize(c Coordinates3D) {
 	if self == nil {
 		return
 	}
 	self.Size = c
 }
 
-func (self BBox) Contains(rhs Coordinates) bool {
+func (self BBox) Contains(rhs Coordinates3D) bool {
 	return (rhs.X >= self.Position.X && rhs.X < self.Position.X+self.Size.X &&
 		rhs.Y >= self.Position.Y && rhs.Y < self.Position.Y+self.Size.Y &&
 		rhs.Z >= self.Position.Z && rhs.Z < self.Position.Z+self.Size.Z)
@@ -144,7 +144,7 @@ func (self BBox) IntersectsBox(rhs BBox) bool {
 }
 
 //IntersectsPoint
-func (self BBox) IntersectsPoint(rhs Coordinates) bool {
+func (self BBox) IntersectsPoint(rhs Coordinates3D) bool {
 	return (rhs.X >= self.Position.X && rhs.X < self.Position.X+self.Size.X &&
 		rhs.Y >= self.Position.Y && rhs.Y < self.Position.Y+self.Size.Y &&
 		rhs.Z >= self.Position.Z && rhs.Z < self.Position.Z+self.Size.Z)

--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -189,6 +189,9 @@ func (self Coordinates2D) Abs() float64 {
 	return math.Sqrt(self.X*self.X + self.Y*self.Y)
 }
 
+// SBSFootprint the size of standard SBS format plates
+var SBSFootprint = Coordinates2D{X: 127.76, Y: 85.48}
+
 //a rectangle
 type Rectangle struct {
 	lowerLeft  Coordinates2D

--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -24,7 +24,6 @@ package wtype
 
 import (
 	"fmt"
-	"github.com/antha-lang/antha/antha/anthalib/wunit"
 	"math"
 )
 
@@ -115,13 +114,6 @@ func (self Coordinates) To2D() Coordinates2D {
 		X: self.X,
 		Y: self.Y,
 	}
-}
-
-//Geometry interface for 3D geometry
-type Geometry interface {
-	Height() wunit.Length
-	Width() wunit.Length
-	Depth() wunit.Length
 }
 
 type PointSet []Coordinates

--- a/antha/anthalib/wtype/geometry.go
+++ b/antha/anthalib/wtype/geometry.go
@@ -27,27 +27,27 @@ import (
 	"math"
 )
 
-type Coordinates struct {
+type Coordinates3D struct {
 	X float64
 	Y float64
 	Z float64
 }
 
-func (c Coordinates) Equals(c2 Coordinates) bool {
+func (c Coordinates3D) Equals(c2 Coordinates3D) bool {
 	return c.X == c2.X && c.Y == c2.Y && c.Z == c2.Z
 }
 
 //String implements Stringer
-func (self Coordinates) String() string {
+func (self Coordinates3D) String() string {
 	return fmt.Sprintf("%.1fx%.1fx%.1f mm", self.X, self.Y, self.Z)
 }
 
-func (self Coordinates) StringXY() string {
+func (self Coordinates3D) StringXY() string {
 	return fmt.Sprintf("%.1fx%.1f mm", self.X, self.Y)
 }
 
 //Dim Value for dimension
-func (a Coordinates) Dim(x int) float64 {
+func (a Coordinates3D) Dim(x int) float64 {
 	switch x {
 	case 0:
 		return a.X
@@ -61,64 +61,64 @@ func (a Coordinates) Dim(x int) float64 {
 }
 
 //Add Addition returns a new wtype.Coordinates
-func (self Coordinates) Add(rhs Coordinates) Coordinates {
-	return Coordinates{self.X + rhs.X,
+func (self Coordinates3D) Add(rhs Coordinates3D) Coordinates3D {
+	return Coordinates3D{self.X + rhs.X,
 		self.Y + rhs.Y,
 		self.Z + rhs.Z}
 }
 
 //Subtract returns a new wtype.Coordinates
-func (self Coordinates) Subtract(rhs Coordinates) Coordinates {
-	return Coordinates{self.X - rhs.X,
+func (self Coordinates3D) Subtract(rhs Coordinates3D) Coordinates3D {
+	return Coordinates3D{self.X - rhs.X,
 		self.Y - rhs.Y,
 		self.Z - rhs.Z}
 }
 
 //Multiply returns a new wtype.Coordinates
-func (self Coordinates) Multiply(v float64) Coordinates {
-	return Coordinates{self.X * v,
+func (self Coordinates3D) Multiply(v float64) Coordinates3D {
+	return Coordinates3D{self.X * v,
 		self.Y * v,
 		self.Z * v}
 }
 
 //Divide returns a new wtype.Coordinates divided by v. If v is zero, inf will be returned
-func (self Coordinates) Divide(v float64) Coordinates {
-	return Coordinates{self.X / v,
+func (self Coordinates3D) Divide(v float64) Coordinates3D {
+	return Coordinates3D{self.X / v,
 		self.Y / v,
 		self.Z / v}
 }
 
 //Dot product
-func (self Coordinates) Dot(rhs Coordinates) float64 {
+func (self Coordinates3D) Dot(rhs Coordinates3D) float64 {
 	return self.X*rhs.X + self.Y + rhs.Y + self.Z + rhs.Z
 }
 
 //Abs L2-Norm
-func (self Coordinates) Abs() float64 {
+func (self Coordinates3D) Abs() float64 {
 	return math.Sqrt(self.X*self.X + self.Y*self.Y + self.Z*self.Z)
 }
 
 //AbsXY L2-Norm in XY only
-func (self Coordinates) AbsXY() float64 {
+func (self Coordinates3D) AbsXY() float64 {
 	return math.Sqrt(self.X*self.X + self.Y*self.Y)
 }
 
 //Unit return a Unit vector in the same direction as the coordinates
-func (self Coordinates) Unit() Coordinates {
+func (self Coordinates3D) Unit() Coordinates3D {
 	return self.Divide(self.Abs())
 }
 
 //To2D return a two dimensional coordinate by dropping z dimension
-func (self Coordinates) To2D() Coordinates2D {
+func (self Coordinates3D) To2D() Coordinates2D {
 	return Coordinates2D{
 		X: self.X,
 		Y: self.Y,
 	}
 }
 
-type PointSet []Coordinates
+type PointSet []Coordinates3D
 
-func (ps PointSet) CentreTo(c Coordinates) PointSet {
+func (ps PointSet) CentreTo(c Coordinates3D) PointSet {
 	ret := make(PointSet, len(ps))
 
 	for i, p := range ps {

--- a/antha/anthalib/wtype/iterators_test.go
+++ b/antha/anthalib/wtype/iterators_test.go
@@ -27,12 +27,12 @@ func (self *testAddressable) GetChildByAddress(WellCoords) LHObject {
 	return (LHObject)(nil)
 }
 
-func (self *testAddressable) CoordsToWellCoords(c Coordinates) (WellCoords, Coordinates) {
-	return WellCoords{}, Coordinates{}
+func (self *testAddressable) CoordsToWellCoords(c Coordinates3D) (WellCoords, Coordinates3D) {
+	return WellCoords{}, Coordinates3D{}
 }
 
-func (self *testAddressable) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates, bool) {
-	return Coordinates{}, true
+func (self *testAddressable) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates3D, bool) {
+	return Coordinates3D{}, true
 }
 
 type addressIteratorTest struct {

--- a/antha/anthalib/wtype/lhdeck.go
+++ b/antha/anthalib/wtype/lhdeck.go
@@ -33,11 +33,11 @@ import (
 type deckSlot struct {
 	contents LHObject
 	position Coordinates
-	size     Coordinates
+	size     Coordinates2D
 	accepts  []string
 }
 
-func newDeckSlot(position, size Coordinates) *deckSlot {
+func newDeckSlot(position Coordinates, size Coordinates2D) *deckSlot {
 	r := deckSlot{nil, position, size, make([]string, 0)}
 	return &r
 }
@@ -286,13 +286,13 @@ func (self *LHDeck) Accepts(name string, child LHObject) bool {
 	return false
 }
 
-func (self *LHDeck) GetSlotSize(name string) Coordinates {
+func (self *LHDeck) GetSlotSize(name string) Coordinates2D {
 	return self.slots[name].size
 }
 
 //LHDeck specific methods
 
-func (self *LHDeck) AddSlot(name string, position, size Coordinates) {
+func (self *LHDeck) AddSlot(name string, position Coordinates, size Coordinates2D) {
 	self.slots[name] = newDeckSlot(position, size)
 }
 

--- a/antha/anthalib/wtype/lhdeck.go
+++ b/antha/anthalib/wtype/lhdeck.go
@@ -32,17 +32,17 @@ import (
 
 type deckSlot struct {
 	contents LHObject
-	position Coordinates
+	position Coordinates3D
 	size     Coordinates2D
 	accepts  []string
 }
 
-func newDeckSlot(position Coordinates, size Coordinates2D) *deckSlot {
+func newDeckSlot(position Coordinates3D, size Coordinates2D) *deckSlot {
 	r := deckSlot{nil, position, size, make([]string, 0)}
 	return &r
 }
 
-func (self *deckSlot) Fits(size Coordinates) bool {
+func (self *deckSlot) Fits(size Coordinates3D) bool {
 	//.1mm tolerance for potential numerical error
 	return math.Abs(self.size.X-size.X) < 0.1 &&
 		math.Abs(self.size.Y-size.Y) < 0.1
@@ -65,7 +65,7 @@ func (self *deckSlot) GetAccepted() []string {
 	return self.accepts
 }
 
-func (self *deckSlot) IsBelow(point Coordinates) bool {
+func (self *deckSlot) IsBelow(point Coordinates3D) bool {
 	return (point.X >= self.position.X && point.X <= self.position.X+self.size.X &&
 		point.Y >= self.position.Y && point.Y <= self.position.Y+self.size.Y)
 }
@@ -144,13 +144,13 @@ func (self *LHDeck) GetID() string {
 
 //@implements LHObject
 
-func (self *LHDeck) GetPosition() Coordinates {
-	return Coordinates{}
+func (self *LHDeck) GetPosition() Coordinates3D {
+	return Coordinates3D{}
 }
 
 //zero size
-func (self *LHDeck) GetSize() Coordinates {
-	return Coordinates{}
+func (self *LHDeck) GetSize() Coordinates3D {
+	return Coordinates3D{}
 }
 
 func (self *LHDeck) GetBoxIntersections(box BBox) []LHObject {
@@ -163,7 +163,7 @@ func (self *LHDeck) GetBoxIntersections(box BBox) []LHObject {
 	return ret
 }
 
-func (self *LHDeck) GetPointIntersections(point Coordinates) []LHObject {
+func (self *LHDeck) GetPointIntersections(point Coordinates3D) []LHObject {
 	ret := []LHObject{}
 	for _, ds := range self.slots {
 		if ds.contents != nil {
@@ -173,7 +173,7 @@ func (self *LHDeck) GetPointIntersections(point Coordinates) []LHObject {
 	return ret
 }
 
-func (self *LHDeck) SetOffset(o Coordinates) error {
+func (self *LHDeck) SetOffset(o Coordinates3D) error {
 	return fmt.Errorf("Can't set offset for deck \"%s\"", self.GetName())
 }
 
@@ -222,14 +222,14 @@ func (self *LHDeck) GetSlotNames() []string {
 	return ret
 }
 
-func (self *LHDeck) GetSlotPosition(name string) Coordinates {
+func (self *LHDeck) GetSlotPosition(name string) Coordinates3D {
 	if self == nil {
-		return Coordinates{}
+		return Coordinates3D{}
 	}
 	if ds, ok := self.slots[name]; ok {
 		return ds.position
 	}
-	return Coordinates{}
+	return Coordinates3D{}
 }
 
 func (self *LHDeck) GetSlotContaining(obj LHObject) string {
@@ -292,7 +292,7 @@ func (self *LHDeck) GetSlotSize(name string) Coordinates2D {
 
 //LHDeck specific methods
 
-func (self *LHDeck) AddSlot(name string, position Coordinates, size Coordinates2D) {
+func (self *LHDeck) AddSlot(name string, position Coordinates3D, size Coordinates2D) {
 	self.slots[name] = newDeckSlot(position, size)
 }
 
@@ -302,7 +302,7 @@ func (self *LHDeck) SetSlotAccepts(name string, class string) {
 	}
 }
 
-func (self *LHDeck) GetSlotNamesBelow(point Coordinates) []string {
+func (self *LHDeck) GetSlotNamesBelow(point Coordinates3D) []string {
 	ret := make([]string, 0)
 	for name, slot := range self.slots {
 		if slot.IsBelow(point) {
@@ -313,7 +313,7 @@ func (self *LHDeck) GetSlotNamesBelow(point Coordinates) []string {
 }
 
 //get all objects above and below the point
-func (self *LHDeck) GetVChildren(point Coordinates) []LHObject {
+func (self *LHDeck) GetVChildren(point Coordinates3D) []LHObject {
 	//get all children in the same vertical plane
 	box := NewBBox6f(point.X, point.Y, -math.MaxFloat64/2, 0, 0, math.MaxFloat64)
 	return self.GetBoxIntersections(*box)
@@ -323,7 +323,7 @@ func (self *LHDeck) GetVChildren(point Coordinates) []LHObject {
 //Return the nearest object below the point, nil if none.
 //The base of the object is used as reference, so e.g. a point within a well
 //will return the plate
-func (self *LHDeck) GetChildBelow(point Coordinates) LHObject {
+func (self *LHDeck) GetChildBelow(point Coordinates3D) LHObject {
 	candidates := self.GetVChildren(point)
 	//find the closest that's below
 	z_off_min := math.MaxFloat64

--- a/antha/anthalib/wtype/lhhead_test.go
+++ b/antha/anthalib/wtype/lhhead_test.go
@@ -6,8 +6,8 @@ import (
 
 //makeAlignmentTestPlate make a plate setting only the important things
 func makeTestPlate(wellsX, wellsY int, offsetX, offsetY float64) *LHPlate {
-	plateSize := Coordinates{X: 127.76, Y: 85.48, Z: 15.0}
-	wellSize := Coordinates{X: plateSize.X / float64(wellsX), Y: plateSize.Y / float64(wellsY), Z: 15.0}
+	plateSize := Coordinates3D{X: 127.76, Y: 85.48, Z: 15.0}
+	wellSize := Coordinates3D{X: plateSize.X / float64(wellsX), Y: plateSize.Y / float64(wellsY), Z: 15.0}
 
 	shape := NewShape("box", "mm", wellSize.X, wellSize.Y, wellSize.Z)
 	well := NewLHWell("ul", 100.0, 10.0, shape, FlatWellBottom, wellSize.X, wellSize.Y, wellSize.Z, 0.0, "mm")

--- a/antha/anthalib/wtype/lhinterfaces.go
+++ b/antha/anthalib/wtype/lhinterfaces.go
@@ -133,7 +133,7 @@ type LHParent interface {
 	//Accepts test if slot can accept a certain class
 	Accepts(string, LHObject) bool
 	//GetSlotSize
-	GetSlotSize(string) Coordinates
+	GetSlotSize(string) Coordinates2D
 }
 
 //WellReference used for specifying position within a well

--- a/antha/anthalib/wtype/lhinterfaces.go
+++ b/antha/anthalib/wtype/lhinterfaces.go
@@ -78,15 +78,15 @@ func ClassOf(o interface{}) string {
 //of objects that exist within a liquid handler
 type LHObject interface {
 	//GetPosition get the absolute position of the object (mm)
-	GetPosition() Coordinates
+	GetPosition() Coordinates3D
 	//GetSize get the size of the object (mm)
-	GetSize() Coordinates
+	GetSize() Coordinates3D
 	//GetBoxIntersections get a list of LHObjects (can be this object or children) which intersect with the BBox
 	GetBoxIntersections(BBox) []LHObject
 	//GetPointIntersections get a list of LHObjects (can be this object or children) which intersect with the given point
-	GetPointIntersections(Coordinates) []LHObject
+	GetPointIntersections(Coordinates3D) []LHObject
 	//SetOffset set the offset of the object relative to its parent (global if parent is nil)
-	SetOffset(Coordinates) error
+	SetOffset(Coordinates3D) error
 	//SetParent Store the offset of the object
 	SetParent(LHObject) error
 	//ClearParent Clear the parent of the object
@@ -115,11 +115,11 @@ func GetObjectRoot(o LHObject) LHObject {
 }
 
 //get the origin for the objects coordinate system
-func OriginOf(o LHObject) Coordinates {
+func OriginOf(o LHObject) Coordinates3D {
 	if p := o.GetParent(); p != nil {
 		return p.GetPosition()
 	}
-	return Coordinates{}
+	return Coordinates3D{}
 }
 
 //LHParent An LHObject that can hold other LHObjects
@@ -175,21 +175,21 @@ type Addressable interface {
 	//of the center of the well/tip to the given coordinate
 	//(this leaves the caller to ascertain whether any mis-alignment
 	//is acceptable)
-	CoordsToWellCoords(Coordinates) (WellCoords, Coordinates)
+	CoordsToWellCoords(Coordinates3D) (WellCoords, Coordinates3D)
 	//WellCoordsToCoords Get the physical location of an addressable
 	//position relative to the object origin.
 	//WellCoords should be valid in the object, or the bool will
 	//return false and Coordinates are undefined.
 	//WellReference is the position within a well.
 	//Requesting LiquidReference on a LHTipbox will return false
-	WellCoordsToCoords(WellCoords, WellReference) (Coordinates, bool)
+	WellCoordsToCoords(WellCoords, WellReference) (Coordinates3D, bool)
 }
 
 type Targetted interface {
 	//GetTargetOffset Gets the well target location for the numbered channel of the named adaptor
-	GetTargetOffset(string, int) Coordinates
+	GetTargetOffset(string, int) Coordinates3D
 	//GetTargets return all the defined targets for the named adaptor
-	GetTargets(string) []Coordinates
+	GetTargets(string) []Coordinates3D
 }
 
 //LHContainer a tip or a well or something that holds liquids

--- a/antha/anthalib/wtype/lhtip.go
+++ b/antha/anthalib/wtype/lhtip.go
@@ -75,12 +75,12 @@ func (self *LHTip) GetClass() string {
 }
 
 //@implement LHObject
-func (self *LHTip) GetPosition() Coordinates {
+func (self *LHTip) GetPosition() Coordinates3D {
 	return OriginOf(self).Add(self.Bounds.GetPosition())
 }
 
 //@implement LHObject
-func (self *LHTip) GetSize() Coordinates {
+func (self *LHTip) GetSize() Coordinates3D {
 	return self.Bounds.GetSize()
 }
 
@@ -102,7 +102,7 @@ func (self *LHTip) GetBoxIntersections(box BBox) []LHObject {
 }
 
 //@implement LHObject
-func (self *LHTip) GetPointIntersections(point Coordinates) []LHObject {
+func (self *LHTip) GetPointIntersections(point Coordinates3D) []LHObject {
 	if self == nil {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (self *LHTip) GetPointIntersections(point Coordinates) []LHObject {
 }
 
 //@implement LHObject
-func (self *LHTip) SetOffset(point Coordinates) error {
+func (self *LHTip) SetOffset(point Coordinates3D) error {
 	self.Bounds.SetPosition(point)
 	return nil
 }
@@ -200,7 +200,7 @@ func NewLHTip(mfr, ttype string, minvol, maxvol float64, volunit string, filtere
 		MaxVol: wunit.NewVolume(maxvol, volunit),
 		MinVol: wunit.NewVolume(minvol, volunit),
 		Shape:  shape,
-		Bounds: BBox{Coordinates{}, Coordinates{
+		Bounds: BBox{Coordinates3D{}, Coordinates3D{
 			shape.Height().ConvertToString("mm"), //not a mistake, Shape currently has height&width as
 			shape.Width().ConvertToString("mm"),  // XY coordinates and Depth as Z
 			shape.Depth().ConvertToString("mm"),

--- a/antha/anthalib/wtype/lhtip_test.go
+++ b/antha/anthalib/wtype/lhtip_test.go
@@ -25,8 +25,8 @@ func TestTipSerialization(t *testing.T) {
 			MinVol: wunit.NewVolume(5, "ul"),
 			Shape:  &Shape{},
 			Bounds: BBox{
-				Position: Coordinates{X: 12.0, Y: 24.0, Z: 48.0},
-				Size:     Coordinates{X: 10.0, Y: 20.0, Z: 40.0},
+				Position: Coordinates3D{X: 12.0, Y: 24.0, Z: 48.0},
+				Size:     Coordinates3D{X: 10.0, Y: 20.0, Z: 40.0},
 			},
 			EffectiveHeight: 42.0,
 			Filtered:        true,

--- a/antha/anthalib/wtype/lhtipbox.go
+++ b/antha/anthalib/wtype/lhtipbox.go
@@ -53,7 +53,7 @@ type LHTipbox struct {
 	parent LHObject `gotopb:"-"`
 }
 
-func NewLHTipbox(nrows, ncols int, size Coordinates, manufacturer, boxtype string, tiptype *LHTip, well *LHWell, tipxoffset, tipyoffset, tipxstart, tipystart, tipzstart float64) *LHTipbox {
+func NewLHTipbox(nrows, ncols int, size Coordinates3D, manufacturer, boxtype string, tiptype *LHTip, well *LHWell, tipxoffset, tipyoffset, tipxstart, tipystart, tipzstart float64) *LHTipbox {
 	var tipbox LHTipbox
 	//tipbox.ID = "tipbox-" + GetUUID()
 	tipbox.ID = GetUUID()
@@ -233,26 +233,26 @@ func (tb *LHTipbox) HasEnoughTips(requested int) bool {
 //@implement LHObject
 //##############################################
 
-func (self *LHTipbox) GetPosition() Coordinates {
+func (self *LHTipbox) GetPosition() Coordinates3D {
 	if self.parent != nil {
 		return self.parent.GetPosition().Add(self.Bounds.GetPosition())
 	}
 	return self.Bounds.GetPosition()
 }
 
-func (self *LHTipbox) GetSize() Coordinates {
+func (self *LHTipbox) GetSize() Coordinates3D {
 	return self.Bounds.GetSize()
 }
 
 func (self *LHTipbox) GetTipBounds() BBox {
 	tipSize := self.Tiptype.GetSize()
 
-	pos := self.Bounds.GetPosition().Add(Coordinates{
+	pos := self.Bounds.GetPosition().Add(Coordinates3D{
 		X: self.TipXStart - 0.5*tipSize.X,
 		Y: self.TipYStart - 0.5*tipSize.Y,
 		Z: self.TipZStart})
 
-	size := Coordinates{
+	size := Coordinates3D{
 		X: self.TipXOffset*float64(self.NCols()-1) + tipSize.X,
 		Y: self.TipYOffset*float64(self.NRows()-1) + tipSize.Y,
 		Z: tipSize.Z,
@@ -330,7 +330,7 @@ func trimToMask(wells []string, mask []bool) []string {
 	return ret
 }
 
-func (self *LHTipbox) GetPointIntersections(point Coordinates) []LHObject {
+func (self *LHTipbox) GetPointIntersections(point Coordinates3D) []LHObject {
 	//relative point
 	relPoint := point.Subtract(OriginOf(self))
 	ret := []LHObject{}
@@ -349,7 +349,7 @@ func (self *LHTipbox) GetPointIntersections(point Coordinates) []LHObject {
 	return ret
 }
 
-func (self *LHTipbox) SetOffset(o Coordinates) error {
+func (self *LHTipbox) SetOffset(o Coordinates3D) error {
 	self.Bounds.SetPosition(o)
 	return nil
 }
@@ -415,7 +415,7 @@ func (tb *LHTipbox) GetChildByAddress(c WellCoords) LHObject {
 	return tb.Tips[c.X][c.Y]
 }
 
-func (tb *LHTipbox) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
+func (tb *LHTipbox) CoordsToWellCoords(r Coordinates3D) (WellCoords, Coordinates3D) {
 	//get relative Coordinates
 	rel := r.Subtract(tb.GetPosition())
 	tipSize := tb.Tiptype.GetSize()
@@ -439,9 +439,9 @@ func (tb *LHTipbox) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) 
 	return wc, r.Subtract(r2)
 }
 
-func (tb *LHTipbox) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates, bool) {
+func (tb *LHTipbox) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates3D, bool) {
 	if !tb.AddressExists(wc) {
-		return Coordinates{}, false
+		return Coordinates3D{}, false
 	}
 
 	var z float64
@@ -450,10 +450,10 @@ func (tb *LHTipbox) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordina
 	} else if r == TopReference {
 		z = tb.TipZStart + tb.Tiptype.GetSize().Z
 	} else {
-		return Coordinates{}, false
+		return Coordinates3D{}, false
 	}
 
-	return tb.GetPosition().Add(Coordinates{
+	return tb.GetPosition().Add(Coordinates3D{
 		tb.TipXStart + float64(wc.X)*tb.TipXOffset,
 		tb.TipYStart + float64(wc.Y)*tb.TipYOffset,
 		z}), true
@@ -773,7 +773,7 @@ func initialize_tips(tipbox *LHTipbox, tiptype *LHTip) *LHTipbox {
 	for i := 0; i < nc; i++ {
 		for j := 0; j < nr; j++ {
 			tipbox.Tips[i][j] = tiptype.Dup()
-			tipbox.Tips[i][j].SetOffset(Coordinates{ //nolint
+			tipbox.Tips[i][j].SetOffset(Coordinates3D{ //nolint
 				X: tipbox.TipXStart + float64(i)*tipbox.TipXOffset + x_off,
 				Y: tipbox.TipYStart + float64(j)*tipbox.TipYOffset + y_off,
 				Z: tipbox.TipZStart,

--- a/antha/anthalib/wtype/lhtipbox_test.go
+++ b/antha/anthalib/wtype/lhtipbox_test.go
@@ -10,7 +10,7 @@ func makeTipboxForTest() *LHTipbox {
 	shp := NewShape("cylinder", "mm", 7.3, 7.3, 51.2)
 	w := NewLHWell("ul", 250.0, 10.0, shp, FlatWellBottom, 7.3, 7.3, 51.2, 0.0, "mm")
 	tiptype := makeTipForTest()
-	tb := NewLHTipbox(8, 12, Coordinates{127.76, 85.48, 120.0}, "me", "mytype", tiptype, w, 9.0, 9.0, 0.5, 0.5, 0.0)
+	tb := NewLHTipbox(8, 12, Coordinates3D{127.76, 85.48, 120.0}, "me", "mytype", tiptype, w, 9.0, 9.0, 0.5, 0.5, 0.0)
 	return tb
 }
 
@@ -147,7 +147,7 @@ func TestTipboxCoordsToWellCoords(t *testing.T) {
 
 	tb := makeTipboxForTest()
 
-	pos := Coordinates{
+	pos := Coordinates3D{
 		X: tb.TipXStart + 0.75*tb.TipXOffset,
 		Y: tb.TipYStart + 0.75*tb.TipYOffset,
 	}
@@ -169,12 +169,12 @@ func TestTipboxGetWellBounds(t *testing.T) {
 
 	tb := makeTipboxForTest()
 
-	eStart := Coordinates{
+	eStart := Coordinates3D{
 		X: 0.5 - 0.5*7.3,
 		Y: 0.5 - 0.5*7.3,
 		Z: 0.0,
 	}
-	eSize := Coordinates{
+	eSize := Coordinates3D{
 		X: 9.0*11 + 7.3,
 		Y: 9.0*7 + 7.3,
 		Z: 51.2,

--- a/antha/anthalib/wtype/lhtipwaste.go
+++ b/antha/anthalib/wtype/lhtipwaste.go
@@ -108,7 +108,7 @@ func (self *LHTipwaste) GetClass() string {
 	return "tipwaste"
 }
 
-func NewLHTipwaste(capacity int, typ, mfr string, size Coordinates, w *LHWell, wellxstart, wellystart, wellzstart float64) *LHTipwaste {
+func NewLHTipwaste(capacity int, typ, mfr string, size Coordinates3D, w *LHWell, wellxstart, wellystart, wellzstart float64) *LHTipwaste {
 	var lht LHTipwaste
 	//	lht.ID = "tipwaste-" + GetUUID()
 	lht.ID = GetUUID()
@@ -123,7 +123,7 @@ func NewLHTipwaste(capacity int, typ, mfr string, size Coordinates, w *LHWell, w
 	lht.WellZStart = wellzstart
 
 	w.SetParent(&lht) //nolint
-	offset := Coordinates{
+	offset := Coordinates3D{
 		X: wellxstart - 0.5*w.GetSize().X,
 		Y: wellystart - 0.5*w.GetSize().Y,
 		Z: wellzstart,
@@ -172,14 +172,14 @@ func (lht *LHTipwaste) DisposeNum(num int) bool {
 //@implement LHObject
 //##############################################
 
-func (self *LHTipwaste) GetPosition() Coordinates {
+func (self *LHTipwaste) GetPosition() Coordinates3D {
 	if self.parent != nil {
 		return self.parent.GetPosition().Add(self.Bounds.GetPosition())
 	}
 	return self.Bounds.GetPosition()
 }
 
-func (self *LHTipwaste) GetSize() Coordinates {
+func (self *LHTipwaste) GetSize() Coordinates3D {
 	return self.Bounds.GetSize()
 }
 
@@ -197,7 +197,7 @@ func (self *LHTipwaste) GetBoxIntersections(box BBox) []LHObject {
 	return ret
 }
 
-func (self *LHTipwaste) GetPointIntersections(point Coordinates) []LHObject {
+func (self *LHTipwaste) GetPointIntersections(point Coordinates3D) []LHObject {
 	if r := self.AsWell.GetPointIntersections(point); len(r) > 0 {
 		return r
 	}
@@ -213,7 +213,7 @@ func (self *LHTipwaste) GetPointIntersections(point Coordinates) []LHObject {
 	return ret
 }
 
-func (self *LHTipwaste) SetOffset(o Coordinates) error {
+func (self *LHTipwaste) SetOffset(o Coordinates3D) error {
 	self.Bounds.SetPosition(o)
 	return nil
 }
@@ -269,7 +269,7 @@ func (self *LHTipwaste) GetChildByAddress(c WellCoords) LHObject {
 	return self.AsWell
 }
 
-func (self *LHTipwaste) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
+func (self *LHTipwaste) CoordsToWellCoords(r Coordinates3D) (WellCoords, Coordinates3D) {
 	wc := WellCoords{0, 0}
 
 	c, _ := self.WellCoordsToCoords(wc, TopReference)
@@ -277,9 +277,9 @@ func (self *LHTipwaste) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinat
 	return wc, r.Subtract(c)
 }
 
-func (self *LHTipwaste) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates, bool) {
+func (self *LHTipwaste) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates3D, bool) {
 	if !self.AddressExists(wc) {
-		return Coordinates{}, false
+		return Coordinates3D{}, false
 	}
 
 	var z float64
@@ -288,26 +288,26 @@ func (self *LHTipwaste) WellCoordsToCoords(wc WellCoords, r WellReference) (Coor
 	} else if r == TopReference {
 		z = self.WellZStart + self.AsWell.GetSize().Z
 	} else {
-		return Coordinates{}, false
+		return Coordinates3D{}, false
 	}
 
-	return self.GetPosition().Add(Coordinates{
+	return self.GetPosition().Add(Coordinates3D{
 		self.WellXStart,
 		self.WellYStart,
 		z}), true
 }
 
 //GetTargetOffset get the offset for addressing a well with the named adaptor and channel
-func (self *LHTipwaste) GetTargetOffset(adaptorName string, channel int) Coordinates {
+func (self *LHTipwaste) GetTargetOffset(adaptorName string, channel int) Coordinates3D {
 	targets := self.AsWell.GetWellTargets(adaptorName)
 	if channel < 0 || channel >= len(targets) {
-		return Coordinates{}
+		return Coordinates3D{}
 	}
 	return targets[channel]
 }
 
 //GetTargets return all the defined targets for the named adaptor
-func (self *LHTipwaste) GetTargets(adaptorName string) []Coordinates {
+func (self *LHTipwaste) GetTargets(adaptorName string) []Coordinates3D {
 	return self.AsWell.GetWellTargets(adaptorName)
 }
 

--- a/antha/anthalib/wtype/lhtipwaste_test.go
+++ b/antha/anthalib/wtype/lhtipwaste_test.go
@@ -9,7 +9,7 @@ import (
 func makeTipwasteForTest() *LHTipwaste {
 	shp := NewShape("box", "mm", 123.0, 80.0, 92.0)
 	w := NewLHWell("ul", 800000.0, 800000.0, shp, 0, 123.0, 80.0, 92.0, 0.0, "mm")
-	lht := NewLHTipwaste(6000, "TipwasteForTest", "ACME Corp.", Coordinates{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
+	lht := NewLHTipwaste(6000, "TipwasteForTest", "ACME Corp.", Coordinates3D{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
 	return lht
 }
 
@@ -35,9 +35,9 @@ func TestTipwasteCoordsToWellCoords(t *testing.T) {
 
 	tw := makeTipwasteForTest()
 
-	eDelta := Coordinates{X: -0.2 * tw.AsWell.GetSize().X, Y: -0.3 * tw.AsWell.GetSize().Y}
+	eDelta := Coordinates3D{X: -0.2 * tw.AsWell.GetSize().X, Y: -0.3 * tw.AsWell.GetSize().Y}
 
-	pos := Coordinates{
+	pos := Coordinates3D{
 		X: tw.WellXStart + eDelta.X,
 		Y: tw.WellYStart + eDelta.Y,
 	}
@@ -56,7 +56,7 @@ func TestTipwasteCoordsToWellCoords(t *testing.T) {
 
 func TestTipwasteSerialisation(t *testing.T) {
 	partFull := makeTipwasteForTest()
-	partFull.SetOffset(Coordinates{X: 1.0, Y: 2.0, Z: 3.0})
+	partFull.SetOffset(Coordinates3D{X: 1.0, Y: 2.0, Z: 3.0})
 	partFull.Contents = 300
 
 	tipwastes := []*LHTipwaste{

--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -216,12 +216,12 @@ func (lhd *LHDevice) Dup() *LHDevice {
 // describes a position on the liquid handling deck
 type LHPosition struct {
 	Name     string        // human readable name of the position chosen by device driver
-	Location Coordinates   // absolute position of read left corner of the position
+	Location Coordinates3D // absolute position of read left corner of the position
 	Size     Coordinates2D // size of the position - equal to the footprint of objects which can be accepted
 }
 
 // NewLHPosition constructs a new position on a liquidhandling deck
-func NewLHPosition(name string, location Coordinates, size Coordinates2D) *LHPosition {
+func NewLHPosition(name string, location Coordinates3D, size Coordinates2D) *LHPosition {
 	return &LHPosition{
 		Name:     name,
 		Location: location,
@@ -362,7 +362,7 @@ func (s TipLoadingBehaviour) String() string {
 
 // LHHeadAssemblyPosition a position within a head assembly
 type LHHeadAssemblyPosition struct {
-	Offset Coordinates
+	Offset Coordinates3D
 	Head   *LHHead
 }
 
@@ -413,7 +413,7 @@ func (self *LHHeadAssembly) DupWithoutHeads() *LHHeadAssembly {
 }
 
 //AddPosition add a position to the head assembly with the given offset
-func (self *LHHeadAssembly) AddPosition(Offset Coordinates) {
+func (self *LHHeadAssembly) AddPosition(Offset Coordinates3D) {
 	p := LHHeadAssemblyPosition{
 		Offset: Offset,
 	}

--- a/antha/anthalib/wtype/lhtypes.go
+++ b/antha/anthalib/wtype/lhtypes.go
@@ -215,15 +215,17 @@ func (lhd *LHDevice) Dup() *LHDevice {
 
 // describes a position on the liquid handling deck
 type LHPosition struct {
-	Name     string      // human readable name of the position chosen by device driver
-	Location Coordinates // absolute position of read left corner of the position
+	Name     string        // human readable name of the position chosen by device driver
+	Location Coordinates   // absolute position of read left corner of the position
+	Size     Coordinates2D // size of the position - equal to the footprint of objects which can be accepted
 }
 
 // NewLHPosition constructs a new position on a liquidhandling deck
-func NewLHPosition(name string, location Coordinates) *LHPosition {
+func NewLHPosition(name string, location Coordinates, size Coordinates2D) *LHPosition {
 	return &LHPosition{
 		Name:     name,
 		Location: location,
+		Size:     size,
 	}
 }
 

--- a/antha/anthalib/wtype/lhwell.go
+++ b/antha/anthalib/wtype/lhwell.go
@@ -89,12 +89,12 @@ func (self *LHWell) GetWellCoords() WellCoords {
 }
 
 //@implement LHObject
-func (self *LHWell) GetPosition() Coordinates {
+func (self *LHWell) GetPosition() Coordinates3D {
 	return OriginOf(self).Add(self.Bounds.GetPosition())
 }
 
 //@implement LHObject
-func (self *LHWell) GetSize() Coordinates {
+func (self *LHWell) GetSize() Coordinates3D {
 	return self.Bounds.GetSize()
 }
 
@@ -113,7 +113,7 @@ func (self *LHWell) GetBoxIntersections(box BBox) []LHObject {
 }
 
 //@implement LHObject
-func (self *LHWell) GetPointIntersections(point Coordinates) []LHObject {
+func (self *LHWell) GetPointIntersections(point Coordinates3D) []LHObject {
 	//relative point
 	point = point.Subtract(OriginOf(self))
 	//At some point this should be called self.shape for a more accurate intersection test
@@ -125,7 +125,7 @@ func (self *LHWell) GetPointIntersections(point Coordinates) []LHObject {
 }
 
 //@implement LHObject
-func (self *LHWell) SetOffset(point Coordinates) error {
+func (self *LHWell) SetOffset(point Coordinates3D) error {
 	self.Bounds.SetPosition(point)
 	return nil
 }
@@ -639,7 +639,7 @@ func NewLHWell(vunit string, vol, rvol float64, shape *Shape, bott WellBottomTyp
 	well.Rvol = wunit.NewVolume(rvol, vunit).ConvertToString("ul")
 	well.WShape = shape.Dup()
 	well.Bottom = bott
-	well.Bounds = BBox{Coordinates{}, Coordinates{
+	well.Bounds = BBox{Coordinates3D{}, Coordinates3D{
 		wunit.NewLength(xdim, dunit).ConvertToString("mm"),
 		wunit.NewLength(ydim, dunit).ConvertToString("mm"),
 		wunit.NewLength(zdim, dunit).ConvertToString("mm"),
@@ -862,22 +862,22 @@ func (w LHWell) CheckExtraKey(s string) error {
 
 const wellTargetKey = "well_targets"
 
-func (w *LHWell) getTargetMap() map[string][]Coordinates {
+func (w *LHWell) getTargetMap() map[string][]Coordinates3D {
 	m, ok := w.Extra[wellTargetKey]
 	if !ok {
-		ret := make(map[string][]Coordinates)
+		ret := make(map[string][]Coordinates3D)
 		w.Extra[wellTargetKey] = ret
 		return ret
 	}
-	ret, ok := m.(map[string][]Coordinates)
+	ret, ok := m.(map[string][]Coordinates3D)
 	//gets broken by serialise/deserialise
 	if !ok {
-		ret := make(map[string][]Coordinates)
+		ret := make(map[string][]Coordinates3D)
 		for name, coords := range m.(map[string]interface{}) {
-			ret[name] = make([]Coordinates, 0)
+			ret[name] = make([]Coordinates3D, 0)
 			for _, crd := range coords.([]interface{}) {
 				c := crd.(map[string]interface{})
-				ret[name] = append(ret[name], Coordinates{X: c["X"].(float64),
+				ret[name] = append(ret[name], Coordinates3D{X: c["X"].(float64),
 					Y: c["Y"].(float64),
 					Z: c["Z"].(float64)})
 			}
@@ -892,18 +892,18 @@ func (w *LHWell) getTargetMap() map[string][]Coordinates {
 //the well center for each channel.
 //len(offsets) specifies the maximum number of channels which can access the well
 //simultaneously using adaptor
-func (w *LHWell) SetWellTargets(adaptor string, offsets []Coordinates) {
+func (w *LHWell) SetWellTargets(adaptor string, offsets []Coordinates3D) {
 	wtMap := w.getTargetMap()
 	wtMap[adaptor] = offsets
 }
 
 //GetWellTargets return the well targets for the given adaptor
 //if the adaptor has no defined targets, simply returns the well center
-func (w *LHWell) GetWellTargets(adaptor string) []Coordinates {
+func (w *LHWell) GetWellTargets(adaptor string) []Coordinates3D {
 	wtMap := w.getTargetMap()
 	adaptorTargets, ok := wtMap[adaptor]
 	if !ok {
-		return []Coordinates{}
+		return []Coordinates3D{}
 	}
 	return adaptorTargets
 }

--- a/antha/anthalib/wtype/plate.go
+++ b/antha/anthalib/wtype/plate.go
@@ -590,7 +590,7 @@ func (lhp *Plate) NextEmptyWell(it AddressIterator) WellCoords {
 	return ZeroWellCoords()
 }
 
-func NewLHPlate(platetype, mfr string, nrows, ncols int, size Coordinates, welltype *LHWell, wellXOffset, wellYOffset, wellXStart, wellYStart, wellZStart float64) *Plate {
+func NewLHPlate(platetype, mfr string, nrows, ncols int, size Coordinates3D, welltype *LHWell, wellXOffset, wellYOffset, wellXStart, wellYStart, wellZStart float64) *Plate {
 	var lhp Plate
 	lhp.Type = platetype
 	//lhp.ID = "plate-" + GetUUID()
@@ -639,7 +639,7 @@ func NewLHPlate(platetype, mfr string, nrows, ncols int, size Coordinates, wellt
 			arr[i][j].Plate = &lhp
 			arr[i][j].Crds = crds
 			arr[i][j].WContents.Loc = lhp.ID + ":" + crds.FormatA1()
-			arr[i][j].SetOffset(Coordinates{ //nolint
+			arr[i][j].SetOffset(Coordinates3D{ //nolint
 				wellXStart + float64(j)*wellXOffset - xOff,
 				wellYStart + float64(i)*wellYOffset - yOff,
 				wellZStart,
@@ -947,28 +947,28 @@ func (p *Plate) GetAllConstraints() map[string][]string {
 //@implement LHObject
 //##############################################
 
-func (self *Plate) GetPosition() Coordinates {
+func (self *Plate) GetPosition() Coordinates3D {
 	if self.parent != nil {
 		return self.parent.GetPosition().Add(self.Bounds.GetPosition())
 	}
 	return self.Bounds.GetPosition()
 }
 
-func (self *Plate) GetSize() Coordinates {
+func (self *Plate) GetSize() Coordinates3D {
 	return self.Bounds.GetSize()
 }
 
-func (self *Plate) GetWellOffset() Coordinates {
-	return Coordinates{self.WellXStart, self.WellYStart, self.WellZStart}
+func (self *Plate) GetWellOffset() Coordinates3D {
+	return Coordinates3D{self.WellXStart, self.WellYStart, self.WellZStart}
 }
 
-func (self *Plate) GetWellCorner() Coordinates {
+func (self *Plate) GetWellCorner() Coordinates3D {
 	size := self.Welltype.GetSize()
-	return Coordinates{self.WellXStart - 0.5*size.X, self.WellYStart - 0.5*size.Y, self.WellZStart}
+	return Coordinates3D{self.WellXStart - 0.5*size.X, self.WellYStart - 0.5*size.Y, self.WellZStart}
 }
 
-func (self *Plate) GetWellSize() Coordinates {
-	return Coordinates{
+func (self *Plate) GetWellSize() Coordinates3D {
+	return Coordinates3D{
 		self.WellXOffset*float64(self.NCols()-1) + self.Welltype.GetSize().X,
 		self.WellYOffset*float64(self.NRows()-1) + self.Welltype.GetSize().Y,
 		self.Welltype.GetSize().Z,
@@ -1002,7 +1002,7 @@ func (self *Plate) GetBoxIntersections(box BBox) []LHObject {
 	return ret
 }
 
-func (self *Plate) GetPointIntersections(point Coordinates) []LHObject {
+func (self *Plate) GetPointIntersections(point Coordinates3D) []LHObject {
 	//relative
 	point = point.Subtract(OriginOf(self))
 	ret := []LHObject{}
@@ -1021,7 +1021,7 @@ func (self *Plate) GetPointIntersections(point Coordinates) []LHObject {
 	return ret
 }
 
-func (self *Plate) SetOffset(o Coordinates) error {
+func (self *Plate) SetOffset(o Coordinates3D) error {
 	self.Bounds.SetPosition(o)
 	return nil
 }
@@ -1095,7 +1095,7 @@ func (self *Plate) GetChildByAddress(c WellCoords) LHObject {
 	return self.Cols[c.X][c.Y]
 }
 
-func (self *Plate) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
+func (self *Plate) CoordsToWellCoords(r Coordinates3D) (WellCoords, Coordinates3D) {
 	rel := r.Subtract(self.GetPosition())
 	wellSize := self.Welltype.GetSize()
 	wc := WellCoords{
@@ -1118,9 +1118,9 @@ func (self *Plate) CoordsToWellCoords(r Coordinates) (WellCoords, Coordinates) {
 	return wc, r.Subtract(r2)
 }
 
-func (self *Plate) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates, bool) {
+func (self *Plate) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinates3D, bool) {
 	if !self.AddressExists(wc) {
-		return Coordinates{}, false
+		return Coordinates3D{}, false
 	}
 
 	child := self.GetChildByAddress(wc).(*LHWell)
@@ -1141,7 +1141,7 @@ func (self *Plate) WellCoordsToCoords(wc WellCoords, r WellReference) (Coordinat
 
 	center := child.GetPosition().Add(child.GetSize().Multiply(0.5))
 
-	return Coordinates{center.X, center.Y, z}, true
+	return Coordinates3D{center.X, center.Y, z}, true
 }
 
 func (p *Plate) ResetID(newID string) {
@@ -1411,16 +1411,16 @@ func (p *Plate) ColVol() wunit.Volume {
 }
 
 //GetTargetOffset get the offset for addressing a well with the named adaptor and channel
-func (p *Plate) GetTargetOffset(adaptorName string, channel int) Coordinates {
+func (p *Plate) GetTargetOffset(adaptorName string, channel int) Coordinates3D {
 	targets := p.Welltype.GetWellTargets(adaptorName)
 	if channel < 0 || channel >= len(targets) {
-		return Coordinates{}
+		return Coordinates3D{}
 	}
 	return targets[channel]
 }
 
 //GetTargets return all the defined targets for the named adaptor
-func (p *Plate) GetTargets(adaptorName string) []Coordinates {
+func (p *Plate) GetTargets(adaptorName string) []Coordinates3D {
 	return p.Welltype.GetWellTargets(adaptorName)
 }
 

--- a/antha/anthalib/wtype/plate_test.go
+++ b/antha/anthalib/wtype/plate_test.go
@@ -14,7 +14,7 @@ import (
 func makeplatefortest() *Plate {
 	swshp := NewShape("box", "mm", 8.2, 8.2, 41.3)
 	welltype := NewLHWell("ul", 200, 10, swshp, VWellBottom, 8.2, 8.2, 41.3, 4.7, "mm")
-	p := NewLHPlate("DSW96", "none", 8, 12, Coordinates{127.76, 85.48, 43.1}, welltype, 9.0, 9.0, 0.5, 0.5, 0.5)
+	p := NewLHPlate("DSW96", "none", 8, 12, Coordinates3D{127.76, 85.48, 43.1}, welltype, 9.0, 9.0, 0.5, 0.5, 0.5)
 	return p
 }
 
@@ -51,7 +51,7 @@ func make6platefortest() *LHPlate {
 func maketroughfortest() *Plate {
 	stshp := NewShape("box", "mm", 8.2, 72, 41.3)
 	trough12 := NewLHWell("ul", 15000, 5000, stshp, VWellBottom, 8.2, 72, 41.3, 4.7, "mm")
-	plate := NewLHPlate("DWST12", "Unknown", 1, 12, Coordinates{127.76, 85.48, 44.1}, trough12, 9, 9, 0, 30.0, 4.5)
+	plate := NewLHPlate("DWST12", "Unknown", 1, 12, Coordinates3D{127.76, 85.48, 44.1}, trough12, 9, 9, 0, 30.0, 4.5)
 	return plate
 }
 
@@ -509,7 +509,7 @@ func TestWellCoordsToCoords(t *testing.T) {
 	type TestCase struct {
 		Address          string
 		Reference        WellReference
-		ExpectedPosition Coordinates
+		ExpectedPosition Coordinates3D
 		ExpectingError   bool
 	}
 
@@ -517,17 +517,17 @@ func TestWellCoordsToCoords(t *testing.T) {
 		{
 			Address:          "A1",
 			Reference:        BottomReference,
-			ExpectedPosition: Coordinates{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.Bottomh},
+			ExpectedPosition: Coordinates3D{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.Bottomh},
 		},
 		{
 			Address:          "A1",
 			Reference:        TopReference,
-			ExpectedPosition: Coordinates{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.GetSize().Z},
+			ExpectedPosition: Coordinates3D{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.GetSize().Z},
 		},
 		{
 			Address:          "A1",
 			Reference:        LiquidReference,
-			ExpectedPosition: Coordinates{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.Bottomh + 9.264858420611434},
+			ExpectedPosition: Coordinates3D{X: plate.WellXStart, Y: plate.WellYStart, Z: plate.WellZStart + plate.Welltype.Bottomh + 9.264858420611434},
 		},
 		{
 			Address:        "Z1",
@@ -555,7 +555,7 @@ func TestCoordsToWellCoords(t *testing.T) {
 
 	plate := makeplatefortest()
 
-	pos := Coordinates{
+	pos := Coordinates3D{
 		X: plate.WellXStart + 0.75*plate.WellXOffset,
 		Y: plate.WellYStart + 0.75*plate.WellYOffset,
 	}
@@ -577,12 +577,12 @@ func TestGetWellBounds(t *testing.T) {
 
 	plate := makeplatefortest()
 
-	eStart := Coordinates{
+	eStart := Coordinates3D{
 		X: 0.5 - 0.5*8.2,
 		Y: 0.5 - 0.5*8.2,
 		Z: 0.5,
 	}
-	eSize := Coordinates{
+	eSize := Coordinates3D{
 		X: 9.0*11 + 8.2,
 		Y: 9.0*7 + 8.2,
 		Z: 41.3,

--- a/antha/anthalib/wtype/serialize.go
+++ b/antha/anthalib/wtype/serialize.go
@@ -207,7 +207,7 @@ func (w *LHWell) AddDimensions(lhwt *LHWellType) {
 	w.Rvol = wunit.NewVolume(lhwt.Rvol, lhwt.Vunit).ConvertToString("ul")
 	w.WShape = NewShape(ShapeTypeID(lhwt.ShapeName), lhwt.Dunit, lhwt.Xdim, lhwt.Ydim, lhwt.Zdim)
 	w.Bottom = lhwt.Bottom
-	w.Bounds.SetSize(Coordinates{
+	w.Bounds.SetSize(Coordinates3D{
 		wunit.NewLength(lhwt.Xdim, lhwt.Dunit).ConvertToString("mm"),
 		wunit.NewLength(lhwt.Ydim, lhwt.Dunit).ConvertToString("mm"),
 		wunit.NewLength(lhwt.Zdim, lhwt.Dunit).ConvertToString("mm"),
@@ -421,7 +421,7 @@ func (stw *sTipwaste) Fill(tw *LHTipwaste) {
 }
 
 type sHeadAssemblyPosition struct {
-	Offset    Coordinates
+	Offset    Coordinates3D
 	HeadIndex int
 }
 

--- a/antha/anthalib/wtype/serialize_test.go
+++ b/antha/anthalib/wtype/serialize_test.go
@@ -132,7 +132,7 @@ func TestLHWellSerialize(t *testing.T) {
 			51.2,
 		},
 		FlatWellBottom,
-		BBox{Coordinates{}, Coordinates{7.3, 7.3, 51.2}},
+		BBox{Coordinates3D{}, Coordinates3D{7.3, 7.3, 51.2}},
 		46,
 		wellExtra,
 		nil,

--- a/driver/liquidhandling/objects_test.go
+++ b/driver/liquidhandling/objects_test.go
@@ -103,7 +103,7 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *liquidhandling.LH
 		xp = x0
 		for x := 0; x < 3; x++ {
 			posname := fmt.Sprintf("position_%d", i+1)
-			layout[posname] = wtype.NewLHPosition(posname, wtype.Coordinates{X: xp, Y: yp, Z: zp})
+			layout[posname] = wtype.NewLHPosition(posname, wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			i += 1
 			xp += xi
 		}

--- a/driver/liquidhandling/objects_test.go
+++ b/driver/liquidhandling/objects_test.go
@@ -14,7 +14,7 @@ import (
 func makePlateForTest() *wtype.Plate {
 	swshp := wtype.NewShape("box", "mm", 8.2, 8.2, 41.3)
 	welltype := wtype.NewLHWell("ul", 200, 10, swshp, wtype.VWellBottom, 8.2, 8.2, 41.3, 4.7, "mm")
-	p := wtype.NewLHPlate("DSW96", "none", 8, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 43.1}, welltype, 9.0, 9.0, 0.5, 0.5, 0.5)
+	p := wtype.NewLHPlate("DSW96", "none", 8, 12, wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 43.1}, welltype, 9.0, 9.0, 0.5, 0.5, 0.5)
 	return p
 }
 
@@ -27,14 +27,14 @@ func makeTipboxForTest() *wtype.LHTipbox {
 	shp := wtype.NewShape("cylinder", "mm", 7.3, 7.3, 51.2)
 	w := wtype.NewLHWell("ul", 250.0, 10.0, shp, wtype.FlatWellBottom, 7.3, 7.3, 51.2, 0.0, "mm")
 	tiptype := makeTipForTest()
-	tb := wtype.NewLHTipbox(8, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 120.0}, "me", "mytype", tiptype, w, 9.0, 9.0, 0.5, 0.5, 0.0)
+	tb := wtype.NewLHTipbox(8, 12, wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 120.0}, "me", "mytype", tiptype, w, 9.0, 9.0, 0.5, 0.5, 0.0)
 	return tb
 }
 
 func makeTipwasteForTest() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 123.0, 80.0, 92.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 123.0, 80.0, 92.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(6000, "TipwasteForTest", "ACME Corp.", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
+	lht := wtype.NewLHTipwaste(6000, "TipwasteForTest", "ACME Corp.", wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
 	return lht
 }
 
@@ -103,7 +103,7 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *liquidhandling.LH
 		xp = x0
 		for x := 0; x < 3; x++ {
 			posname := fmt.Sprintf("position_%d", i+1)
-			layout[posname] = wtype.NewLHPosition(posname, wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
+			layout[posname] = wtype.NewLHPosition(posname, wtype.Coordinates3D{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			i += 1
 			xp += xi
 		}
@@ -133,8 +133,8 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *liquidhandling.LH
 	lvhead.Adaptor = lvadaptor
 
 	ha := wtype.NewLHHeadAssembly(nil)
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: -18.08, Z: 0})
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: 0, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: -18.08, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: 0, Z: 0})
 	ha.LoadHead(hvhead)
 	ha.LoadHead(lvhead)
 	lhp.Heads = append(lhp.Heads, hvhead, lvhead)

--- a/inventory/testinventory/make_tip_library.go
+++ b/inventory/testinventory/make_tip_library.go
@@ -32,8 +32,8 @@ const (
 	sbsY    = 85.48
 )
 
-func getTipboxSize() wtype.Coordinates {
-	return wtype.Coordinates{X: sbsX, Y: sbsY, Z: 60.13}
+func getTipboxSize() wtype.Coordinates3D {
+	return wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 60.13}
 }
 
 func makeTipboxes() (tipboxes []*wtype.LHTipbox) {

--- a/inventory/testinventory/make_tip_waste_library.go
+++ b/inventory/testinventory/make_tip_waste_library.go
@@ -31,7 +31,7 @@ func makeTipwastes() (tipwastes []*wtype.LHTipwaste) {
 func makeGilsonTipWaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 123.0, 80.0, 92.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 123.0, 80.0, 92.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 92.0}, w, 49.5+xOffset, 31.5+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 92.0}, w, 49.5+xOffset, 31.5+yOffset, 0.0)
 	return lht
 }
 
@@ -39,7 +39,7 @@ func makeGilsonTipWaste() *wtype.LHTipwaste {
 func makeGilsonTipChute() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 50.0, 63.8, 82.98)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, wtype.FlatWellBottom, 50.0, 63.8, 82.98, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(6000, "GilsonTipChute", "gilson", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 50.0}, w, sbsX/2.0, sbsY/2.0, 0.0)
+	lht := wtype.NewLHTipwaste(6000, "GilsonTipChute", "gilson", wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 50.0}, w, sbsX/2.0, sbsY/2.0, 0.0)
 	return lht
 }
 
@@ -47,7 +47,7 @@ func makeGilsonTipChute() *wtype.LHTipwaste {
 func makeCyBioTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(700, "CyBiotipwaste", "cybio", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(700, "CyBiotipwaste", "cybio", wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }
 
@@ -55,13 +55,13 @@ func makeCyBioTipwaste() *wtype.LHTipwaste {
 func makeManualTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(1000000, "Manualtipwaste", "ACMEBagsInc", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(1000000, "Manualtipwaste", "ACMEBagsInc", wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }
 
 func makeTecanTipwaste() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 90.5, 171.0, 90.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 90.5, 171.0, 90.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(2000, "Tecantipwaste", "Tecan", wtype.Coordinates{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
+	lht := wtype.NewLHTipwaste(2000, "Tecantipwaste", "Tecan", wtype.Coordinates3D{X: sbsX, Y: sbsY, Z: 90.5}, w, 85.5+xOffset, 45.0+yOffset, 0.0)
 	return lht
 }

--- a/inventory/testinventory/serialPlate.go
+++ b/inventory/testinventory/serialPlate.go
@@ -50,7 +50,7 @@ func (pt PlateForSerializing) LHPlate() *wtype.Plate {
 
 	return plate
 }
-func makePlateCoords(height float64) wtype.Coordinates {
+func makePlateCoords(height float64) wtype.Coordinates3D {
 	//standard X/Y size for 96 well plates
-	return wtype.Coordinates{X: 127.76, Y: 85.48, Z: height}
+	return wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: height}
 }

--- a/inventory/testinventory/serialize/make_plate_library.go
+++ b/inventory/testinventory/serialize/make_plate_library.go
@@ -78,7 +78,7 @@ func addRiser(plate *wtype.Plate, riser device) (plates []*wtype.Plate) {
 		riserheight = riserheight + plateRiserSpecificOffset(plate, riser)
 
 		newplate.WellZStart = plate.WellZStart + riserheight
-		newplate.Bounds.SetSize(plate.GetSize().Add(wtype.Coordinates{X: 0.0, Y: 0.0, Z: riserheight}))
+		newplate.Bounds.SetSize(plate.GetSize().Add(wtype.Coordinates3D{X: 0.0, Y: 0.0, Z: riserheight}))
 		newname := plate.Type + "_" + risername
 		newplate.Type = newname
 		if riser.GetConstraints() != nil {
@@ -669,9 +669,9 @@ func makePCRPlateWell() *wtype.LHWell {
 	return pcrplatewell
 }
 
-func makePlateCoords(height float64) wtype.Coordinates {
+func makePlateCoords(height float64) wtype.Coordinates3D {
 	//standard X/Y size for 96 well plates
-	return wtype.Coordinates{X: 127.76, Y: 85.48, Z: height}
+	return wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: height}
 }
 
 func makePCRPlate() *wtype.Plate {

--- a/microArch/driver/liquidhandling/compositerobotinstruction.go
+++ b/microArch/driver/liquidhandling/compositerobotinstruction.go
@@ -3279,7 +3279,7 @@ func makeZOffsetSafe(ctx context.Context, prms *LHProperties, zoffset float64, h
 	adaptor := prms.GetLoadedAdaptor(headIndex)
 	channelSpacing := 9.0 //get this from adaptor in future
 	coneDiameter := 5.5   //get this from adaptor in future
-	adaptorSize := wtype.Coordinates{X: coneDiameter, Y: coneDiameter}
+	adaptorSize := wtype.Coordinates3D{X: coneDiameter, Y: coneDiameter}
 	adaptorWidth := channelSpacing*float64(adaptor.Params.Multi-1) + coneDiameter
 	if adaptor.Params.Orientation == wtype.LHVChannel {
 		adaptorSize.Y = adaptorWidth

--- a/microArch/driver/liquidhandling/testutils_test.go
+++ b/microArch/driver/liquidhandling/testutils_test.go
@@ -74,7 +74,7 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *LHProperties {
 	for y := 0; y < 3; y++ {
 		xp = x0
 		for x := 0; x < 3; x++ {
-			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp})
+			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			layout[pos.Name] = pos
 			i += 1
 			xp += xi

--- a/microArch/driver/liquidhandling/testutils_test.go
+++ b/microArch/driver/liquidhandling/testutils_test.go
@@ -74,7 +74,7 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *LHProperties {
 	for y := 0; y < 3; y++ {
 		xp = x0
 		for x := 0; x < 3; x++ {
-			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
+			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates3D{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			layout[pos.Name] = pos
 			i += 1
 			xp += xi
@@ -105,8 +105,8 @@ func makeGilsonForTest(ctx context.Context, tipList []string) *LHProperties {
 	lvhead.Adaptor = lvadaptor
 
 	ha := wtype.NewLHHeadAssembly(nil)
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: -18.08, Z: 0})
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: 0, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: -18.08, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: 0, Z: 0})
 	ha.LoadHead(hvhead)
 	ha.LoadHead(lvhead)
 	lhp.Heads = append(lhp.Heads, hvhead, lvhead)

--- a/microArch/sampletracker/sampletracker_test.go
+++ b/microArch/sampletracker/sampletracker_test.go
@@ -15,7 +15,7 @@ func assertLocation(t *testing.T, st *SampleTracker, id string, eloc string, eok
 func getPlateForTest() *wtype.Plate {
 	cone := wtype.NewShape("cylinder", "mm", 5.5, 5.5, 20.4)
 	welltype := wtype.NewLHWell("ul", 200, 5, cone, wtype.UWellBottom, 5.5, 5.5, 20.4, 1.4, "mm")
-	return wtype.NewLHPlate("pcrplate_skirted_riser", "Unknown", 8, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 25.7}, welltype, 9, 9, 0.0, 0.0, 38.5)
+	return wtype.NewLHPlate("pcrplate_skirted_riser", "Unknown", 8, 12, wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 25.7}, welltype, 9, 9, 0.0, 0.0, 38.5)
 }
 
 func getLiquidForTest(name string, volume float64) *wtype.Liquid {

--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -866,15 +866,15 @@ func addWellTargetsPlate(adaptor *wtype.LHAdaptor, plate *wtype.Plate) {
 	}
 
 	//channelPositions should come from the adaptor
-	channelPositions := make([]wtype.Coordinates, 0, adaptor.Params.Multi)
+	channelPositions := make([]wtype.Coordinates3D, 0, adaptor.Params.Multi)
 	for i := 0; i < adaptor.Params.Multi; i++ {
-		channelPositions = append(channelPositions, wtype.Coordinates{Y: float64(i) * adaptorSpacing})
+		channelPositions = append(channelPositions, wtype.Coordinates3D{Y: float64(i) * adaptorSpacing})
 	}
 
 	//ystart and count should come from some geometric calculation between channelPositions and well size
 	ystart, count := getWellTargetYStart(plate.NRows())
 
-	targets := make([]wtype.Coordinates, count)
+	targets := make([]wtype.Coordinates3D, count)
 	copy(targets, channelPositions)
 
 	for i := 0; i < count; i++ {
@@ -888,9 +888,9 @@ func addWellTargetsTipWaste(adaptor *wtype.LHAdaptor, waste *wtype.LHTipwaste) {
 	// this may vary in future but for now we just need to add the following eight entries:
 	ystart := -31.5
 	yinc := 9.0
-	targets := make([]wtype.Coordinates, 0, adaptor.Params.Multi)
+	targets := make([]wtype.Coordinates3D, 0, adaptor.Params.Multi)
 	for i := 0; i < adaptor.Params.Multi; i++ {
-		targets = append(targets, wtype.Coordinates{Y: ystart + float64(i)*yinc})
+		targets = append(targets, wtype.Coordinates3D{Y: ystart + float64(i)*yinc})
 	}
 
 	waste.AsWell.SetWellTargets(adaptor.Name, targets)

--- a/microArch/scheduler/liquidhandling/liquidhandling_test.go
+++ b/microArch/scheduler/liquidhandling/liquidhandling_test.go
@@ -56,7 +56,7 @@ func GetPlateForTest() *wtype.Plate {
 	cone := wtype.NewShape("cylinder", "mm", 5.5, 5.5, 20.4)
 	welltype := wtype.NewLHWell("ul", 200, 5, cone, wtype.UWellBottom, 5.5, 5.5, 20.4, 1.4, "mm")
 
-	plate := wtype.NewLHPlate("pcrplate_skirted_riser", "Unknown", 8, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 25.7}, welltype, 9, 9, 0.0, 0.0, riserheightinmm-1.25)
+	plate := wtype.NewLHPlate("pcrplate_skirted_riser", "Unknown", 8, 12, wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 25.7}, welltype, 9, 9, 0.0, 0.0, riserheightinmm-1.25)
 	return plate
 }
 
@@ -72,14 +72,14 @@ func PrefillPlateForTest(ctx context.Context, plate *wtype.LHPlate, liquidType s
 func GetTipwasteForTest() *wtype.LHTipwaste {
 	shp := wtype.NewShape("box", "mm", 123.0, 80.0, 92.0)
 	w := wtype.NewLHWell("ul", 800000.0, 800000.0, shp, 0, 123.0, 80.0, 92.0, 0.0, "mm")
-	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
+	lht := wtype.NewLHTipwaste(6000, "Gilsontipwaste", "gilson", wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 92.0}, w, 49.5, 31.5, 0.0)
 	return lht
 }
 
 func GetTroughForTest() *wtype.Plate {
 	stshp := wtype.NewShape("box", "mm", 8.2, 72, 41.3)
 	trough12 := wtype.NewLHWell("ul", 1500, 500, stshp, wtype.VWellBottom, 8.2, 72, 41.3, 4.7, "mm")
-	plate := wtype.NewLHPlate("DWST12", "Unknown", 1, 12, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 44.1}, trough12, 9, 9, 0, 30.0, 4.5)
+	plate := wtype.NewLHPlate("DWST12", "Unknown", 1, 12, wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 44.1}, trough12, 9, 9, 0, 30.0, 4.5)
 	return plate
 }
 
@@ -1183,7 +1183,7 @@ func TestFixDuplicatePlateNames(t *testing.T) {
 
 }
 
-func assertCoordsEq(lhs, rhs []wtype.Coordinates) bool {
+func assertCoordsEq(lhs, rhs []wtype.Coordinates3D) bool {
 	if len(lhs) != len(rhs) {
 		return false
 	}
@@ -1213,7 +1213,7 @@ func TestAddWellTargets(t *testing.T) {
 
 	lh.addWellTargets()
 
-	expected := []wtype.Coordinates{
+	expected := []wtype.Coordinates3D{
 		{X: 0.0, Y: -31.5, Z: 0.0},
 		{X: 0.0, Y: -22.5, Z: 0.0},
 		{X: 0.0, Y: -13.5, Z: 0.0},
@@ -1224,7 +1224,7 @@ func TestAddWellTargets(t *testing.T) {
 		{X: 0.0, Y: 31.5, Z: 0.0},
 	}
 
-	if e, g := []wtype.Coordinates{}, plate.Welltype.GetWellTargets("DummyAdaptor"); !assertCoordsEq(e, g) {
+	if e, g := []wtype.Coordinates3D{}, plate.Welltype.GetWellTargets("DummyAdaptor"); !assertCoordsEq(e, g) {
 		t.Errorf("plate well targets incorrect, expected %v, got %v", e, g)
 	}
 

--- a/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
+++ b/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
@@ -63,7 +63,7 @@ func makeGilson(ctx context.Context) *liquidhandling.LHProperties {
 	for y := 0; y < 3; y++ {
 		xp = x0
 		for x := 0; x < 3; x++ {
-			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp})
+			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			layout[pos.Name] = pos
 			i += 1
 			xp += xi

--- a/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
+++ b/microArch/scheduler/liquidhandling/make_liquidhandler_test.go
@@ -63,7 +63,7 @@ func makeGilson(ctx context.Context) *liquidhandling.LHProperties {
 	for y := 0; y < 3; y++ {
 		xp = x0
 		for x := 0; x < 3; x++ {
-			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
+			pos := wtype.NewLHPosition(fmt.Sprintf("position_%d", i+1), wtype.Coordinates3D{X: xp, Y: yp, Z: zp}, wtype.SBSFootprint)
 			layout[pos.Name] = pos
 			i += 1
 			xp += xi
@@ -94,8 +94,8 @@ func makeGilson(ctx context.Context) *liquidhandling.LHProperties {
 	lvhead.Adaptor = lvadaptor
 
 	ha := wtype.NewLHHeadAssembly(nil)
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: -18.08, Z: 0})
-	ha.AddPosition(wtype.Coordinates{X: 0, Y: 0, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: -18.08, Z: 0})
+	ha.AddPosition(wtype.Coordinates3D{X: 0, Y: 0, Z: 0})
 	ha.LoadHead(hvhead)
 	ha.LoadHead(lvhead)
 	lhp.Heads = append(lhp.Heads, hvhead, lvhead)

--- a/microArch/simulator/liquidhandling/robotstate.go
+++ b/microArch/simulator/liquidhandling/robotstate.go
@@ -39,14 +39,14 @@ import (
 //ChannelState Represent the physical state of a single channel
 type ChannelState struct {
 	number   int
-	tip      *wtype.LHTip      //Nil if no tip loaded, otherwise the tip that's loaded
-	contents *wtype.Liquid     //What's in the tip?
-	position wtype.Coordinates //position relative to the adaptor
-	adaptor  *AdaptorState     //the channel's adaptor
+	tip      *wtype.LHTip        //Nil if no tip loaded, otherwise the tip that's loaded
+	contents *wtype.Liquid       //What's in the tip?
+	position wtype.Coordinates3D //position relative to the adaptor
+	adaptor  *AdaptorState       //the channel's adaptor
 	radius   float64
 }
 
-func NewChannelState(number int, adaptor *AdaptorState, position wtype.Coordinates, radius float64) *ChannelState {
+func NewChannelState(number int, adaptor *AdaptorState, position wtype.Coordinates3D, radius float64) *ChannelState {
 	r := ChannelState{}
 	r.number = number
 	r.position = position
@@ -91,24 +91,24 @@ func (self *ChannelState) GetBounds(channelClearance float64) wtype.BBox {
 	}
 
 	ret := wtype.NewBBox(
-		self.GetAbsolutePosition().Subtract(wtype.Coordinates{X: r, Y: r, Z: h}),
-		wtype.Coordinates{X: 2.0 * r, Y: 2.0 * r, Z: h})
+		self.GetAbsolutePosition().Subtract(wtype.Coordinates3D{X: r, Y: r, Z: h}),
+		wtype.Coordinates3D{X: 2.0 * r, Y: 2.0 * r, Z: h})
 
 	return *ret
 }
 
 //GetRelativePosition get the channel's position relative to the head
-func (self *ChannelState) GetRelativePosition() wtype.Coordinates {
+func (self *ChannelState) GetRelativePosition() wtype.Coordinates3D {
 	return self.position
 }
 
 //SetRelativePosition get the channel's position relative to the head
-func (self *ChannelState) SetRelativePosition(v wtype.Coordinates) {
+func (self *ChannelState) SetRelativePosition(v wtype.Coordinates3D) {
 	self.position = v
 }
 
 //GetAbsolutePosition get the channel's absolute position
-func (self *ChannelState) GetAbsolutePosition() wtype.Coordinates {
+func (self *ChannelState) GetAbsolutePosition() wtype.Coordinates3D {
 	return self.position.Add(self.adaptor.GetPosition())
 }
 
@@ -211,7 +211,7 @@ func coneInWell(cone wtype.BBox, well *wtype.LHWell) bool {
 type AdaptorState struct {
 	name         string
 	channels     []*ChannelState
-	offset       wtype.Coordinates
+	offset       wtype.Coordinates3D
 	independent  bool
 	params       *wtype.LHChannelParameter
 	group        *AdaptorGroup
@@ -222,14 +222,13 @@ type AdaptorState struct {
 func NewAdaptorState(name string,
 	independent bool,
 	channels int,
-	channel_offset wtype.Coordinates,
-	coneRadius float64,
+	channel_offset wtype.Coordinates3D, coneRadius float64,
 	params *wtype.LHChannelParameter,
 	tipBehaviour wtype.TipLoadingBehaviour) *AdaptorState {
 	as := AdaptorState{
 		name,
 		make([]*ChannelState, 0, channels),
-		wtype.Coordinates{},
+		wtype.Coordinates3D{},
 		independent,
 		params.Dup(),
 		nil,
@@ -280,7 +279,7 @@ func (self *AdaptorState) SummariseTips() string {
 //displayed in the output.
 func (self *AdaptorState) SummarisePositions(channelsColliding []int) string {
 
-	positions := make([]wtype.Coordinates, len(self.channels))
+	positions := make([]wtype.Coordinates3D, len(self.channels))
 	for i, channel := range self.channels {
 		positions[i] = channel.GetAbsolutePosition()
 		positions[i].Z -= channel.GetTip().GetEffectiveHeight()
@@ -351,7 +350,7 @@ func (self *AdaptorState) GetName() string {
 }
 
 //GetPosition
-func (self *AdaptorState) GetPosition() wtype.Coordinates {
+func (self *AdaptorState) GetPosition() wtype.Coordinates3D {
 	return self.offset.Add(self.group.GetPosition())
 }
 
@@ -407,11 +406,11 @@ func (self *AdaptorState) SetGroup(g *AdaptorGroup) {
 	self.group = g
 }
 
-func (self *AdaptorState) SetPosition(p wtype.Coordinates) error {
+func (self *AdaptorState) SetPosition(p wtype.Coordinates3D) error {
 	return self.group.SetPosition(p.Subtract(self.offset))
 }
 
-func (self *AdaptorState) SetOffset(p wtype.Coordinates) {
+func (self *AdaptorState) SetOffset(p wtype.Coordinates3D) {
 	self.offset = p
 }
 
@@ -511,18 +510,18 @@ func (self *AdaptorState) GetTipCoordsToLoad(tb *wtype.LHTipbox, num int) ([][]w
 // AdaptorGroup simulate a set of adaptors which are physically attached
 type AdaptorGroup struct {
 	adaptors      []*AdaptorState
-	offsets       []wtype.Coordinates
+	offsets       []wtype.Coordinates3D
 	motionLimits  *wtype.BBox
 	velocity      *wunit.Velocity3D
 	velocityRange *wtype.VelocityRange
-	position      wtype.Coordinates
+	position      wtype.Coordinates3D
 	robot         *RobotState
 }
 
 // NewAdaptorGroup convert a HeadAssembly into an AdaptorGroup for simulation
 func NewAdaptorGroup(assembly *wtype.LHHeadAssembly) *AdaptorGroup {
 
-	offsets := make([]wtype.Coordinates, len(assembly.Positions))
+	offsets := make([]wtype.Coordinates3D, len(assembly.Positions))
 	for i, pos := range assembly.Positions {
 		offsets[i] = pos.Offset
 	}
@@ -543,7 +542,7 @@ func NewAdaptorGroup(assembly *wtype.LHHeadAssembly) *AdaptorGroup {
 		//9mm spacing currently hardcoded.
 		//At some point we'll either need to fetch this from the driver or
 		//infer it from the type of tipboxes/plates accepted
-		spacing := wtype.Coordinates{X: 0, Y: 0, Z: 0}
+		spacing := wtype.Coordinates3D{X: 0, Y: 0, Z: 0}
 		if p.Orientation == wtype.LHVChannel {
 			spacing.Y = 9.
 		} else if p.Orientation == wtype.LHHChannel {
@@ -582,7 +581,7 @@ func (self *AdaptorGroup) LoadAdaptor(pos int, adaptor *AdaptorState) {
 	}
 }
 
-func (self *AdaptorGroup) GetPosition() wtype.Coordinates {
+func (self *AdaptorGroup) GetPosition() wtype.Coordinates3D {
 	return self.position
 }
 
@@ -594,7 +593,7 @@ func oneDP(v float64) string {
 	return ret
 }
 
-func (self *AdaptorGroup) SetPosition(p wtype.Coordinates) error {
+func (self *AdaptorGroup) SetPosition(p wtype.Coordinates3D) error {
 	self.position = p
 	if self.motionLimits != nil && !self.motionLimits.Contains(p) {
 		template := "%smm too %s"

--- a/microArch/simulator/liquidhandling/robotstate_test.go
+++ b/microArch/simulator/liquidhandling/robotstate_test.go
@@ -45,7 +45,7 @@ func (self *tipCoordsTest) run(t *testing.T) {
 		tb.RemoveTip(wc)
 	}
 
-	adaptor := NewAdaptorState("", false, 8, wtype.Coordinates{}, 0.0, &wtype.LHChannelParameter{Orientation: self.orientation}, self.tipBehaviour)
+	adaptor := NewAdaptorState("", false, 8, wtype.Coordinates3D{}, 0.0, &wtype.LHChannelParameter{Orientation: self.orientation}, self.tipBehaviour)
 
 	out, err := adaptor.GetTipCoordsToLoad(tb, self.num)
 	if err != nil {

--- a/microArch/simulator/liquidhandling/simulator.go
+++ b/microArch/simulator/liquidhandling/simulator.go
@@ -440,8 +440,8 @@ func (self *VirtualLiquidHandler) validateLHArgs(head, multi int, platetype, wha
 
 //getTargetPosition get a position within the liquidhandler, adding any errors as neccessary
 //bool is false if the instruction shouldn't continue (e.g. missing deckposition e.t.c)
-func (self *VirtualLiquidHandler) getTargetPosition(adaptorName string, channelIndex int, deckposition, platetype string, wc wtype.WellCoords, ref wtype.WellReference) (wtype.Coordinates, bool) {
-	ret := wtype.Coordinates{}
+func (self *VirtualLiquidHandler) getTargetPosition(adaptorName string, channelIndex int, deckposition, platetype string, wc wtype.WellCoords, ref wtype.WellReference) (wtype.Coordinates3D, bool) {
+	ret := wtype.Coordinates3D{}
 
 	target, ok := self.state.GetDeck().GetChild(deckposition)
 	if !ok {
@@ -490,13 +490,13 @@ func (self *VirtualLiquidHandler) getTargetPosition(adaptorName string, channelI
 }
 
 func (self *VirtualLiquidHandler) getWellsBelow(height float64, adaptor *AdaptorState) []*wtype.LHWell {
-	tip_pos := make([]wtype.Coordinates, adaptor.GetChannelCount())
+	tip_pos := make([]wtype.Coordinates3D, adaptor.GetChannelCount())
 	wells := make([]*wtype.LHWell, adaptor.GetChannelCount())
-	size := wtype.Coordinates{X: 0, Y: 0, Z: height}
+	size := wtype.Coordinates3D{X: 0, Y: 0, Z: height}
 	deck := self.state.GetDeck()
 	for i := 0; i < adaptor.GetChannelCount(); i++ {
 		if ch := adaptor.GetChannel(i); ch.HasTip() {
-			tip_pos[i] = ch.GetAbsolutePosition().Subtract(wtype.Coordinates{X: 0., Y: 0., Z: ch.GetTip().GetEffectiveHeight()})
+			tip_pos[i] = ch.GetAbsolutePosition().Subtract(wtype.Coordinates3D{X: 0., Y: 0., Z: ch.GetTip().GetEffectiveHeight()})
 		} else {
 			tip_pos[i] = ch.GetAbsolutePosition()
 		}
@@ -512,8 +512,8 @@ func (self *VirtualLiquidHandler) getWellsBelow(height float64, adaptor *Adaptor
 	return wells
 }
 
-func makeOffsets(Xs, Ys, Zs []float64) []wtype.Coordinates {
-	ret := make([]wtype.Coordinates, len(Xs))
+func makeOffsets(Xs, Ys, Zs []float64) []wtype.Coordinates3D {
+	ret := make([]wtype.Coordinates3D, len(Xs))
 	for i := range Xs {
 		ret[i].X = Xs[i]
 		ret[i].Y = Ys[i]
@@ -598,7 +598,7 @@ func (self *VirtualLiquidHandler) Move(deckpositionS []string, wellcoords []stri
 	offsets := makeOffsets(offsetX, offsetY, offsetZ)
 
 	//find the coordinates of each explicitly requested position
-	coords := make([]wtype.Coordinates, adaptor.GetChannelCount())
+	coords := make([]wtype.Coordinates3D, adaptor.GetChannelCount())
 	for _, ch := range channels {
 		c, ok := self.getTargetPosition(adaptor.GetName(), ch, deckposition, platetype, wc[ch], refs[ch])
 		if !ok {
@@ -608,7 +608,7 @@ func (self *VirtualLiquidHandler) Move(deckpositionS []string, wellcoords []stri
 		coords[ch] = coords[ch].Add(offsets[ch])
 		//if there's a tip, raise the coortinates to the top of the tip to take account of it
 		if tip := adaptor.GetChannel(ch).GetTip(); tip != nil {
-			coords[ch] = coords[ch].Add(wtype.Coordinates{X: 0., Y: 0., Z: tip.GetEffectiveHeight()})
+			coords[ch] = coords[ch].Add(wtype.Coordinates3D{X: 0., Y: 0., Z: tip.GetEffectiveHeight()})
 		}
 	}
 
@@ -636,7 +636,7 @@ func (self *VirtualLiquidHandler) Move(deckpositionS []string, wellcoords []stri
 	}
 
 	//Get the locations of each channel relative to the head
-	rel_coords := make([]wtype.Coordinates, adaptor.GetChannelCount())
+	rel_coords := make([]wtype.Coordinates3D, adaptor.GetChannelCount())
 	for i := range coords {
 		rel_coords[i] = coords[i].Subtract(origin)
 	}
@@ -1155,7 +1155,7 @@ func (self *VirtualLiquidHandler) LoadTips(channels []int, head, multi int,
 	amount := []string{}
 	for _, ch := range channels {
 		tip_s := tips[ch].GetSize()
-		tip_p := tips[ch].GetPosition().Add(wtype.Coordinates{X: 0.5 * tip_s.X, Y: 0.5 * tip_s.Y, Z: tip_s.Z})
+		tip_p := tips[ch].GetPosition().Add(wtype.Coordinates3D{X: 0.5 * tip_s.X, Y: 0.5 * tip_s.Y, Z: tip_s.Z})
 		ch_p := adaptor.GetChannel(ch).GetAbsolutePosition()
 		delta := ch_p.Subtract(tip_p)
 		if xy := delta.AbsXY(); xy > 0.5 {
@@ -1679,7 +1679,7 @@ func (self *VirtualLiquidHandler) AddPlateTo(position string, plate interface{},
 					position, wtype.TypeOf(plate), wellOff)
 			}
 
-			overSpill := wtype.Coordinates{
+			overSpill := wtype.Coordinates3D{
 				X: math.Max(wellLim.X-plateSize.X, 0.0),
 				Y: math.Max(wellLim.Y-plateSize.Y, 0.0),
 				Z: math.Max(wellLim.Z-plateSize.Z, 0.0),

--- a/microArch/simulator/liquidhandling/simulator.go
+++ b/microArch/simulator/liquidhandling/simulator.go
@@ -81,7 +81,7 @@ func NewVirtualLiquidHandler(props *liquidhandling.LHProperties, settings *Simul
 	deck := wtype.NewLHDeck("simulated deck", props.Mnfr, props.Model)
 	for name, pos := range props.Positions {
 		//size not given un LHProperties, assuming standard 96well size
-		deck.AddSlot(name, pos.Location, wtype.Coordinates{X: 127.76, Y: 85.48, Z: 0})
+		deck.AddSlot(name, pos.Location, pos.Size)
 		//deck.SetSlotAccepts(name, "riser")
 	}
 

--- a/microArch/simulator/liquidhandling/simulator_test.go
+++ b/microArch/simulator/liquidhandling/simulator_test.go
@@ -49,7 +49,7 @@ func TestNewVirtualLiquidHandler_ValidProps(t *testing.T) {
 func TestVLH_AddPlateTo(t *testing.T) {
 	// create a wide deckposition and enable input plates to go there
 	propsWithWideSlot := defaultLHProperties()
-	propsWithWideSlot.Positions["widePosition"] = wtype.NewLHPosition("widePosition", wtype.Coordinates{X: -300}, wtype.Coordinates2D{X: 300.0, Y: 85.48})
+	propsWithWideSlot.Positions["widePosition"] = wtype.NewLHPosition("widePosition", wtype.Coordinates3D{X: -300}, wtype.Coordinates2D{X: 300.0, Y: 85.48})
 	propsWithWideSlot.Preferences.Inputs = append(propsWithWideSlot.Preferences.Inputs, "widePosition")
 
 	SimulatorTests{
@@ -321,7 +321,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 200.0, Y: 0.0, Z: 62.2}),
+				positionAssertion(0, wtype.Coordinates3D{X: 200.0, Y: 0.0, Z: 62.2}),
 			},
 		},
 		{
@@ -342,7 +342,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 49.5, Y: 400., Z: 93.}),
+				positionAssertion(0, wtype.Coordinates3D{X: 49.5, Y: 400., Z: 93.}),
 			},
 		},
 		{
@@ -363,7 +363,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 49.5, Y: 400., Z: 93}),
+				positionAssertion(0, wtype.Coordinates3D{X: 49.5, Y: 400., Z: 93}),
 			},
 		},
 		{
@@ -384,7 +384,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 0.0, Y: -27.0, Z: 62.2}),
+				positionAssertion(0, wtype.Coordinates3D{X: 0.0, Y: -27.0, Z: 62.2}),
 			},
 		},
 		{
@@ -405,7 +405,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 400.0, Y: 63.0, Z: 25.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 400.0, Y: 63.0, Z: 25.7}),
 			},
 		},
 		{
@@ -426,7 +426,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 400.0, Y: 27.0, Z: 25.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 400.0, Y: 27.0, Z: 25.7}),
 			},
 		},
 		{
@@ -447,7 +447,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 400.0, Y: -31.5, Z: 46.8}),
+				positionAssertion(0, wtype.Coordinates3D{X: 400.0, Y: -31.5, Z: 46.8}),
 			},
 		},
 		{
@@ -468,7 +468,7 @@ func Test_Move(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 400.0, Y: -31.5, Z: 44.8}),
+				positionAssertion(0, wtype.Coordinates3D{X: 400.0, Y: -31.5, Z: 44.8}),
 			},
 		},
 		{
@@ -492,7 +492,7 @@ func Test_Move(t *testing.T) {
 				"(err) Move[0]: head 0 channels 0-7 to 1 mm below TopReference of A1,A1,A1,A1,A1,A1,A1,A1@trough1 at position input_1: collision detected: head 0 channel 7 and plate \"trough1\" of type trough at position input_1",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 400.0, Y: -27.5, Z: 44.8}),
+				positionAssertion(0, wtype.Coordinates3D{X: 400.0, Y: -27.5, Z: 44.8}),
 			},
 		},
 		{
@@ -720,7 +720,7 @@ func TestCrashes(t *testing.T) {
 				"(err) Move[0]: head 0 channels 0-7 to 1 mm below TopReference of A1-H1@tipbox2 at position tipbox_2: collision detected: head 0 channels 0-7 and head 1 channels 0-7 and tips A1-H1,A3-H3@tipbox2 at position tipbox_2",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 128.0, Y: 0.0, Z: 60.2}),
+				positionAssertion(0, wtype.Coordinates3D{X: 128.0, Y: 0.0, Z: 60.2}),
 			},
 		},
 		{
@@ -800,8 +800,8 @@ func Test_Multihead(t *testing.T) {
 				},
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 128.0, Y: 0.0, Z: 62.2}),
-				positionAssertion(1, wtype.Coordinates{X: 146.0, Y: 0.0, Z: 62.2}),
+				positionAssertion(0, wtype.Coordinates3D{X: 128.0, Y: 0.0, Z: 62.2}),
+				positionAssertion(1, wtype.Coordinates3D{X: 146.0, Y: 0.0, Z: 62.2}),
 			},
 		},
 		{
@@ -855,8 +855,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 1 channels 0-7 to 1 mm above TopReference of A1-H1@tipbox1 at position tipbox_1: head cannot reach position: position is 9mm too far left, please try rearranging the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: -18.0, Y: 0.0, Z: 62.2}),
-				positionAssertion(1, wtype.Coordinates{X: 0.0, Y: 0.0, Z: 62.2}),
+				positionAssertion(0, wtype.Coordinates3D{X: -18.0, Y: 0.0, Z: 62.2}),
+				positionAssertion(1, wtype.Coordinates3D{X: 0.0, Y: 0.0, Z: 62.2}),
 			},
 		},
 		{
@@ -881,8 +881,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channels 0-7 to 1 mm above TopReference of A12-H12@plate1 at position input_1: head cannot reach position: position is 30mm too far right, please try rearranging the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 405.0, Y: 0.0, Z: 26.7}),
-				positionAssertion(1, wtype.Coordinates{X: 423.0, Y: 0.0, Z: 26.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 405.0, Y: 0.0, Z: 26.7}),
+				positionAssertion(1, wtype.Coordinates3D{X: 423.0, Y: 0.0, Z: 26.7}),
 			},
 		},
 		{
@@ -907,8 +907,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channel 0 to 1 mm above TopReference of H12@wasteplate at position waste: head cannot reach position: position is 7mm too far forwards, please try rearranging the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 355.0, Y: 265.0, Z: 26.7}),
-				positionAssertion(1, wtype.Coordinates{X: 373.0, Y: 265.0, Z: 26.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 355.0, Y: 265.0, Z: 26.7}),
+				positionAssertion(1, wtype.Coordinates3D{X: 373.0, Y: 265.0, Z: 26.7}),
 			},
 		},
 		{
@@ -933,8 +933,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channel 7 to 1 mm above TopReference of A12@plate1 at position input_1: head cannot reach position: position is 63mm too far backwards, please try rearranging the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 355.0, Y: -63.0, Z: 26.7}),
-				positionAssertion(1, wtype.Coordinates{X: 373.0, Y: -63.0, Z: 26.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 355.0, Y: -63.0, Z: 26.7}),
+				positionAssertion(1, wtype.Coordinates3D{X: 373.0, Y: -63.0, Z: 26.7}),
 			},
 		},
 		{
@@ -959,8 +959,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channel 0 to 600 mm above TopReference of A1@plate1 at position input_1: head cannot reach position: position is 25.7mm too high, please try lowering the object on the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 256.0, Y: 0.0, Z: 625.7}),
-				positionAssertion(1, wtype.Coordinates{X: 274.0, Y: 0.0, Z: 625.7}),
+				positionAssertion(0, wtype.Coordinates3D{X: 256.0, Y: 0.0, Z: 625.7}),
+				positionAssertion(1, wtype.Coordinates3D{X: 274.0, Y: 0.0, Z: 625.7}),
 			},
 		},
 		{
@@ -986,8 +986,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channel 0 to 0.5 mm above BottomReference of A4@plate1 at position input_1: head cannot reach position: position is 8.1mm too low, please try adding a riser to the object on the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 283.0, Y: 0.0, Z: 51.9}),
-				positionAssertion(1, wtype.Coordinates{X: 301.0, Y: 0.0, Z: 51.9}),
+				positionAssertion(0, wtype.Coordinates3D{X: 283.0, Y: 0.0, Z: 51.9}),
+				positionAssertion(1, wtype.Coordinates3D{X: 301.0, Y: 0.0, Z: 51.9}),
 			},
 		},
 		{
@@ -1013,8 +1013,8 @@ func TestMotionLimits(t *testing.T) {
 				"(err) Move[0]: head 0 channel 7 to 0.5 mm above BottomReference of A4@plate1 at position input_1: head cannot reach position: position is 63mm too far backwards and 8.1mm too low, please try rearranging the deck and adding a riser to the object on the deck",
 			},
 			Assertions: []*AssertionFn{
-				positionAssertion(0, wtype.Coordinates{X: 283.0, Y: -63.0, Z: 51.9}),
-				positionAssertion(1, wtype.Coordinates{X: 301.0, Y: -63.0, Z: 51.9}),
+				positionAssertion(0, wtype.Coordinates3D{X: 283.0, Y: -63.0, Z: 51.9}),
+				positionAssertion(1, wtype.Coordinates3D{X: 301.0, Y: -63.0, Z: 51.9}),
 			},
 		},
 	}.Run(t)

--- a/microArch/simulator/liquidhandling/simulator_test.go
+++ b/microArch/simulator/liquidhandling/simulator_test.go
@@ -47,6 +47,11 @@ func TestNewVirtualLiquidHandler_ValidProps(t *testing.T) {
 }
 
 func TestVLH_AddPlateTo(t *testing.T) {
+	// create a wide deckposition and enable input plates to go there
+	propsWithWideSlot := defaultLHProperties()
+	propsWithWideSlot.Positions["widePosition"] = wtype.NewLHPosition("widePosition", wtype.Coordinates{X: -300}, wtype.Coordinates2D{X: 300.0, Y: 85.48})
+	propsWithWideSlot.Preferences.Inputs = append(propsWithWideSlot.Preferences.Inputs, "widePosition")
+
 	SimulatorTests{
 		{
 			Name: "OK",
@@ -110,6 +115,14 @@ func TestVLH_AddPlateTo(t *testing.T) {
 			},
 			ExpectedErrors: []string{
 				"(err) AddPlateTo[1]: Footprint of plate \"plate1\"[300mm x 85.48mm] doesn't fit slot \"output_1\"[127.76mm x 85.48mm]",
+			},
+		},
+		{
+			Name:  "non-SBS format plate",
+			Props: propsWithWideSlot,
+			Instructions: []TestRobotInstruction{
+				&Initialize{},
+				&AddPlateTo{"widePosition", wideLHPlate("plate1"), "plate1"},
 			},
 		},
 	}.Run(t)

--- a/microArch/simulator/liquidhandling/simulator_testcode_test.go
+++ b/microArch/simulator/liquidhandling/simulator_testcode_test.go
@@ -110,7 +110,7 @@ func makeLHHead(hp HeadParams) *wtype.LHHead {
 
 type HeadAssemblyParams struct {
 	MotionLimits    *wtype.BBox
-	PositionOffsets []wtype.Coordinates
+	PositionOffsets []wtype.Coordinates3D
 	Heads           []HeadParams
 	VelocityLimits  *wtype.VelocityRange
 }
@@ -144,7 +144,7 @@ func makeLHProperties(p *LHPropertiesParams) *liquidhandling.LHProperties {
 
 	layout := make(map[string]*wtype.LHPosition)
 	for _, lp := range p.Layouts {
-		layout[lp.Name] = wtype.NewLHPosition(lp.Name, wtype.Coordinates{X: lp.Xpos, Y: lp.Ypos, Z: lp.Zpos}, wtype.SBSFootprint)
+		layout[lp.Name] = wtype.NewLHPosition(lp.Name, wtype.Coordinates3D{X: lp.Xpos, Y: lp.Ypos, Z: lp.Zpos}, wtype.SBSFootprint)
 	}
 
 	lhp := liquidhandling.NewLHProperties(p.Name, p.Mfg, liquidhandling.LLLiquidHandler, liquidhandling.DisposableTips, layout)
@@ -216,7 +216,7 @@ type LHPlateParams struct {
 	mfr         string
 	nrows       int
 	ncols       int
-	size        wtype.Coordinates
+	size        wtype.Coordinates3D
 	welltype    LHWellParams
 	wellXOffset float64
 	wellYOffset float64
@@ -266,7 +266,7 @@ func makeLHTip(p *LHTipParams) *wtype.LHTip {
 type LHTipboxParams struct {
 	nrows        int
 	ncols        int
-	size         wtype.Coordinates
+	size         wtype.Coordinates3D
 	manufacturer string
 	boxtype      string
 	tiptype      LHTipParams
@@ -299,7 +299,7 @@ type LHTipwasteParams struct {
 	capacity   int
 	typ        string
 	mfr        string
-	size       wtype.Coordinates
+	size       wtype.Coordinates3D
 	w          LHWellParams
 	wellxstart float64
 	wellystart float64
@@ -365,7 +365,7 @@ func defaultLHPlateProps() *LHPlateParams {
 		mfr:       "test_plate_mfr",
 		nrows:     8,
 		ncols:     12,
-		size:      wtype.Coordinates{X: 127.76, Y: 85.48, Z: 25.7},
+		size:      wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 25.7},
 		welltype: LHWellParams{
 			crds:  wtype.ZeroWellCoords(),
 			vunit: "ul",
@@ -419,7 +419,7 @@ func troughLHPlateProps() *LHPlateParams {
 		mfr:       "test_trough_mfr",
 		nrows:     1,
 		ncols:     12,
-		size:      wtype.Coordinates{X: 127.76, Y: 85.48, Z: 45.8},
+		size:      wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 45.8},
 		welltype: LHWellParams{
 			crds:  wtype.ZeroWellCoords(),
 			vunit: "ul",
@@ -452,7 +452,7 @@ func troughLHPlateProps() *LHPlateParams {
 func troughLHPlate(name string) *wtype.Plate {
 	params := troughLHPlateProps()
 	plate := makeLHPlate(params, name)
-	targets := []wtype.Coordinates{
+	targets := []wtype.Coordinates3D{
 		{X: 0.0, Y: -31.5, Z: 0.0},
 		{X: 0.0, Y: -22.5, Z: 0.0},
 		{X: 0.0, Y: -13.5, Z: 0.0},
@@ -470,7 +470,7 @@ func defaultLHTipbox(name string) *wtype.LHTipbox {
 	params := LHTipboxParams{
 		nrows:        8,
 		ncols:        12,
-		size:         wtype.Coordinates{X: 127.76, Y: 85.48, Z: 60.13},
+		size:         wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 60.13},
 		manufacturer: "test Tipbox mfg",
 		boxtype:      "tipbox",
 		tiptype: LHTipParams{
@@ -522,7 +522,7 @@ func smallLHTipbox(name string) *wtype.LHTipbox {
 	params := LHTipboxParams{
 		nrows:        8,
 		ncols:        12,
-		size:         wtype.Coordinates{X: 127.76, Y: 85.48, Z: 60.13},
+		size:         wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 60.13},
 		manufacturer: "test Tipbox mfg",
 		boxtype:      "tipbox",
 		tiptype: LHTipParams{
@@ -575,7 +575,7 @@ func defaultLHTipwaste(name string) *wtype.LHTipwaste {
 		capacity: 700,
 		typ:      "tipwaste",
 		mfr:      "testTipwaste mfr",
-		size:     wtype.Coordinates{X: 127.76, Y: 85.48, Z: 92.0},
+		size:     wtype.Coordinates3D{X: 127.76, Y: 85.48, Z: 92.0},
 		w: LHWellParams{
 			crds:  wtype.ZeroWellCoords(),
 			vunit: "ul",
@@ -619,7 +619,7 @@ func defaultLHProperties() *liquidhandling.LHProperties {
 		},
 		HeadAssemblies: []HeadAssemblyParams{
 			{
-				PositionOffsets: []wtype.Coordinates{{X: 0, Y: 0, Z: 0}},
+				PositionOffsets: []wtype.Coordinates3D{{X: 0, Y: 0, Z: 0}},
 				Heads: []HeadParams{
 					{
 						Name: "Head0 Name",
@@ -688,7 +688,7 @@ func multiheadLHPropertiesProps() *LHPropertiesParams {
 		HeadAssemblies: []HeadAssemblyParams{
 			{
 				MotionLimits:    wtype.NewBBox6f(0, 0, 0, 3*x_step, 3*y_step, 600.),
-				PositionOffsets: []wtype.Coordinates{{X: -9}, {X: 9}},
+				PositionOffsets: []wtype.Coordinates3D{{X: -9}, {X: 9}},
 				Heads: []HeadParams{
 					{
 						Name: "Head0 Name",
@@ -1233,7 +1233,7 @@ func adaptorAssertion(head int, tips []tipDesc) *AssertionFn {
 }
 
 //adaptorPositionAssertion assert that the adaptor has tips in the given positions
-func positionAssertion(head int, origin wtype.Coordinates) *AssertionFn {
+func positionAssertion(head int, origin wtype.Coordinates3D) *AssertionFn {
 	var ret AssertionFn = func(t *testing.T, vlh *VirtualLiquidHandler) {
 		adaptor, err := vlh.GetAdaptorState(head)
 		if err != nil {

--- a/microArch/simulator/liquidhandling/simulator_testcode_test.go
+++ b/microArch/simulator/liquidhandling/simulator_testcode_test.go
@@ -144,7 +144,7 @@ func makeLHProperties(p *LHPropertiesParams) *liquidhandling.LHProperties {
 
 	layout := make(map[string]*wtype.LHPosition)
 	for _, lp := range p.Layouts {
-		layout[lp.Name] = wtype.NewLHPosition(lp.Name, wtype.Coordinates{X: lp.Xpos, Y: lp.Ypos, Z: lp.Zpos})
+		layout[lp.Name] = wtype.NewLHPosition(lp.Name, wtype.Coordinates{X: lp.Xpos, Y: lp.Ypos, Z: lp.Zpos}, wtype.SBSFootprint)
 	}
 
 	lhp := liquidhandling.NewLHProperties(p.Name, p.Mfg, liquidhandling.LLLiquidHandler, liquidhandling.DisposableTips, layout)


### PR DESCRIPTION
Previously we've always assumed that deck positions are "SBS format" (i.e. 127.76x85.48 mm) since this is always the case with gilson.

Hamilton has several pieces of labware which aren't (the first of which being the tipwaste). This breaks the physical simulator, because it gets upset when you try to place an obviously non-SBS format piece of labware on a position which (it assumes) is SBS format.

This change adds a "Size" property to LHPosition, and requires the various liquidhandler drivers to specify the size of the available positions when returning the robot state in `GetCapabilities`. Once this PR is opened, I'll open PRs in each of the drivers and reference this PR so they show up below.

Testing:
I've added a test in the simulator to demonstrate that a non-sbs plate can now be added to a robot with a non-sbs shaped deck position.