### PR TITLE
Basic migration of the test information.

### DIFF
--- a/workflow/testing.go
+++ b/workflow/testing.go
@@ -1,0 +1,20 @@
+package workflow
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/antha-lang/antha/antha/anthalib/wtype"
+)
+
+// Testing contains data and configuration for testing.
+type Testing struct {
+	MixTaskChecks []MixTaskCheck
+}
+
+// MixStepCheck contains check data for a single mix step.
+type MixTaskCheck struct {
+	Instructions json.RawMessage
+	Outputs      map[string]*wtype.Plate
+	TimeEstimate time.Duration
+}

--- a/workflow/v1_2/migrater.go
+++ b/workflow/v1_2/migrater.go
@@ -217,7 +217,9 @@ func (m *Migrater) migrateConnections() error {
 }
 
 func (m *Migrater) migrateJobIdAndMeta() error {
-	m.Cur.JobId = workflow.JobId(m.Old.Properties.Name)
+	if m.Old.Properties.Name != "" {
+		m.Cur.JobId = workflow.JobId(m.Old.Properties.Name)
+	}
 	if desc := m.Old.Properties.Description; desc != "" {
 		m.Cur.Meta.Rest["Description"] = desc
 	}
@@ -259,7 +261,7 @@ func (m *Migrater) ValidateCur() error {
 
 // ValidateOld checks that the workflow supplied as input is of the correct version
 func (m *Migrater) ValidateOld() error {
-	if m.Old.Version != "1.2.0" {
+	if !(m.Old.Version == "1.2.0" || m.Old.Version == "") {
 		return fmt.Errorf("Unexpected version '%s'", m.Old.Version)
 	}
 	return nil

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -25,6 +25,8 @@ type Workflow struct {
 
 	Config Config `json:"Config"`
 
+	Testing *Testing `json:"Testing,omitempty"`
+
 	typeNames map[ElementTypeName]*ElementType
 }
 


### PR DESCRIPTION
How does this look for migrating the testing information? Although we have a few other fields in the old workflow none have practical application (either ignored, or switch whether to compare output or instructions - but seems sensible just to compare whichever we're supplied with...)