### PR TITLE
ANTHA-2635 migrate to composer-cloud.sh 

### DIFF
--- a/scripts/cloud.sh
+++ b/scripts/cloud.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -eu
-
-## Expects the environment variable $WF_JSON to be set to a workflow value.
-## Executes $* but with the given workflow inserted as a final file argument.
-exec "$@" <(echo "$WF_JSON")

--- a/scripts/composer-cloud.sh
+++ b/scripts/composer-cloud.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+# Ambassador-compatible wrapper script for composer. Expects the environment
+# variable $WF_JSON to be set to a workflow value.  Other flags could also be
+# set, but not -indir and -outdir.
+COMPOSER=${COMPOSER:-composer}
+
+# Well-known directory name set by the workload service.  
+# (See https://github.com/Synthace/microservice/tree/master/cmd/workload#compatible-containers )
+DATA_DIR=${DATA_DIR:-/data}
+
+# (See https://github.com/Synthace/microservice/tree/master/cmd/ambassador )
+{ while ! [[ -r $DATA_DIR/inputReady ]]; do sleep 0.1; done; }
+< $DATA_DIR/inputReady
+trap "{ > $DATA_DIR/outputReady; }" EXIT
+
+$COMPOSER "$@" -indir "$DATA_DIR/input" -outdir "$DATA_DIR/output" - <<<$WF_JSON


### PR DESCRIPTION
This sets up `composer` to conform to our ambassador sidecar using well-known paths, so we can run it in the simulations cluster with access to content provided via GCS, and uploaded back to datarepo.

See https://paper.dropbox.com/doc/antha-core-workloads-and-git--AbVQgS3DcRoYLEVIGWjNQuixAg-4NDehisKdv1P0MJfah64n for how this will be invoked.