### PR TITLE
[AC-57] Include XLSX-encoded liquid handling policies in migrated workflows

### DIFF
--- a/workflow/v1_2/config.go
+++ b/workflow/v1_2/config.go
@@ -28,6 +28,7 @@ type opt struct {
 	DriverSpecificTipPreferences      []string `json:"driverSpecificTipPreferences,omitempty"` // Driver specific position names (e.g., position_1 or A2)
 	DriverSpecificTipWastePreferences []string `json:"driverSpecificTipWastePreferences,omitempty"`
 	DriverSpecificWashPreferences     []string `json:"driverSpecificWashPreferences,omitempty"`
+	LiquidHandlingPolicyXlsxJmpFile   []byte   `json:"liquidHandlingPolicyXlsxJmpFile,omitempty"`
 
 	ModelEvaporation         bool `json:"modelEvaporation"`
 	OutputSort               bool `json:"outputSort"`

--- a/workflow/v1_2/migrater.go
+++ b/workflow/v1_2/migrater.go
@@ -136,16 +136,20 @@ func (m *Migrater) migrateGlobalMixerConfig() error {
 	}
 
 	customPolicyRuleSet := m.Old.Config.CustomPolicyRuleSet
-	if customPolicyRuleSet == nil {
-		customPolicyRuleSet = wtype.NewLHPolicyRuleSet()
-	}
 	if m.Old.Config.LiquidHandlingPolicyXlsxJmpFile != nil {
 		policyMap, err := liquidtype.PolicyMakerFromBytes(m.Old.Config.LiquidHandlingPolicyXlsxJmpFile, wtype.PolicyName(liquidtype.BASEPolicy))
 		if err != nil {
 			return err
 		}
-		for name, policy := range policyMap {
-			customPolicyRuleSet.Policies[name] = policy
+		lhpr := wtype.NewLHPolicyRuleSet()
+		lhpr, err = wtype.AddUniversalRules(lhpr, policyMap)
+		if err != nil {
+			return err
+		}
+		if customPolicyRuleSet == nil {
+			customPolicyRuleSet = lhpr
+		} else {
+			customPolicyRuleSet.MergeWith(lhpr)
 		}
 	}
 

--- a/workflow/v1_2/migrater.go
+++ b/workflow/v1_2/migrater.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/antha/anthalib/wtype/liquidtype"
 	"github.com/antha-lang/antha/laboratory/effects"
 
 	"github.com/antha-lang/antha/logger"
@@ -107,7 +108,9 @@ func (m *Migrater) migrateTesting() error {
 }
 
 func (m *Migrater) migrateConfig() error {
-	m.migrateGlobalMixerConfig()
+	if err := m.migrateGlobalMixerConfig(); err != nil {
+		return err
+	}
 	m.migrateGilsonConfigs()
 	return nil
 }
@@ -127,17 +130,33 @@ func (m *Migrater) migrateGilsonConfigs() {
 	m.Cur.Config.GilsonPipetMax.Devices[devId] = m.migrateGilsonConfig()
 }
 
-func (m *Migrater) migrateGlobalMixerConfig() {
+func (m *Migrater) migrateGlobalMixerConfig() error {
 	if m.Old.Config == nil {
-		return
+		return nil
 	}
+
+	customPolicyRuleSet := m.Old.Config.CustomPolicyRuleSet
+	if customPolicyRuleSet == nil {
+		customPolicyRuleSet = wtype.NewLHPolicyRuleSet()
+	}
+	if m.Old.Config.LiquidHandlingPolicyXlsxJmpFile != nil {
+		policyMap, err := liquidtype.PolicyMakerFromBytes(m.Old.Config.LiquidHandlingPolicyXlsxJmpFile, wtype.PolicyName(liquidtype.BASEPolicy))
+		if err != nil {
+			return err
+		}
+		for name, policy := range policyMap {
+			customPolicyRuleSet.Policies[name] = policy
+		}
+	}
+
 	m.Cur.Config.GlobalMixer = workflow.GlobalMixerConfig{
-		CustomPolicyRuleSet:      m.Old.Config.CustomPolicyRuleSet,
+		CustomPolicyRuleSet:      customPolicyRuleSet,
 		IgnorePhysicalSimulation: m.Old.Config.IgnorePhysicalSimulation,
 		InputPlates:              m.Old.Config.InputPlates,
 		PrintInstructions:        m.Old.Config.PrintInstructions,
 		UseDriverTipTracking:     m.Old.Config.UseDriverTipTracking,
 	}
+	return nil
 }
 
 func (m *Migrater) migrateLayoutPreferences() *workflow.LayoutOpt {


### PR DESCRIPTION
Includes user LH policies in migrated workflows. With this change, the test plan from AC-57 completes without error.


```sh
$ cat /tmp/AC-57/wf/workflow/workflow.json | jq '.Config.GlobalMixer.customPolicyRuleSet'
```

Result:

```json
{
  "Policies": {
    "DNALV": {
      "POST_MIX": 1,
      "POST_MIX_RATE": 3,
      "POST_MIX_VOLUME": 5,
      "POST_MIX_Z": 0.5,
      "RESET_OVERRIDE": true,
      "TOUCHOFF": false
    },
    "Needtomix LLD": {
      "ASPREFERENCE": 2,
      "ASPZOFFSET": -0.5,
      "BLOWOUTOFFSET": 0,
      "BLOWOUTREFERENCE": 1,
      "BLOWOUTVOLUME": 50,
      "BLOWOUTVOLUMEUNIT": "ul",
      "CAN_MSA": false,
      "CAN_MULTI": true,
      "CAN_SDD": true,
      "DEFAULTPIPETTESPEED": 3.7,
      "DEFAULTZSPEED": 140,
      "DESCRIPTION": "Needtomix LLD v1",
      "DONT_BE_DIRTY": true,
      "DSPREFERENCE": 0,
      "DSPZOFFSET": 0.5,
      "JUSTBLOWOUT": false,
      "LLFABOVESURFACE": 3,
      "LLFBELOWSURFACE": 3,
      "MANUALPTZ": false,
      "MIX_VOLUME_OVERRIDE_TIP_MAX": false,
      "NO_AIR_DISPENSE": true,
      "OFFSETZADJUST": 0,
      "POLICYNAME": "Needtomix LLD",
      "POST_MIX": 3,
      "POST_MIX_Z": 0.5,
      "PRE_MIX": 3,
      "PRE_MIX_VOLUME": 20,
      "PRE_MIX_Z": 0.5,
      "PTZOFFSET": -0.5,
      "PTZREFERENCE": 1,
      "TIP_REUSE_LIMIT": 0,
      "TOUCHOFF": false,
      "TOUCHOFFSET": 0.5,
      "USE_LLF": false
    },
    "Smartmix LLD": {
      "ASPREFERENCE": 2,
      "ASPZOFFSET": -0.5,
      "BLOWOUTOFFSET": 0,
      "BLOWOUTREFERENCE": 1,
      "BLOWOUTVOLUME": 50,
      "BLOWOUTVOLUMEUNIT": "ul",
      "CAN_MSA": false,
      "CAN_MULTI": true,
      "CAN_SDD": true,
      "DEFAULTPIPETTESPEED": 3.7,
      "DEFAULTZSPEED": 140,
      "DESCRIPTION": "smartmix LLD v1",
      "DONT_BE_DIRTY": true,
      "DSPREFERENCE": 0,
      "DSPZOFFSET": 0.5,
      "JUSTBLOWOUT": false,
      "LLFABOVESURFACE": 3,
      "LLFBELOWSURFACE": 3,
      "MANUALPTZ": false,
      "MIX_VOLUME_OVERRIDE_TIP_MAX": true,
      "NO_AIR_DISPENSE": true,
      "OFFSETZADJUST": 0,
      "POLICYNAME": "Smartmix LLD",
      "POST_MIX": 3,
      "POST_MIX_VOLUME": 19,
      "POST_MIX_Z": 0.5,
      "PRE_MIX": 0,
      "PRE_MIX_VOLUME": 0,
      "PRE_MIX_Z": 0.5,
      "PTZOFFSET": -0.5,
      "PTZREFERENCE": 1,
      "TIP_REUSE_LIMIT": 0,
      "TOUCHOFF": false,
      "TOUCHOFFSET": 0.5,
      "USE_LLF": false
    },
    "doNotMixIfEmpty": {
      "POST_MIX": 0
    }
  },
  "Rules": {
    "DNALV": {
      "Name": "DNALV",
      "Conditions": [
        {
          "TestVariable": "VOLUME",
          "Condition": {
            "Upper": 1.99,
            "Lower": 0
          }
        },
        {
          "TestVariable": "LIQUIDCLASS",
          "Condition": {
            "Category": "dna"
          }
        }
      ],
      "Priority": 2,
      "Type": 0
    },
    "Needtomix LLD": {
      "Name": "Needtomix LLD",
      "Conditions": [
        {
          "TestVariable": "LIQUIDCLASS",
          "Condition": {
            "Category": "Needtomix LLD"
          }
        }
      ],
      "Priority": 1,
      "Type": 0
    },
    "Smartmix LLD": {
      "Name": "Smartmix LLD",
      "Conditions": [
        {
          "TestVariable": "LIQUIDCLASS",
          "Condition": {
            "Category": "Smartmix LLD"
          }
        }
      ],
      "Priority": 1,
      "Type": 0
    },
    "doNotMixIfEmpty": {
      "Name": "doNotMixIfEmpty",
      "Conditions": [
        {
          "TestVariable": "WELLTOVOLUME",
          "Condition": {
            "Upper": 0.009,
            "Lower": 0
          }
        }
      ],
      "Priority": 1,
      "Type": 0
    }
  },
  "Options": {}
}
```