### PR TITLE
ANTHA-2747 Add parquet metadata support to data tables.

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/schemas/datainfo.go
+++ b/antha/AnthaStandardLibrary/Packages/schemas/datainfo.go
@@ -1,0 +1,56 @@
+package schemas
+
+import "encoding/json"
+
+// DataInfo contains metadata that cannot be inferred from a file directly.
+// All fields should be considered optional.
+type DataInfo struct {
+	Tool    *Tool    `json:"tool,omitempty"`
+	Origin  *Origin  `json:"origin,omitempty"`
+	Columns *Columns `json:"columns,omitempty"`
+
+	// A short name identifying the type of data represented - such as
+	// "spectrometer" or "cell count". This is not human-readable and may be
+	// used in future as as key in a schema registry or ontology.
+	Kind string `json:"kind,omitempty"`
+
+	// A longer comment on the provenance of the data, which might be useful to
+	// end-users.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Origin describes the original source of this data, if any.
+type Origin struct {
+	// If the data was transformed from a vendor-specific file format, this
+	// can be used to identify that format (eg. "xml" or "csv")
+	Format string `json:"format,omitempty"`
+
+	// Arbitrary key-value properties from a vendor-specific file.
+	Properties map[string]json.RawMessage `json:"properties,omitempty"`
+}
+
+// Tool describes the software tool that generated this data.
+type Tool struct {
+	// An artifact version, in machine-readable form such as a docker image
+	// name.
+	ExternalID string `json:"external_id,omitempty"`
+}
+
+// Columns holds column-level metadata.
+type Columns struct {
+	// If set, this should contain human-readable column names in the same order
+	// as the physical dataset. This may be useful if the file format does not
+	// allow arbitrary names in the physical schema.
+	Names []string `json:"names,omitempty"`
+}
+
+// TODO further usecases
+// - data sort order (NB. duplicating Parquet feature?)
+// - column statistics
+// - Go datatype information
+// - biological ontology
+// - units of measure
+// - timezone of potentially ambiguous timestamp values
+// - time source used (eg based on what device's clock)
+// - operator ID
+// - legal - copyright info, information barriers

--- a/antha/AnthaStandardLibrary/Packages/schemas/doc.go
+++ b/antha/AnthaStandardLibrary/Packages/schemas/doc.go
@@ -1,0 +1,7 @@
+/*
+Package schemas contains utilities for defining data schemas.
+
+It is designed to complement package github.com/antha/antha/anthalib/data with concrete
+names and types.
+*/
+package schemas

--- a/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo.go
+++ b/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo.go
@@ -1,0 +1,46 @@
+package parquetinfo
+
+import (
+	"encoding/json"
+	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/schemas"
+	"github.com/antha-lang/antha/antha/anthalib/data/parquet"
+)
+
+// ParquetInfoKey is used to embed JSON DataInfo in a Parquet file footer as
+// `key_value_metadata`.
+const ParquetInfoKey = "antha:data-info"
+
+// AddAnthaInfo inserts the JSON DataInfo representation in the footer when
+// writing a file. Use it like:
+//      meta := parquet.FileKeyValueMetadata{}
+//      _ = parquetinfo.AddAnthaInfo(meta, dataInfo)
+//      parquet.TableToBytes(table, meta.Write())
+func AddAnthaInfo(meta parquet.FileKeyValueMetadata, dataInfo schemas.DataInfo) error {
+	if meta == nil {
+		return nil
+	}
+	infoJSON, err := json.Marshal(dataInfo)
+	if err != nil {
+		return err
+	}
+	meta[ParquetInfoKey] = string(infoJSON)
+	return err
+}
+
+// GetAnthaInfo reads the JSON DataIfo representation from the footer.
+// Use it together with data tableslike:
+//      meta := parquet.FileKeyValueMetadata{}
+//		table, err = parquet.TableFromReader(reader, meta.Read())
+//		dataInfo := GetAnthaInfo(meta)
+func GetAnthaInfo(meta parquet.FileKeyValueMetadata) (schemas.DataInfo, error) {
+	inf := schemas.DataInfo{}
+	if meta == nil {
+		return inf, nil
+	}
+	infoJSON := meta[ParquetInfoKey]
+	if infoJSON == "" {
+		return inf, nil
+	}
+	err := json.Unmarshal([]byte(infoJSON), &inf)
+	return inf, err
+}

--- a/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo.go
+++ b/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo.go
@@ -27,11 +27,11 @@ func AddAnthaInfo(meta parquet.FileKeyValueMetadata, dataInfo schemas.DataInfo) 
 	return err
 }
 
-// GetAnthaInfo reads the JSON DataIfo representation from the footer.
-// Use it together with data tableslike:
+// GetAnthaInfo reads the JSON DataInfo representation from the footer.
+// Use it together with data tables like:
 //      meta := parquet.FileKeyValueMetadata{}
 //		table, err = parquet.TableFromReader(reader, meta.Read())
-//		dataInfo := GetAnthaInfo(meta)
+//		dataInfo, err := GetAnthaInfo(meta)
 func GetAnthaInfo(meta parquet.FileKeyValueMetadata) (schemas.DataInfo, error) {
 	inf := schemas.DataInfo{}
 	if meta == nil {

--- a/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo_test.go
+++ b/antha/AnthaStandardLibrary/Packages/schemas/parquetinfo/parquetinfo_test.go
@@ -1,0 +1,29 @@
+package parquetinfo
+
+import (
+	"testing"
+
+	"github.com/antha-lang/antha/antha/AnthaStandardLibrary/Packages/schemas"
+	"github.com/antha-lang/antha/antha/anthalib/data/parquet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAnthaInfo(t *testing.T) {
+	meta := (parquet.FileKeyValueMetadata)(nil)
+	require.NoError(t, AddAnthaInfo(meta, schemas.DataInfo{}))
+	assert.Nil(t, meta, "nil")
+	meta = parquet.FileKeyValueMetadata{"x": "1"}
+	require.NoError(t, AddAnthaInfo(meta, schemas.DataInfo{}))
+	assert.Contains(t, meta, "x")
+	assert.Contains(t, meta, ParquetInfoKey)
+}
+
+func TestRoundtripAnthaInfo(t *testing.T) {
+	meta := parquet.FileKeyValueMetadata{}
+	inf := schemas.DataInfo{Tool: &schemas.Tool{ExternalID: "a tool"}}
+	require.NoError(t, AddAnthaInfo(meta, inf))
+	infUnmarshal, err := GetAnthaInfo(meta)
+	require.NoError(t, err)
+	assert.EqualValues(t, inf, infUnmarshal)
+}

--- a/antha/anthalib/data/parquet/filemeta.go
+++ b/antha/anthalib/data/parquet/filemeta.go
@@ -7,7 +7,7 @@ import (
 // FileKeyValueMetadata represents keys in file-level Parquet
 // metadata, as defined in:
 // https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L924 .
-// In the presence of duplicate keys ion the file, behavior is undefined.
+// In the presence of duplicate keys in the file, behavior is undefined.
 type FileKeyValueMetadata map[string]string
 
 // Write gives a WriteOpt that writes all the given keyvalues into file metadata.
@@ -15,10 +15,10 @@ func (m FileKeyValueMetadata) Write() WriteOpt {
 	return func(w *writeState) error {
 
 		for k, v := range m {
-			kv := parquet.NewKeyValue()
-			kv.Key = k
 			// we need a copy, not &v
 			metaValue := v
+			kv := parquet.NewKeyValue()
+			kv.Key = k
 			kv.Value = &metaValue
 			w.writer.Footer.KeyValueMetadata = append(w.writer.Footer.KeyValueMetadata, kv)
 		}
@@ -30,9 +30,9 @@ func (m FileKeyValueMetadata) Write() WriteOpt {
 // Read gives a ReadOpt that populates this map as a side effect, when the file is read.
 func (m FileKeyValueMetadata) Read() ReadOpt {
 	return func(r *readState) error {
-		kv := r.reader.Footer.GetKeyValueMetadata()
-		for _, v := range kv {
-			m[v.GetKey()] = v.GetValue()
+		kvs := r.reader.Footer.GetKeyValueMetadata()
+		for _, kv := range kvs {
+			m[kv.GetKey()] = kv.GetValue()
 		}
 
 		return nil

--- a/antha/anthalib/data/parquet/filemeta.go
+++ b/antha/anthalib/data/parquet/filemeta.go
@@ -1,0 +1,40 @@
+package parquet
+
+import (
+	"github.com/xitongsys/parquet-go/parquet"
+)
+
+// FileKeyValueMetadata represents keys in file-level Parquet
+// metadata, as defined in:
+// https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L924 .
+// In the presence of duplicate keys ion the file, behavior is undefined.
+type FileKeyValueMetadata map[string]string
+
+// Write gives a WriteOpt that writes all the given keyvalues into file metadata.
+func (m FileKeyValueMetadata) Write() WriteOpt {
+	return func(w *writeState) error {
+
+		for k, v := range m {
+			kv := parquet.NewKeyValue()
+			kv.Key = k
+			// we need a copy, not &v
+			metaValue := v
+			kv.Value = &metaValue
+			w.writer.Footer.KeyValueMetadata = append(w.writer.Footer.KeyValueMetadata, kv)
+		}
+
+		return nil
+	}
+}
+
+// Read gives a ReadOpt that populates this map as a side effect, when the file is read.
+func (m FileKeyValueMetadata) Read() ReadOpt {
+	return func(r *readState) error {
+		kv := r.reader.Footer.GetKeyValueMetadata()
+		for _, v := range kv {
+			m[v.GetKey()] = v.GetValue()
+		}
+
+		return nil
+	}
+}

--- a/antha/anthalib/data/parquet/parquet_test.go
+++ b/antha/anthalib/data/parquet/parquet_test.go
@@ -37,7 +37,7 @@ func TestParquet(t *testing.T) {
 			return nil, err
 		}
 
-		return TableFromFile(fileName, columns...)
+		return TableFromFile(fileName, Columns(columns...))
 	})
 
 	// bytes: write + read
@@ -47,7 +47,7 @@ func TestParquet(t *testing.T) {
 			return nil, err
 		}
 
-		return TableFromBytes(blob, columns...)
+		return TableFromBytes(blob, Columns(columns...))
 	})
 
 	// write to io.Writer + read from io.Reader
@@ -58,8 +58,21 @@ func TestParquet(t *testing.T) {
 			return nil, err
 		}
 
-		return TableFromReader(buffer, columns...)
+		return TableFromReader(buffer, Columns(columns...))
 	})
+
+	// // bytes: write + read, also setting arbitrary keyvalue metadata
+	// parquetTest(t, "Bytes + kv meta", table, []data.ColumnName{}, func(src *data.Table, columns ...data.ColumnName) (*data.Table, error) {
+	// 	blob, err := TableToBytes(src, &FileKeyValueMetadata{"meta-key": "meta-value"})
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	// check metadata round trip
+	// 	readMeta := &FileKeyValueMetadata{}
+
+	// 	r := TableFromBytes(blob, columns...)
+	// 	return r
+	// })
 }
 
 func parquetTest(t *testing.T, caption string, src *data.Table, columns []data.ColumnName, writeAndRead func(*data.Table, ...data.ColumnName) (*data.Table, error)) {

--- a/antha/anthalib/data/parquet/reader.go
+++ b/antha/anthalib/data/parquet/reader.go
@@ -92,10 +92,7 @@ func readTable(r *readState, err error) (*data.Table, error) {
 	}
 
 	// reading Parquet file metadata
-	metadata, err := r.readMetadata()
-	if err != nil {
-		return nil, err
-	}
+	metadata := r.reader.Footer
 
 	// transforming Parquet file metadata into parquetSchema
 	schema, err := schemaFromParquetMetadata(metadata, r.columnNames)
@@ -131,17 +128,6 @@ func readTable(r *readState, err error) (*data.Table, error) {
 
 	// building a Table
 	return builder.Build(), nil
-}
-
-// reads Parquet file metadata
-func (r *readState) readMetadata() (*parquet.FileMetaData, error) {
-	// seeking to the beginning of the file again
-	// _, err := r.reader.PFile.Seek(0, io.SeekStart)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "ParquetFile.Seek")
-	// }
-
-	return r.reader.Footer, nil
 }
 
 // Reads rows from Parquet file

--- a/antha/anthalib/data/parquet/writer.go
+++ b/antha/anthalib/data/parquet/writer.go
@@ -12,8 +12,19 @@ import (
 	"github.com/xitongsys/parquet-go/parquet"
 )
 
+// WriteOpt sets an optional behavior when creating parquet files.
+type WriteOpt interface {
+}
+
+// FileKeyValueMetadata is a WriteOpt that sets keys in file-level Parquet
+// metadata, as defined in:
+// https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L924
+type FileKeyValueMetadata map[string]string
+
+var _ WriteOpt = (*FileKeyValueMetadata)(nil)
+
 // TableToWriter writes a data.Table to io.Writer
-func TableToWriter(table *data.Table, writer io.Writer) error {
+func TableToWriter(table *data.Table, writer io.Writer, opts ...WriteOpt) error {
 	// wrapping io.Writer in a ParquetFile.ParquetFile
 	file := ParquetFile.NewWriterFile(writer)
 
@@ -22,7 +33,7 @@ func TableToWriter(table *data.Table, writer io.Writer) error {
 }
 
 // TableToBytes writes a data.Table to a memory buffer
-func TableToBytes(table *data.Table) ([]byte, error) {
+func TableToBytes(table *data.Table, opts ...WriteOpt) ([]byte, error) {
 	// a memory buffer writer
 	buffer := bytes.NewBuffer(nil)
 
@@ -37,7 +48,7 @@ func TableToBytes(table *data.Table) ([]byte, error) {
 }
 
 // TableToFile writes a data.Table to a file on disk
-func TableToFile(table *data.Table, filePath string) error {
+func TableToFile(table *data.Table, filePath string, opts ...WriteOpt) error {
 	// opening the file
 	file, err := ParquetFile.NewLocalFileWriter(filePath)
 	if err != nil {

--- a/antha/anthalib/data/parquet/writer.go
+++ b/antha/anthalib/data/parquet/writer.go
@@ -13,23 +13,19 @@ import (
 )
 
 // WriteOpt sets an optional behavior when creating parquet files.
-type WriteOpt interface {
+type WriteOpt func(*writeState) error
+
+type writeState struct {
+	table  *data.Table
+	writer *ParquetWriter.ParquetWriter
 }
-
-// FileKeyValueMetadata is a WriteOpt that sets keys in file-level Parquet
-// metadata, as defined in:
-// https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L924
-type FileKeyValueMetadata map[string]string
-
-var _ WriteOpt = (*FileKeyValueMetadata)(nil)
 
 // TableToWriter writes a data.Table to io.Writer
 func TableToWriter(table *data.Table, writer io.Writer, opts ...WriteOpt) error {
 	// wrapping io.Writer in a ParquetFile.ParquetFile
 	file := ParquetFile.NewWriterFile(writer)
 
-	// writing the table
-	return writeTable(table, file)
+	return writeTable(write(file, table, opts))
 }
 
 // TableToBytes writes a data.Table to a memory buffer
@@ -41,7 +37,7 @@ func TableToBytes(table *data.Table, opts ...WriteOpt) ([]byte, error) {
 	file := ParquetFile.NewWriterFile(buffer)
 
 	// writing the table
-	if err := TableToWriter(table, file); err != nil {
+	if err := TableToWriter(table, file, opts...); err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil
@@ -56,17 +52,39 @@ func TableToFile(table *data.Table, filePath string, opts ...WriteOpt) error {
 	}
 	defer file.Close() //nolint
 
-	// writing a table
-	return writeTable(table, file)
+	return writeTable(write(file, table, opts))
+}
+
+func write(file ParquetFile.ParquetFile, table *data.Table, opts []WriteOpt) (*writeState, error) {
+	// Parquet writer and its settings
+	writer, err := ParquetWriter.NewParquetWriter(file, nil, 1)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating Parquet writer")
+	}
+	writer.RowGroupSize = 128 * 1024 * 1024 //128M
+	writer.CompressionType = parquet.CompressionCodec_SNAPPY
+
+	w := &writeState{writer: writer, table: table}
+	for _, o := range opts {
+		err := o(w)
+		if err != nil {
+			return nil, errors.Wrapf(err, "WriteOpt %v generated an error state when writing %v", o, file)
+		}
+	}
+	return w, nil
 }
 
 // writes a data.Table to ParquetFile.ParquetFile
-func writeTable(table *data.Table, file ParquetFile.ParquetFile) error {
+func writeTable(w *writeState, err error) error {
+	if err != nil {
+		return err
+	}
+
 	// parquet schema
-	tableSchema := table.Schema()
+	tableSchema := w.table.Schema()
 	schema := newParquetSchema(&tableSchema)
 
-	// converting parquetSchame to json understandable by parquet-go
+	// converting parquetSchema to json understandable by parquet-go
 	jsonSchema, err := schema.toJSON()
 	if err != nil {
 		return err
@@ -76,11 +94,11 @@ func writeTable(table *data.Table, file ParquetFile.ParquetFile) error {
 	rowType := rowStructFromSchema(schema)
 
 	// starting iterating through the table
-	iter, done := table.Iter()
+	iter, done := w.table.Iter()
 	defer done()
 
 	// writing to Parquet
-	return writeToParquet(file, jsonSchema, rowType, func() (interface{}, error) {
+	return w.writeToParquet(jsonSchema, rowType, func() (interface{}, error) {
 		row, ok := <-iter
 		if !ok {
 			return nil, nil
@@ -90,17 +108,10 @@ func writeTable(table *data.Table, file ParquetFile.ParquetFile) error {
 }
 
 // Writes rows to Parquet file
-func writeToParquet(file ParquetFile.ParquetFile, jsonSchema string, rowType reflect.Type, rowIter func() (interface{}, error)) error {
-	// Parquet writer and its settings
-	writer, err := ParquetWriter.NewParquetWriter(file, nil, 1)
-	if err != nil {
-		return errors.Wrap(err, "creating Parquet writer")
-	}
-	writer.RowGroupSize = 128 * 1024 * 1024 //128M
-	writer.CompressionType = parquet.CompressionCodec_SNAPPY
+func (w *writeState) writeToParquet(jsonSchema string, rowType reflect.Type, rowIter func() (interface{}, error)) error {
 
 	// parquet schema
-	if err := writer.SetSchemaHandlerFromJSON(jsonSchema); err != nil {
+	if err := w.writer.SetSchemaHandlerFromJSON(jsonSchema); err != nil {
 		return errors.Wrap(err, "set Parquet schema")
 	}
 
@@ -113,13 +124,13 @@ func writeToParquet(file ParquetFile.ParquetFile, jsonSchema string, rowType ref
 		if row == nil {
 			break
 		}
-		if err = writer.Write(row); err != nil {
+		if err = w.writer.Write(row); err != nil {
 			return err
 		}
 	}
 
 	// Flush
-	return writer.WriteStop()
+	return w.writer.WriteStop()
 }
 
 // copies data.Row content into a dynamic data struct suitable for Parquet writer


### PR DESCRIPTION
The use case for this is adding antha-specific JSON document into the footer.  documentation on the expected usage here: https://paper.dropbox.com/doc/Empirical-data-schemas--Ab8UyJdC2_NJJPkjMEPsY4vlAg-RvV9MPtb5vRwFCvuSIGEM

As part of this, we are no longer redundantly seeking in the file (in reader).