### PR TITLE
Align mods 5

### DIFF
--- a/antha/AnthaStandardLibrary/Packages/sequences/align/align.go
+++ b/antha/AnthaStandardLibrary/Packages/sequences/align/align.go
@@ -334,12 +334,6 @@ func DNA(template, query wtype.DNASequence, alignmentMatrix ScoringMatrix) (alig
 		return fwdResult, fmt.Errorf(fmt.Sprintf("Error with aligning reverse complement of query sequence %s: %s", query.Nm, err.Error()))
 	}
 
-	if len(query.Seq) > len(template.Seq) {
-		if err == nil {
-			err = fmt.Errorf("query sequence is larger than template, this may result in an unusual alignment")
-		}
-	}
-
 	if revResult.Matches() > fwdResult.Matches() {
 		return revResult, err
 	}

--- a/antha/AnthaStandardLibrary/Packages/sequences/align/align.go
+++ b/antha/AnthaStandardLibrary/Packages/sequences/align/align.go
@@ -334,7 +334,7 @@ func DNA(template, query wtype.DNASequence, alignmentMatrix ScoringMatrix) (alig
 		return fwdResult, fmt.Errorf(fmt.Sprintf("Error with aligning reverse complement of query sequence %s: %s", query.Nm, err.Error()))
 	}
 
-	if revResult.Matches() > fwdResult.Matches() {
+	if revResult.Score() > fwdResult.Score() {
 		return revResult, err
 	}
 


### PR DESCRIPTION
1) 
The situation of query length > template length might give unusual results in some situations but that would be to do with the context (`ValidateSequenceResults`?) rather than the alignment process. Pairwise alignment should be completely symmetric in query/template and so should not generate an error here.

2)
Rank alignments by alignment score rather than matches. Alignment score also includes the costs of gaps and mismatches and is a better and more standard way to rank alignments. Won't make a big difference for close matches.
