### PR TITLE
A little de-bit-rotting for the Dragonfly / any HighLevelLiquidHandler

### DIFF
--- a/microArch/scheduler/liquidhandling/liquidhandler.go
+++ b/microArch/scheduler/liquidhandling/liquidhandler.go
@@ -343,12 +343,16 @@ func (this *Liquidhandler) shrinkVolumes(rq *LHRequest) error {
 			HandleTransfer: func(ins *liquidhandling.TransferInstruction) {
 				for _, mtf := range ins.Transfers {
 					for _, tf := range mtf.Transfers {
-						if plate, ok := this.Properties.PlateLookup[tf.PltFrom].(*wtype.LHPlate); ok {
-							usedPlates[plate] = true
-							if well := plate.Wellcoords[tf.WellFrom]; well.IsAutoallocated() {
-								useVol(well, tf.Volume, wunit.ZeroVolume())
+						for _, pos := range []string{tf.PltFrom, tf.PltTo} {
+							plateID := this.Properties.PosLookup[pos]
+							if plate, ok := this.Properties.PlateLookup[plateID].(*wtype.LHPlate); ok {
+								usedPlates[plate] = true
+								if well := plate.Wellcoords[tf.WellFrom]; well.IsAutoallocated() {
+									useVol(well, tf.Volume, wunit.ZeroVolume())
+								}
 							}
 						}
+
 					}
 				}
 			},
@@ -448,13 +452,11 @@ func (this *Liquidhandler) shrinkVolumes(rq *LHRequest) error {
 			rq.InputPlateOrder = ipo
 		}
 	}
-
 	return nil
 }
 
 // updateIDs
 func (this *Liquidhandler) updateIDs() error {
-
 	// keep track of object ID changes
 	this.plateIDMap = make(map[string]string, len(this.Properties.PlateLookup))
 	for id := range this.Properties.PlateIDLookup {
@@ -781,7 +783,6 @@ func OutputSetup(robot *liquidhandling.LHProperties) {
 // LHInstruction which generated it, so this function updates the name of each liquid
 // to be equal to that which was set in the Mix instruction which created it
 func (lh *Liquidhandler) updateComponentNames(rq *LHRequest) error {
-
 	// get the instructions in the ordere that they happen
 	orderedInstructions, err := rq.GetOrderedLHInstructions()
 	if err != nil {

--- a/microArch/scheduler/liquidhandling/setupagent.go
+++ b/microArch/scheduler/liquidhandling/setupagent.go
@@ -206,6 +206,7 @@ func BasicSetupAgent(ctx context.Context, request *LHRequest, params *liquidhand
 		if err := params.AddPlateTo(position, p); err != nil {
 			return errors.WithMessage(err, "while setting up output plates")
 		}
+		fmt.Println(fmt.Sprintf("Output plate of type %s in position %s", p.Type, position))
 	}
 
 	for _, pid := range input_plate_order {

--- a/target/auto/try.go
+++ b/target/auto/try.go
@@ -64,6 +64,7 @@ var mixerMap = map[string]func(*tryer, context.Context, *grpc.ClientConn, interf
 	"TecanEvo":       (*tryer).addLowLevelMixer,
 	"LabCyteEcho":    (*tryer).addHighLevelMixer,
 	"Hamilton":       (*tryer).addLowLevelMixer,
+	"TTPLabtech":     (*tryer).addHighLevelMixer,
 }
 
 // AddMixer queries a mixer driver and adds the corresponding device to the target

--- a/target/auto/try.go
+++ b/target/auto/try.go
@@ -59,12 +59,12 @@ func (a *tryer) Try(ctx context.Context, conn *grpc.ClientConn, arg interface{})
 }
 
 var mixerMap = map[string]func(*tryer, context.Context, *grpc.ClientConn, interface{}) error{
-	"GilsonPipetmax": (*tryer).addLowLevelMixer,
-	"CyBio":          (*tryer).addLowLevelMixer,
-	"TecanEvo":       (*tryer).addLowLevelMixer,
-	"LabCyteEcho":    (*tryer).addHighLevelMixer,
-	"Hamilton":       (*tryer).addLowLevelMixer,
-	"TTPLabtech":     (*tryer).addHighLevelMixer,
+	"GilsonPipetmax":      (*tryer).addLowLevelMixer,
+	"CyBio":               (*tryer).addLowLevelMixer,
+	"TecanEvo":            (*tryer).addLowLevelMixer,
+	"LabCyteEcho":         (*tryer).addHighLevelMixer,
+	"Hamilton":            (*tryer).addLowLevelMixer,
+	"TTPLabtechDragonfly": (*tryer).addHighLevelMixer,
 }
 
 // AddMixer queries a mixer driver and adds the corresponding device to the target


### PR DESCRIPTION
the earlier visitor change to shrinkVolumes was incorrect for the TransferInstructions, so it was deleting all plates

Can confirm this now works for the Echo and Dragonfly (tested via running a simple bundle in each case) 

Additionally I've added the dragonfly type to the tryer in auto so it is now a Known Driver (shoot me)