### PR TITLE
[AC-71] Reform file creation

### DIFF
--- a/composer/compile.go
+++ b/composer/compile.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/antha-lang/antha/utils"
 	"github.com/antha-lang/antha/workflow"
 )
 
@@ -172,7 +173,7 @@ func (cb *ComposerBase) prepareDrivers(cfg *workflow.Config) error {
 
 	for id, cfg := range conns {
 		outBin := filepath.Join(cb.OutDir, "bin", "drivers", string(id))
-		if err := os.MkdirAll(filepath.Dir(outBin), 0700); err != nil {
+		if err := utils.MkdirAll(filepath.Dir(outBin)); err != nil {
 			return err
 
 		} else if cfg.CompileAndRun != "" {
@@ -191,7 +192,7 @@ func (cb *ComposerBase) prepareDrivers(cfg *workflow.Config) error {
 				return err
 			}
 			defer src.Close()
-			dst, err := os.OpenFile(outBin, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700)
+			dst, err := utils.CreateFile(outBin, utils.ReadWriteExec)
 			if err != nil {
 				return err
 			}

--- a/composer/composer.go
+++ b/composer/composer.go
@@ -44,11 +44,11 @@ func NewComposerBase(logger *logger.Logger, inDir, outDir string) (*ComposerBase
 		return nil, err
 	}
 	// always need to do this:
-	if err := os.MkdirAll(filepath.Join(outDir, "workflow", "data"), 0700); err != nil {
+	if err := utils.MkdirAll(filepath.Join(outDir, "workflow", "data")); err != nil {
 		return nil, err
 	}
 
-	logFH, err := os.OpenFile(filepath.Join(outDir, "logs.txt"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400)
+	logFH, err := utils.CreateFile(filepath.Join(outDir, "logs.txt"), utils.ReadWrite)
 	if err != nil {
 		return nil, err
 	} else {
@@ -97,7 +97,7 @@ func (cb *ComposerBase) cloneRepositories(wf *workflow.Workflow) error {
 func (cb *ComposerBase) generateRepositoryGoMods() error {
 	for repoName := range cb.clonedRepositories {
 		path := filepath.Join(cb.OutDir, "src", filepath.FromSlash(string(repoName)), "go.mod")
-		if fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400); err != nil {
+		if fh, err := utils.CreateFile(path, utils.ReadWrite); err != nil {
 			return err
 		} else {
 			defer fh.Close()
@@ -111,7 +111,7 @@ func (cb *ComposerBase) generateRepositoryGoMods() error {
 
 func (cb *ComposerBase) generateWorkflowGoMod() error {
 	path := filepath.Join(cb.OutDir, "workflow", "go.mod")
-	if fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400); err != nil {
+	if fh, err := utils.CreateFile(path, utils.ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()
@@ -121,7 +121,7 @@ func (cb *ComposerBase) generateWorkflowGoMod() error {
 
 func (cb *ComposerBase) generateGoGenerate() error {
 	path := filepath.Join(cb.OutDir, "workflow", "generate_assets.go")
-	if fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400); err != nil {
+	if fh, err := utils.CreateFile(path, utils.ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()
@@ -207,7 +207,7 @@ func (mc *mainComposer) generateMain() error {
 		return err
 	} else if err := mc.generateWorkflowGoMod(); err != nil {
 		return err
-	} else if fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400); err != nil {
+	} else if fh, err := utils.CreateFile(path, utils.ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()
@@ -308,7 +308,7 @@ func (tc *testComposer) ComposeTestsAndRun() error {
 func (twf *testWorkflow) generateTest() error {
 	path := filepath.Join(twf.OutDir, "workflow", fmt.Sprintf("workflow%d_test.go", twf.index))
 	twf.Logger.Log("progress", "generating workflow test", "path", path)
-	if fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400); err != nil {
+	if fh, err := utils.CreateFile(path, utils.ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()

--- a/composer/transpiler.go
+++ b/composer/transpiler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/antha-lang/antha/antha/compile"
 	"github.com/antha-lang/antha/antha/parser"
 	"github.com/antha-lang/antha/antha/token"
+	"github.com/antha-lang/antha/utils"
 	"github.com/antha-lang/antha/workflow"
 )
 
@@ -124,7 +125,7 @@ func writeAnthaFiles(files *compile.AnthaFiles, baseDir string) error {
 }
 
 func writeAnthaFile(outFile string, file *compile.AnthaFile) error {
-	dst, err := os.OpenFile(outFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400)
+	dst, err := utils.CreateFile(outFile, utils.ReadWrite)
 	if err != nil {
 		return err
 	}

--- a/laboratory/effects/filemanager.go
+++ b/laboratory/effects/filemanager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/antha-lang/antha/antha/anthalib/wtype"
+	"github.com/antha-lang/antha/utils"
 )
 
 type FileManager struct {
@@ -119,7 +120,7 @@ func (fm *FileManager) WithWriter(fun func(io.Writer) error, fileName string) (*
 	fm.writtenCount++
 	leaf := fmt.Sprintf("%d", fm.writtenCount)
 	pLocal := filepath.Join(fm.outDir, leaf)
-	if fh, err := os.OpenFile(pLocal, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400); err != nil {
+	if fh, err := utils.CreateFile(pLocal, utils.ReadWrite); err != nil {
 		return nil, err
 	} else {
 		buf := new(bytes.Buffer)
@@ -146,7 +147,7 @@ func (fm *FileManager) WriteAll(bs []byte, fileName string) (*wtype.File, error)
 	fm.writtenCount++
 	leaf := fmt.Sprintf("%d", fm.writtenCount)
 	pLocal := filepath.Join(fm.outDir, leaf)
-	if err := ioutil.WriteFile(pLocal, bs, 0400); err != nil {
+	if err := utils.CreateAndWriteFile(pLocal, bs, utils.ReadWrite); err != nil {
 		return nil, err
 	} else {
 		fm.outCache[leaf] = copyBytes(bs)

--- a/laboratory/laboratory.go
+++ b/laboratory/laboratory.go
@@ -147,13 +147,13 @@ func (labBuild *LaboratoryBuilder) SetupPaths(inDir, outDir string) error {
 
 	// Create subdirs within it:
 	for _, leaf := range []string{"elements", "data", "tasks", "workflow"} {
-		if err := os.MkdirAll(filepath.Join(labBuild.outDir, leaf), 0700); err != nil {
+		if err := utils.MkdirAll(filepath.Join(labBuild.outDir, leaf)); err != nil {
 			return err
 		}
 	}
 
 	// Switch the logger over to write to disk too:
-	if logFH, err := os.OpenFile(filepath.Join(labBuild.outDir, "logs.txt"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400); err != nil {
+	if logFH, err := utils.CreateFile(filepath.Join(labBuild.outDir, "logs.txt"), utils.ReadWrite); err != nil {
 		return err
 	} else {
 		labBuild.logFH = logFH
@@ -529,7 +529,7 @@ func (eb *ElementBase) Exited() {
 func (eb *ElementBase) Save(lab *Laboratory) {
 	lab.Logger.Log("progress", "completed")
 	p := filepath.Join(lab.labBuild.outDir, "elements", fmt.Sprintf("%d_%s.json", eb.id, eb.element.Name()))
-	if fh, err := os.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400); err != nil {
+	if fh, err := utils.CreateFile(p, utils.ReadWrite); err != nil {
 		lab.error(err)
 	} else {
 		defer fh.Close()

--- a/laboratory/testlab/testing.go
+++ b/laboratory/testlab/testing.go
@@ -16,18 +16,18 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/antha-lang/antha/laboratory"
 	"github.com/antha-lang/antha/laboratory/effects"
+	"github.com/antha-lang/antha/utils"
 	"github.com/antha-lang/antha/workflow"
 )
 
 // Used by generated code build by the composer machinery when processing element test workflows.
 func NewTestLabBuilder(t *testing.T, inDir, outDir string, fh io.ReadCloser) *laboratory.LaboratoryBuilder {
 	if outDir != "" {
-		if err := os.MkdirAll(outDir, 0700); err != nil {
+		if err := utils.MkdirAll(outDir); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/target/mixer/base.go
+++ b/target/mixer/base.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -28,6 +26,7 @@ import (
 	lhdriver "github.com/antha-lang/antha/microArch/driver/liquidhandling"
 	"github.com/antha-lang/antha/microArch/scheduler/liquidhandling"
 	"github.com/antha-lang/antha/target"
+	"github.com/antha-lang/antha/utils"
 	"github.com/antha-lang/antha/workflow"
 	"google.golang.org/grpc"
 )
@@ -372,17 +371,17 @@ func (mo mixOpts) mix() (*target.Mix, error) {
 		mix.SetId(idGen)
 
 		dir := filepath.Join(mo.OutDir, mix.Id(), string(mo.Device.Id()))
-		if err := os.MkdirAll(dir, 0700); err != nil {
+		if err := utils.MkdirAll(dir); err != nil {
 			return nil, err
 		} else if layoutBs, err := mix.SummarizeLayout(idGen); err != nil {
 			return nil, err
 		} else if actionsBs, err := mix.SummarizeActions(idGen); err != nil {
 			return nil, err
-		} else if err := ioutil.WriteFile(filepath.Join(dir, "layout.json"), layoutBs, 0400); err != nil {
+		} else if err := utils.CreateAndWriteFile(filepath.Join(dir, "layout.json"), layoutBs, utils.ReadWrite); err != nil {
 			return nil, err
-		} else if err := ioutil.WriteFile(filepath.Join(dir, "actions.json"), actionsBs, 0400); err != nil {
+		} else if err := utils.CreateAndWriteFile(filepath.Join(dir, "actions.json"), actionsBs, utils.ReadWrite); err != nil {
 			return nil, err
-		} else if err := ioutil.WriteFile(filepath.Join(dir, mo.ContentName), rawBs, 0400); err != nil {
+		} else if err := utils.CreateAndWriteFile(filepath.Join(dir, mo.ContentName), rawBs, utils.ReadWrite); err != nil {
 			return nil, err
 		}
 

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"io"
-	"os"
 	"strings"
 )
 
@@ -63,7 +62,7 @@ func (es ErrorSlice) MarshalJSON() ([]byte, error) {
 
 // WriteToFile writes the contents of an error slice to file as json.
 func (es ErrorSlice) WriteToFile(filename string) error {
-	if fh, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400); err != nil {
+	if fh, err := CreateFile(filename, ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"io"
+	"os"
+)
+
+const (
+	ReadOnly      os.FileMode = 0444
+	ReadWrite     os.FileMode = 0666
+	ReadWriteExec os.FileMode = 0777
+)
+
+// CreateFile creates a new file at the indicated path. The file is
+// opened with O_CREATE|O_EXCL|O_RDWR meaning:
+// a) there will be an error if the file already exists
+// b) if there is no error, then the file handle returned will be
+// available for reading and writing
+//
+// The perm parameter sets the permission bits on the file - the
+// equivalent of chmod. Appropriate consts are provided. In general we
+// rely on the user's umask to limit these, as desired.
+func CreateFile(path string, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, perm)
+}
+
+// CreateAndWriteFile is similar to ioutil.WriteAll, but it ensures
+// that the file does not already exist.
+func CreateAndWriteFile(path string, data []byte, perm os.FileMode) error {
+	fh, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	n, err := fh.Write(data)
+	if err == nil && n < len(data) {
+		return io.ErrShortWrite
+	}
+	// always close, but preserve existing non-nil error:
+	if errClose := fh.Close(); err == nil {
+		err = errClose
+	}
+	return err
+}
+
+// MkdirAll is a simple wrapper around os.MkdirAll(). It exists to avoid
+// having to consider which permissions to set on the created
+// directories. We use 0777, and rely on the user's umask to limit
+// these, as desired.
+func MkdirAll(path string) error {
+	return os.MkdirAll(path, ReadWriteExec)
+}

--- a/workflow/repositories.go
+++ b/workflow/repositories.go
@@ -53,7 +53,7 @@ func (r *Repository) Clone(dir string) error {
 	} else if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := utils.MkdirAll(dir); err != nil {
 		return err
 	}
 	return r.Walk(copier(dir))
@@ -65,7 +65,7 @@ func copier(dir string) func(f *File) error {
 			return nil
 		}
 		dst := filepath.Join(dir, f.Name)
-		if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+		if err := utils.MkdirAll(filepath.Dir(dst)); err != nil {
 			return err
 		}
 		srcFh, err := f.Contents()
@@ -73,7 +73,7 @@ func copier(dir string) func(f *File) error {
 			return err
 		}
 		defer srcFh.Close()
-		dstFh, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400)
+		dstFh, err := utils.CreateFile(dst, utils.ReadWrite)
 		if err != nil {
 			return err
 		}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -128,7 +128,7 @@ func (wf *Workflow) EnsureWorkflowId() error {
 func (wf *Workflow) WriteToFile(p string, pretty bool) error {
 	if p == "" || p == "-" {
 		return wf.ToWriter(os.Stdout, pretty)
-	} else if fh, err := os.OpenFile(p, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0400); err != nil {
+	} else if fh, err := utils.CreateFile(p, utils.ReadWrite); err != nil {
 		return err
 	} else {
 		defer fh.Close()


### PR DESCRIPTION
    In a large number of places we create files and then write to them. We expect those files to not already exist, which means we should be doing O_CREAT|O_EXCL, which we were not.
    Additionally, we were using 0400, 0600 and 0700 as the mode to set on the created files. This is awkward: we should be using the defaults (which I believe are 0444, 0666 and 0777) and then relying on the system imposing the user's umask (typically 0022) to reduce those.
    
    Testing:
    The normal `rm -rf /tmp/foobar && ./composer -outdir /tmp/foobar -keep -linkedDrivers repositories.json workflow3.json.sample gilsonOnly.json.sample` works before and after with sensible permissions appearing.
    Setting umask to 0077 and rerunning does correctly reduce the mode of the created files.
