### PR TITLE
Convert plate types from inventory protobuf

### DIFF
--- a/antha/anthalib/wtype/plate.go
+++ b/antha/anthalib/wtype/plate.go
@@ -643,6 +643,40 @@ func NewLHPlate(idGen *id.IDGenerator, platetype PlateTypeName, mfr string, nrow
 	return &lhp
 }
 
+func (p *Plate) ToPlateType() *PlateType {
+	dupEx := func(ex map[string]interface{}) map[string]interface{} {
+		cp := map[string]interface{}{}
+		for k, v := range ex {
+			cp[k] = v
+		}
+		return cp
+	}
+	return &PlateType{
+		Name:         p.Type,
+		Manufacturer: p.Mnfr,
+		WellShape:    p.Welltype.WShape.Type.Name,
+		WellH:        p.Welltype.WShape.H,
+		WellW:        p.Welltype.WShape.W,
+		WellD:        p.Welltype.WShape.D,
+		MaxVol:       p.Welltype.MaxVol,
+		MinVol:       p.Welltype.Rvol,
+		BottomType:   p.Welltype.Bottom,
+		BottomH:      p.Welltype.Bottomh,
+		WellX:        p.Welltype.Bounds.Size.X,
+		WellY:        p.Welltype.Bounds.Size.Y,
+		WellZ:        p.Welltype.Bounds.Size.Z,
+		WellXOffset:  p.WellXOffset,
+		WellYOffset:  p.WellYOffset,
+		WellXStart:   p.WellXStart,
+		WellYStart:   p.WellYStart,
+		WellZStart:   p.WellZStart,
+		ColSize:      p.WlsY,
+		RowSize:      p.WlsX,
+		Height:       p.Height(),
+		Extra:        dupEx(p.Welltype.Extra),
+	}
+}
+
 func LHPlateFromType(idGen *id.IDGenerator, pt *PlateType) *LHPlate {
 	newWellShape := NewShape(ShapeTypeFromName(pt.WellShape), "mm", pt.WellH, pt.WellW, pt.WellD)
 

--- a/antha/anthalib/wtype/plate_test.go
+++ b/antha/anthalib/wtype/plate_test.go
@@ -3,6 +3,7 @@ package wtype
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/go-test/deep"
 	"reflect"
 	"strings"
 	"testing"
@@ -240,6 +241,30 @@ func TestMergeWith(t *testing.T) {
 
 	if !(p1.Wellcoords["A2"].WContents.CName == "Butter" && p1.Wellcoords["A2"].WContents.Vol == 80.0 && p1.Wellcoords["A2"].WContents.Vunit == "ul") {
 		t.Fatal("Error: MergeWith should add non user-allocated components to  plate merged with")
+	}
+}
+
+func TestPlateType(t *testing.T) {
+	idGen := id.NewIDGenerator(t.Name())
+	p := makeplatefortest(idGen)
+	p.SetConstrained("A", []string{"X"})
+
+	pt := p.ToPlateType()
+
+	idGen2 := id.NewIDGenerator(t.Name())
+
+	p2 := LHPlateFromType(idGen2, pt)
+
+	if diffs := deep.Equal(p, p2); len(diffs) != 0 {
+		t.Errorf("Plate reconsistuted from plate type not correct\n%v", strings.Join(diffs, "\n"))
+	}
+
+	// now check we get the right plate type out
+
+	pt2 := p2.ToPlateType()
+
+	if diffs := deep.Equal(pt, pt2); len(diffs) != 0 {
+		t.Errorf("Using a plate type to create a plate then extracting the plate type from that plate should result in the same plate type as the original. It didn't.\n%v", strings.Join(diffs, "\n"))
 	}
 }
 


### PR DESCRIPTION
antha-runner/aconv already contains converters from inventory plates
and plate types into the antha-lang versions, however the new
PlateType class is not supported.

Since it seems reasonable enough to have a method to extract a plate
type back out of a plate the conversion now works by creating a plate
from the inventory Plate Type then extracting the plate type from it.

I added a basic unit test which demonstrates that the extracted plate
type is fine for making another plate of the same type with, and equal
to the one which was used in the first place.