### PR TITLE
[AC-78] Generally improve all command documentation.

### DIFF
--- a/cmd/composer/doc.go
+++ b/cmd/composer/doc.go
@@ -24,8 +24,8 @@
 //  2. Checkout all the known repositories under outdir/src at the
 //     indicated revisions.
 //
-//  3. Transpile the transitive closure of all antha element files
-//     into Go code.
+//  3. Transpile the transitive closure of all required antha element
+//     files into Go code.
 //
 //  4. Use the merged and validated workflow to generate a main.go in
 //     outdir/workflow. This is the entry point for the execution of
@@ -42,8 +42,8 @@
 //     generation of the workflow binary (for example, for
 //     configuration of device instruction plugins).
 //
-//  7. Compile the generated main.go into outdir/bin/job-id and build
-//     into the generated binary the merged and validated
+//  7. Compile the generated main.go into outdir/bin/workflow and
+//     build into the generated binary the merged and validated
 //     workflow. The generated binary is relatively self contained at
 //     this point - the only external dependencies are non-linked-in
 //     instruction plugins, and input data files.
@@ -73,17 +73,17 @@
 //         calls) will have their paths interpreted as relative to
 //         this directory.
 //
-//  -keep=false
+//  -keep (boolean, default false)
 //    By default, after steps 1-7 are successfully run, the contents
 //    of outdir/src and outdir/workflow are removed (i.e. the checked
 //    out sources, the merged and validated workflow and generated
 //    main.go). These are not removed if -keep=true
 //
-//  -run=true
+//  -run (boolean, default true)
 //    By default, the compiled workflow is executed (step 8). If
-//    -run=false then the composer exits after steps 1-7.q
+//    -run=false then the composer exits after step 7.
 //
-//  -linkedDrivers=false
+//  -linkedDrivers (boolean, default false)
 //    By default we do not require a checkout of the
 //    github.com/Synthace/instruction-plugins repository, which means
 //    that every device within the workflow that requires an

--- a/cmd/composer/doc.go
+++ b/cmd/composer/doc.go
@@ -95,9 +95,9 @@
 //    relevant linked instruction plugin.
 //
 // On the command line, any further arguments are interpreted as paths
-// to json files (in addition to -indir, if provided) and are loaded
-// and merged as workflow snippets. If you provide - as an argument
-// then composer will try to parse a workflow snippet from stdin.
+// to workflow snippet json files (in addition to -indir, if provided)
+// and are loaded and merged. If you provide - as an argument then
+// composer will try to parse a workflow snippet from stdin.
 //
 // Log messages are produced on stderr, and the composer command exits
 // with a code of 0 iff no fatal error in encountered.

--- a/cmd/composer/main.go
+++ b/cmd/composer/main.go
@@ -12,7 +12,10 @@ import (
 )
 
 func main() {
-	flag.Usage = workflow.NewFlagUsage(nil, "Parse, compile and run a workflow", "github.com/antha-lang/antha/cmd/composer")
+	flag.Usage = workflow.NewFlagUsage(nil,
+		"Parse, compile and run a workflow",
+		"[flags] [workflow-snippet.json...]",
+		"github.com/antha-lang/antha/cmd/composer")
 
 	var inDir, outDir string
 	var keep, run, linkedDrivers bool

--- a/cmd/composer/main.go
+++ b/cmd/composer/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	flag.Usage = workflow.NewFlagUsage(nil, "Parse, compile and run a workflow")
+	flag.Usage = workflow.NewFlagUsage(nil, "Parse, compile and run a workflow", "github.com/antha-lang/antha/cmd/composer")
 
 	var inDir, outDir string
 	var keep, run, linkedDrivers bool

--- a/cmd/elements/defaults.go
+++ b/cmd/elements/defaults.go
@@ -16,7 +16,7 @@ import (
 
 func defaults(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" defaults", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Gather defaults for an element set from metadata.json files in the repo")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Gather defaults for an element set from metadata.json files in the repo", "github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")

--- a/cmd/elements/defaults.go
+++ b/cmd/elements/defaults.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -16,7 +15,10 @@ import (
 
 func defaults(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" defaults", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Gather defaults for an element set from metadata.json files in the repo", "github.com/antha-lang/antha/cmd/elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet,
+		"Gather defaults for an element set from metadata.json files in the repo",
+		"[flags] [workflow-snippet.json...]",
+		"github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")
@@ -69,16 +71,12 @@ func defaults(l *logger.Logger, args []string) error {
 			}
 		}
 
-		bs, err := json.Marshal(defaults)
-		if err != nil {
+		if bs, err := json.Marshal(defaults); err != nil {
 			return err
-		}
-		w := bufio.NewWriter(os.Stdout)
-		_, err = w.Write(bs)
-		if err != nil {
+		} else if _, err := os.Stdout.Write(bs); err != nil {
 			return err
+		} else {
+			return nil
 		}
-
-		return nil
 	}
 }

--- a/cmd/elements/describe.go
+++ b/cmd/elements/describe.go
@@ -43,7 +43,7 @@ const (
 
 func describe(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" describe", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Show descriptions of elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Show descriptions of elements", "github.com/antha-lang/antha/cmd/elements")
 
 	validOutputFormats := []string{
 		outputFormatHuman,

--- a/cmd/elements/describe.go
+++ b/cmd/elements/describe.go
@@ -43,7 +43,10 @@ const (
 
 func describe(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" describe", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Show descriptions of elements", "github.com/antha-lang/antha/cmd/elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet,
+		"Show descriptions of elements",
+		"[flags] [workflow-snippet.json...]",
+		"github.com/antha-lang/antha/cmd/elements")
 
 	validOutputFormats := []string{
 		outputFormatHuman,

--- a/cmd/elements/doc.go
+++ b/cmd/elements/doc.go
@@ -1,7 +1,7 @@
 // The Elements Command
 //
 // The elements command is a command to help work with elements and
-// workflows.  Various subcommands are available, and just like the
+// workflows. Various subcommands are available, and just like the
 // composer command (github.com/antha-lang/antha/cmd/composer), they
 // accept workflow snippets as inputs.
 //
@@ -28,6 +28,9 @@
 // is matched against the element type's path. Only matching element
 // types are output. The default is to match all element types.
 //
+// Example:
+//    elements list -regex=Aliquot path/to/repositories.json
+//
 // Describe
 //
 // The describe subcommand is similar to the list subcommand, but for
@@ -53,6 +56,9 @@
 // The information is output via stdout, and is appropriately tab
 // indented.
 //
+// Example:
+//    elements describe -regex=AddFluorescenceTimeCourse path/to/repositories.json
+//
 // Make Workflow
 //
 // The makeWorkflow subcommand allows for workflows to be generated
@@ -68,7 +74,7 @@
 // output to. The default is to output to stdout.
 //
 // For every found element type for which the element type's path
-// matches the regex, the generated worflow with contain a
+// matches the regex, the generated worflow will contain a
 // corresponding Element Type entry, and a corresponding Element
 // Instance entry. No parameters are set on the element instance, and
 // no connections are made between any elements.
@@ -79,18 +85,17 @@
 // elements transpile and compile correct, a command line such as the
 // following could be used:
 //
-//  elements makeWorkflow -regex=QPCR repositories.json | composer -run=false -
+//  elements makeWorkflow -regex=QPCR path/to/repositories.json | composer -run=false -keep -
 //
 // Testing
 //
 // Whilst not a subcommand, testing of elements is supported by this
 // package.
 //
-// Testing accepts the -indir flag exactly as for the list subcommand,
-// and workflow snippets can be provided in exactly the same way. The
-// testing subsystem has built in support for selecting which tests to
-// run, see https://golang.org/cmd/go/#hdr-Testing_flags and
-// particularly the -run flag.
+// Testing accepts the -indir and -regex flags exactly as for the list
+// subcommand, and workflow snippets can be provided in exactly the
+// same way. The -regex flag is only used when selecting test
+// workflows to run.
 //
 // Testing also accepts an -outdir flag which can be used to provide a
 // path to a directory under which all source checkouts, transpilation

--- a/cmd/elements/doc.go
+++ b/cmd/elements/doc.go
@@ -74,7 +74,7 @@
 // output to. The default is to output to stdout.
 //
 // For every found element type for which the element type's path
-// matches the regex, the generated worflow will contain a
+// matches the regex, the generated workflow will contain a
 // corresponding Element Type entry, and a corresponding Element
 // Instance entry. No parameters are set on the element instance, and
 // no connections are made between any elements.

--- a/cmd/elements/list.go
+++ b/cmd/elements/list.go
@@ -11,7 +11,10 @@ import (
 
 func list(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" list", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "List all found element types, tab separated", "github.com/antha-lang/antha/cmd/elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet,
+		"List all found element types, tab separated",
+		"[flags] [workflow-snippet.json...]",
+		"github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")

--- a/cmd/elements/list.go
+++ b/cmd/elements/list.go
@@ -11,7 +11,7 @@ import (
 
 func list(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" list", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "List all found element types, tab separated")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet, "List all found element types, tab separated", "github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")

--- a/cmd/elements/makeworkflow.go
+++ b/cmd/elements/makeworkflow.go
@@ -10,7 +10,10 @@ import (
 
 func makeWorkflowCmd(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" makeWorkflow", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Modify workflow adding selected elements", "github.com/antha-lang/antha/cmd/elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet,
+		"Modify workflow adding selected elements",
+		"[flags] [workflow-snippet.json...]",
+		"github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir, toFile string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")

--- a/cmd/elements/makeworkflow.go
+++ b/cmd/elements/makeworkflow.go
@@ -10,7 +10,7 @@ import (
 
 func makeWorkflowCmd(l *logger.Logger, args []string) error {
 	flagSet := flag.NewFlagSet(flag.CommandLine.Name()+" makeWorkflow", flag.ContinueOnError)
-	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Modify workflow adding selected elements")
+	flagSet.Usage = workflow.NewFlagUsage(flagSet, "Modify workflow adding selected elements", "github.com/antha-lang/antha/cmd/elements")
 
 	var regexStr, inDir, toFile string
 	flagSet.StringVar(&regexStr, "regex", "", "Regular expression to match against element type path (optional)")

--- a/cmd/migrate/doc.go
+++ b/cmd/migrate/doc.go
@@ -2,8 +2,12 @@
 //
 // The migrate command migrates workflows from outdated historical
 // schema versions to the current schema version. Currently, it will
-// accept version=1.2 workflow files as inputs, and will produce
-// SchemaVersion=2.0 workflows.
+// accept as inputs:
+//
+//  version=1.2 workflow files in JSON format (the old "bundle" format)
+//  version=1.2 SimulateRequest protobuf objects
+//
+// and will produce SchemaVersion=2.0 workflows.
 //
 // The version=1.2 format is deficient in that it does not contain
 // enough information for workflow to be repeatedly executed. Thus
@@ -13,42 +17,56 @@
 //
 // The following flags are available:
 //
-//  -from=path/to/file.json
-//    The workflow to migrate. If not provided, the command reads from
-//    stdin.
+//  -from=path/to/file
+//    The workflow to migrate. Use - to read from stdin.
 //
 //  -outdir=path/to/directory
 //    A directory to write the results to. In SchemaVersion=2.0, the
 //    workflow.json itself cannot contain file content. Thus a
-//    directory must be provided so that file content that was within
-//    the old workflow can be extracted and written out. The new
+//    directory must be provided so that file content that was baked
+//    into the old workflow can be extracted and written out. The new
 //    workflow is written to directory/workflow/workflow.json, and any
 //    file contents are written to directory/data/. The new workflow
 //    will contain references to any extracted files, and the
 //    directory layout matches the requirements of the composer -indir
 //    flag. If not provided, a fresh temporary directory is used.
 //
-//  -validate=true (default: true)
+//  -validate (boolean, default true)
 //    Whether or not to attempt to validate the migrated workflow. In
 //    some cases it may be necessary to disable validation if it is
 //    known that the generated workflow is incomplete (e.g. you know
 //    you're only producing a workflow snippet).
 //
-//  -gilson-device=myFirstGilson (optional)
-//    In version=1.2 workflows, the only supported liquid handler
-//    device is the Gilson PipetMax, and only one such device is
-//    supported per workflow. To migrate those configuration values to
-//    corresponding entries in the current SchemaVersion=2.0 workflow,
-//    a device name must be provided. The default is that no such
-//    device name is provided, thus by default PipetMax device
-//    configuration settings are not migrated.
+//  -format=json (enum, default is json, other legal value is protobuf)
+//    Indicate the format of the input workflow to migrate. If json,
+//    then the input is parsed as a version=1.2 JSON workflow file. If
+//    protobuf, then the input is parsed as a version=1.2
+//    SimulateRequest protobuf object.
+//
+//  -gilson-device=myFirstGilson (optional, json only)
+//    In version=1.2 workflows in JSON format, the only supported
+//    liquid handler device is the Gilson PipetMax, and only one such
+//    device is supported per workflow, and the device is unnamed. To
+//    migrate those configuration values to corresponding entries in
+//    the current SchemaVersion=2.0 workflow, a device name must be
+//    provided. If no such device name is provided (which is the
+//    default), then Gilson PipetMax configuration parameters are not
+//    migrated.
+//
+//    For protobuf inputs, the first mixer device only is migrated,
+//    and all non-mixer devices are migrated. This matches the
+//    historical behaviour of antha.
 //
 // Additionally, as normal, workflow snippets in the current
 // SchemaVersion=2.0 format may be provided as additional arguments to
 // the command. As a minimum, it is necessary to provide sufficient
 // Repositories such that every element instance in the input
 // historical workflow (version=1.2) can be located within one of the
-// Repositories. If this is not possible then migration will fail.
+// Repositories. If this is not possible then migration will
+// fail. This is because the older formats do not contain any
+// repository information, thus it is not possible to migrate from an
+// old workflow without providing repository information in the new
+// SchemaVersion=2.0 format.
 //
 // Example:
 //   migrate -from=path/to/old.json myRepositories.json

--- a/cmd/migrate/doc.go
+++ b/cmd/migrate/doc.go
@@ -1,5 +1,8 @@
 // The Migrate Command
 //
+// Example:
+//   migrate -from=path/to/old.json -format=json myRepositories.json
+//
 // The migrate command migrates workflows from outdated historical
 // schema versions to the current schema version. Currently, it will
 // accept as inputs:
@@ -9,11 +12,11 @@
 //
 // and will produce SchemaVersion=2.0 workflows.
 //
-// The version=1.2 format is deficient in that it does not contain
-// enough information for workflow to be repeatedly executed. Thus
-// when migrating, you are required to provide additional information
-// (particularly Repositories) in the SchemaVersion=2.0 format which
-// is then combined with the old workflow to create a workflow.
+// The version=1.2 format does not contain any versioning information
+// for elements. Thus when migrating, as a minimum, you are required
+// to provide Repository information in the SchemaVersion=2.0 format
+// such that each element type can be located within one of the
+// repositories specified.
 //
 // The following flags are available:
 //
@@ -57,19 +60,8 @@
 //    and all non-mixer devices are migrated. This matches the
 //    historical behaviour of antha.
 //
-// Additionally, as normal, workflow snippets in the current
-// SchemaVersion=2.0 format may be provided as additional arguments to
-// the command. As a minimum, it is necessary to provide sufficient
-// Repositories such that every element instance in the input
-// historical workflow (version=1.2) can be located within one of the
-// Repositories. If this is not possible then migration will
-// fail. This is because the older formats do not contain any
-// repository information, thus it is not possible to migrate from an
-// old workflow without providing repository information in the new
-// SchemaVersion=2.0 format.
-//
-// Example:
-//   migrate -from=path/to/old.json myRepositories.json
+// Additionally, as normal, workflow snippets may be provided as
+// additional arguments to the command.
 //
 // Log messages are produced on stderr.
 package main

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -24,7 +24,7 @@ const (
 var validFromFormats = []string{fromFormatJSON, fromFormatProtobuf}
 
 func main() {
-	flag.Usage = workflow.NewFlagUsage(nil, "Migrate workflow to latest schema version")
+	flag.Usage = workflow.NewFlagUsage(nil, "Migrate workflow to latest schema version", "github.com/antha-lang/antha/cmd/migrate")
 
 	var fromFile, outDir, gilsonDevice, fromFormat string
 	var validate bool

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -24,7 +24,10 @@ const (
 var validFromFormats = []string{fromFormatJSON, fromFormatProtobuf}
 
 func main() {
-	flag.Usage = workflow.NewFlagUsage(nil, "Migrate workflow to latest schema version", "github.com/antha-lang/antha/cmd/migrate")
+	flag.Usage = workflow.NewFlagUsage(nil,
+		"Migrate workflow to latest schema version",
+		"[flags] workflow-snippet.json...",
+		"github.com/antha-lang/antha/cmd/migrate")
 
 	var fromFile, outDir, gilsonDevice, fromFormat string
 	var validate bool

--- a/composer/doc.go
+++ b/composer/doc.go
@@ -1,8 +1,8 @@
 // There are two runtimes that we must think about:
 //
 // 1. The composer runtime. This is where we parse and validate the
-// workflow, checkout the necessary sources, generate a main.go, and
-// compile it all.
+// workflow, checkout the necessary sources, transpile antha elements,
+// generate a main.go, and compile it all together.
 //
 // 2. The workflow runtime. This is where we run the generated main.go
 // and consequently the elements, passing their effects into the
@@ -15,31 +15,44 @@
 //
 //  inDir/
 //    data/
-//      # calls to lab.FileManager.ReadAll() must read from in here (workflow runtime)
+//                      # calls to lab.FileManager.ReadAll() must read
+//                      # from in here (workflow runtime)
 //    workflow/
-//      *.json # treated as workflow fragments (composer runtime)
+//      *.json          # treated as workflow fragments (composer runtime)
 //
 //  outDir/ (for composer runtime)
 //    src/
-//      # where we check out the element repositories, and do the transpilation of elements
+//                      # where we check out the element repositories,
+//                      # and do the transpilation of elements
 //    workflow/
-//      main.go # the generated main.go
+//      main.go         # the generated main.go
 //      data/
 //        workflow.json # the merged and validated workflow
-//    logs.txt # logs from the composer only
+//    logs.txt          # logs from the composer runtime only
 //    bin/
-//      workflow # the compiled binary for the whole workflow (result of compiling main.go)
+//      workflow        # the compiled binary for the whole workflow
+//                      # (result of compiling main.go)
 //      drivers/
-//        driverId # binary instruction plugin (iff go:// or file:// Connection string in driver config)
+//        driverId      # binary instruction plugin (iff go:// or
+//                      # file:// Connection string in driver config)
 //
 //  outDir/ (for workflow runtime)
 //    data/
-//      # calls to lab.FileManager.Write* write in here
+//                      # calls to lab.FileManager.Write* write in here
 //    elements/
-//      # each element gets a elemName.json file in here which is the serialization of the element after run
-//    logs.txt # logs from the workflow runtime
-//    errors.txt # if any element gives an error (or panic) it will go in here
+//                      # each element gets a elemName.json file in
+//                      # here which is the serialization of the element
+//                      # after it has run
+//    logs.txt          # logs from the workflow runtime
 //    devices/
 //      task-id/
-//        device-specific-files # files generated for the device as part of the task
+//        device-id/
+//          device-specific-files
+//                      # files generated for the device as part of the task
+//    workflow/
+//      workflow.json   # the workflow, augmented with results of simulation
+//
+// If the outdir for the composer is path/to/directory, and -run=true
+// (the default) then the outdir for the workflow runtime is set to
+// path/to/directory/simulation
 package composer

--- a/workflow/readers.go
+++ b/workflow/readers.go
@@ -56,17 +56,17 @@ func JsonPathsWithin(dir string) ([]string, error) {
 	}
 }
 
-func NewFlagUsage(fs *flag.FlagSet, summary, docstr string) func() {
+func NewFlagUsage(fs *flag.FlagSet, summary, usage, docstr string) func() {
 	if fs == nil {
 		fs = flag.CommandLine
 	}
 	output := fs.Output()
 	name := fs.Name()
 	return func() {
-		fmt.Fprintf(output, "%s: %s\nUsage of %s:\n", name, summary, name)
+		fmt.Fprintf(output, "%s: %s\nUsage:\n  %s %s\n\n", name, summary, name, usage)
 		fs.PrintDefaults()
 		fmt.Fprintf(output,
-			"\nAll further args are interpreted as paths to workflows to be merged and composed. Use - to read a workflow from stdin.\nSee go doc %s for further documentation.\n\n",
+			"\nAll further args are interpreted as paths to workflow snippets to be merged and composed. Use - to read a workflow from stdin.\nSee go doc %s for further documentation.\n",
 			docstr)
 	}
 }

--- a/workflow/readers.go
+++ b/workflow/readers.go
@@ -56,7 +56,7 @@ func JsonPathsWithin(dir string) ([]string, error) {
 	}
 }
 
-func NewFlagUsage(fs *flag.FlagSet, summary string) func() {
+func NewFlagUsage(fs *flag.FlagSet, summary, docstr string) func() {
 	if fs == nil {
 		fs = flag.CommandLine
 	}
@@ -65,7 +65,9 @@ func NewFlagUsage(fs *flag.FlagSet, summary string) func() {
 	return func() {
 		fmt.Fprintf(output, "%s: %s\nUsage of %s:\n", name, summary, name)
 		fs.PrintDefaults()
-		fmt.Fprintf(output, "All further args are interpreted as paths to workflows to be merged and composed. Use - to read a workflow from stdin.\n")
+		fmt.Fprintf(output,
+			"\nAll further args are interpreted as paths to workflows to be merged and composed. Use - to read a workflow from stdin.\nSee go doc %s for further documentation.\n\n",
+			docstr)
 	}
 }
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -47,7 +47,7 @@ type Workflow struct {
 
 func WorkflowFromReaders(rs ...io.ReadCloser) (*Workflow, error) {
 	if len(rs) == 0 {
-		return nil, errors.New("No workflow sources provided.")
+		return nil, errors.New("No workflow provided.")
 	}
 	acc := EmptyWorkflow()
 	for _, r := range rs {


### PR DESCRIPTION
The existing docs are actually pretty reasonable, with one or two oversights.
What's mainly missing is pointers to those docs from the command -h form. So address that.
And generally review and polish all documentation.